### PR TITLE
Fix #8: Docker sandbox mounts workspace read-only, breaking test writes

### DIFF
--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -250,7 +250,7 @@ class DockerSandbox:
             "--network=none",
             "--memory=512m",
             "--cpus=1",
-            "-v", f"{self.working_dir}:/workspace:ro",
+            "-v", f"{self.working_dir}:/workspace:rw",
             "-w", "/workspace",
             self.image,
             "sh", "-c", shlex.join(inner_cmd),


### PR DESCRIPTION
Closes #8

## Problem
`modules/sandbox.py` line 253 mounted the workspace as read-only:

    "-v", f"{self.working_dir}:/workspace:ro",

Any test that writes files during a run — .pyc bytecode, coverage
reports, temp fixtures, log files — would fail inside the Docker
sandbox, even when the test logic itself was correct.

## Fix
Changed the mount flag from `:ro` to `:rw`, so the container can
write to the workspace the same way the SubprocessSandbox fallback
already can.

## Verified
Ran the mount directly with Docker to confirm the before/after
behavior:

    docker run --rm --network=none --memory=512m --cpus=1 \
      -v "${PWD}\sample_repo:/workspace:ro" -w /workspace \
      python:3.11-slim sh -c "touch /workspace/write_test.txt && echo WRITE_OK"

- **Before fix (`:ro`):** fails with `Read-only file system`
- **After fix (`:rw`):** succeeds with `WRITE_OK`

## Note
This issue was assigned to @sasikumar161106, but had no linked PR or
visible activity, so I picked it up. Happy to close in favor of
theirs if they're already working on it.