### PR TITLE
fix: add .gitignore to exclude logs, backups, and pycache (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+logs/
+backups/
+
+__pycache__/
+*.pyc
+*.pyo
+
+.env
+
+.vscode/
+
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Fixes #10

## Description
Added a `.gitignore` file to prevent runtime-generated directories and 
Python bytecode from being tracked by Git.

## Changes
- Ignores `logs/` — JSONL run logs generated at runtime
- Ignores `backups/` — file backups created before modification
- Ignores `__pycache__/` and `*.pyc` — Python bytecode cache
- Ignores `.env` — environment variables file
- Added standard extras: `.vscode/`, `.DS_Store`, `Thumbs.db`

## Type of Change
- [x] Bug fix

## Testing
- [x] Verified `.gitignore` file is present in repo root
- [x] Confirmed `logs/`, `backups/`, `__pycache__/` are no longer 
tracked by Git after adding the file

## Screenshots
N/A — configuration file change, no UI impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated `.gitignore` configuration to exclude common development artifacts, Python bytecode caches, dependency directories, environment files, editor settings, and OS metadata from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->