### PR TITLE
feat: add dry-run mode, approval gate, and rollback support

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+from html import parser
 import os
 import sys
 
@@ -83,6 +84,8 @@ Examples:
                         help="Directory for file backups (default: backups/ inside repo)")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress verbose output")
+    parser.add_argument("--dry-run", "-d", action="store_true",help="Preview changes without applying them. Saves a manifest to logs/.")
+    parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
     # API key
     parser.add_argument("--api-key", default=None,
@@ -95,6 +98,11 @@ def main():
     args = parse_args()
 
     repo_root = os.path.abspath(args.repo)
+    if args.rollback:
+       from modules.code_modifier import CodeModificationEngine
+       modifier = CodeModificationEngine(backup_dir="backups")
+       success = modifier.git_stash_pop(repo_root)
+       sys.exit(0 if success else 1)
     if not os.path.isdir(repo_root):
         print(f"ERROR: Repository path does not exist: {repo_root}", file=sys.stderr)
         sys.exit(1)
@@ -102,6 +110,7 @@ def main():
     config = AgentConfig(
         repo_root=repo_root,
         task=args.task,
+        dry_run=args.dry_run,
 
         # Execution
         test_runner=args.runner,

--- a/main.py
+++ b/main.py
@@ -99,7 +99,7 @@ def main():
 
     repo_root = os.path.abspath(args.repo)
     if args.rollback:
-       from modules.code_modifier import CodeModificationEngine
+       modifier = CodeModificationEngine(repo_root=repo_root, backup_dir="backups")
        modifier = CodeModificationEngine(backup_dir="backups")
        success = modifier.git_stash_pop(repo_root)
        sys.exit(0 if success else 1)

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -37,6 +37,7 @@ from modules.logger import AgentLogger, IterationRecord
 class AgentConfig:
     repo_root: str
     task: str
+    dry_run: bool = False
 
     # Execution
     test_runner: str = "pytest"            # pytest | npm_test | go | cargo | ...
@@ -273,6 +274,39 @@ class AutonomousAgent:
                 else:
                     valid_changes = llm_resp.changes
 
+                from modules.dry_run import print_manifest, save_manifest, ask_confirmation
+
+                changes_list = [
+                    c.__dict__ if hasattr(c, '__dict__') else c
+                    for c in llm_resp.changes
+                ]
+
+                print_manifest(changes_list)
+
+                if self.config.dry_run:
+                    manifest_path = save_manifest(changes_list, self.config.log_dir, self.run_id)
+                    print(f"\n[DRY RUN] No files were modified.")
+                    print(f"[DRY RUN] Manifest saved to: {manifest_path}")
+                    return AgentRunResult(
+                        outcome="dry_run",
+                        run_id=self.run_id,
+                        iterations_used=iteration,
+                        final_message="Dry run complete. Review the manifest before applying.",
+                        branch_name=None,
+                        pr_url=None,
+                    )
+
+                if not ask_confirmation(len(llm_resp.changes)):
+                    return AgentRunResult(
+                        outcome="aborted",
+                        run_id=self.run_id,
+                        iterations_used=iteration,
+                        final_message="Aborted by user at confirmation prompt.",
+                        branch_name=None,
+                        pr_url=None,
+                    )
+
+                self.modifier.git_stash_before_apply(self.config.repo_root)
                 apply_results = self.modifier.apply_changes(valid_changes)
                 self.logger.log_apply_results(apply_results)
                 last_changes = valid_changes

--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -167,3 +167,33 @@ class CodeModificationEngine:
             except ValueError as e:
                 errors.append(str(e))
         return errors
+    
+    def git_stash_before_apply(self, repo_root: str) -> bool:
+        """Stash current working state before agent applies changes."""
+        import subprocess
+        result = subprocess.run(
+            ["git", "stash", "push", "-m", "repopilot-pre-agent-state"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print("[Rollback] Git stash saved. Run with --rollback to undo.")
+        else:
+            print(f"[Rollback] Warning: git stash failed — {result.stderr.strip()}")
+        return result.returncode == 0
+
+    def git_stash_pop(self, repo_root: str) -> bool:
+        """Restore the pre-agent state via git stash pop."""
+        import subprocess
+        result = subprocess.run(
+            ["git", "stash", "pop"],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            print("[Rollback] Successfully restored previous state.")
+        else:
+            print(f"[Rollback] Failed to pop stash — {result.stderr.strip()}")
+        return result.returncode == 0

--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -171,17 +171,25 @@ class CodeModificationEngine:
     def git_stash_before_apply(self, repo_root: str) -> bool:
         """Stash current working state before agent applies changes."""
         import subprocess
-        result = subprocess.run(
+
+        # Check if there's anything to stash
+        check = subprocess.run(
             ["git", "stash", "push", "-m", "repopilot-pre-agent-state"],
             cwd=repo_root,
             capture_output=True,
             text=True,
         )
-        if result.returncode == 0:
-            print("[Rollback] Git stash saved. Run with --rollback to undo.")
-        else:
-            print(f"[Rollback] Warning: git stash failed — {result.stderr.strip()}")
-        return result.returncode == 0
+        if check.returncode != 0:
+            print(f"[Rollback] Warning: git stash failed — {check.stderr.strip()}")
+            return False
+
+        # git stash exits 0 even on a clean tree — detect that case
+        if "No local changes to save" in check.stdout:
+            print("[Rollback] Nothing to stash — working tree is clean.")
+            return False
+
+        print("[Rollback] Git stash saved. Run with --rollback to undo.")
+        return True
 
     def git_stash_pop(self, repo_root: str) -> bool:
         """Restore the pre-agent state via git stash pop."""

--- a/modules/dry_run.py
+++ b/modules/dry_run.py
@@ -26,7 +26,7 @@ def print_manifest(changes: list) -> None:
 def save_manifest(changes: list, log_dir: str, run_id: str) -> str:
     """Save the change manifest as a JSON file and return its path."""
     os.makedirs(log_dir, exist_ok=True)
-    timestamp = datetime.datetime.utcnow().isoformat()
+    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
     path = os.path.join(log_dir, f"manifest_{run_id}.json")
     data = {
         "run_id": run_id,

--- a/modules/dry_run.py
+++ b/modules/dry_run.py
@@ -1,0 +1,58 @@
+# modules/dry_run.py
+import json
+import os
+import datetime
+
+
+def print_manifest(changes: list) -> None:
+    """Print a human-readable change manifest to the console."""
+    print("\n" + "=" * 60)
+    print(f"  CHANGE MANIFEST  ({len(changes)} file(s) affected)")
+    print("=" * 60)
+    for i, c in enumerate(changes, 1):
+        print(f"\n[{i}] Action : {c.get('action', 'modify').upper()}")
+        print(f"    File   : {c.get('file_path', c.get('path', 'unknown'))}")
+        reason = c.get('reason') or c.get('analysis', '')
+        if reason:
+            print(f"    Reason : {reason[:200]}")
+        content = c.get('content', '')
+        if content:
+            preview = content[:300].replace('\n', '\n           ')
+            suffix = '...' if len(content) > 300 else ''
+            print(f"    Preview: {preview}{suffix}")
+    print("\n" + "=" * 60)
+
+
+def save_manifest(changes: list, log_dir: str, run_id: str) -> str:
+    """Save the change manifest as a JSON file and return its path."""
+    os.makedirs(log_dir, exist_ok=True)
+    timestamp = datetime.datetime.utcnow().isoformat()
+    path = os.path.join(log_dir, f"manifest_{run_id}.json")
+    data = {
+        "run_id": run_id,
+        "timestamp": timestamp,
+        "dry_run": True,
+        "total_changes": len(changes),
+        "changes": [
+            {
+                "action": c.get('action', 'modify'),
+                "file": c.get('file_path', c.get('path', 'unknown')),
+                "reason": c.get('reason', ''),
+                "content_preview": (c.get('content', '') or '')[:500],
+            }
+            for c in changes
+        ],
+    }
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    return path
+
+
+def ask_confirmation(n: int) -> bool:
+    """Prompt user to confirm before applying changes. Returns True if approved."""
+    try:
+        answer = input(f"\nApply these {n} change(s)? [Y/n]: ").strip().lower()
+        return answer not in ("n", "no")
+    except (KeyboardInterrupt, EOFError):
+        print("\nAborted.")
+        return False


### PR DESCRIPTION
## Summary
This PR implements the safety and trust features proposed in the issue — 
a Dry-Run mode, Change Manifest, Interactive Approval Gate, and Git-based 
Rollback — to prevent the agent from making unwanted file modifications.

## Changes Made

### New File
- `modules/dry_run.py` — handles manifest printing, JSON saving, and the Y/n confirmation prompt

### Updated Files
- `main.py` — added `--dry-run` / `-d` and `--rollback` CLI flags
- `modules/agent_loop.py` — added `dry_run` field to AgentConfig, integrated manifest display and confirmation prompt before apply
- `modules/code_modifier.py` — added `git_stash_before_apply()` and `git_stash_pop()` for rollback support

## How to Use

### Dry Run (preview only, no files touched)
python main.py --repo . --task "Fix the TypeError" --dry-run

### Normal Run (shows manifest, asks Y/n before writing)
python main.py --repo . --task "Fix the TypeError"

### Rollback (undo last agent run)
python main.py --repo . --task "" --rollback

## Why This Is Needed
- Prevents the agent from accidentally corrupting a codebase
- Lets developers review the agent's plan before giving it control
- Makes the tool safe enough for professional/team environments
- Provides a one-command undo if a change breaks the build

## Related Issue
Closes #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--dry-run` (`-d`) to preview proposed changes; prints and saves a change manifest instead of applying edits.
  * Added `--rollback` to attempt undoing the previous run and report success or failure.
  * Added interactive confirmation before applying changes; declining aborts the run and records the outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->