### PR TITLE
feat(llm): add Ollama provider for local, offline models (Closes #50)

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,9 +87,17 @@ Examples:
     parser.add_argument("--dry-run", "-d", action="store_true",help="Preview changes without applying them. Saves a manifest to logs/.")
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
+    # LLM provider
+    parser.add_argument("--provider", default="anthropic", choices=["anthropic", "ollama"],
+                        help="LLM provider (default: anthropic)")
+    parser.add_argument("--model", default=None,
+                        help="Model name. Defaults per provider: claude-sonnet-4 / llama3")
+    parser.add_argument("--ollama-host", default=None,
+                        help="Ollama base URL (default: http://localhost:11434)")
+
     # API key
     parser.add_argument("--api-key", default=None,
-                        help="Anthropic API key (default: ANTHROPIC_API_KEY env var)")
+                        help="Anthropic API key (default: ANTHROPIC_API_KEY env var). Unused with --provider ollama")
 
     # Non-interactive / CI
     parser.add_argument("--yes", "-y", action="store_true",
@@ -164,6 +172,9 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+        llm_provider=args.provider,
+        llm_model=args.model,
+        ollama_host=args.ollama_host,
     )
 
     try:

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -22,7 +22,7 @@ from typing import Optional
 
 from modules.repo_ingestion import ingest_repository, Repository
 from modules.context_builder import build_context
-from modules.llm_client import LLMClient, LLMResponse, FileChange
+from modules.llm_client import create_llm_client, LLMResponse, FileChange
 from modules.code_modifier import CodeModificationEngine, ApplyResult
 from modules.sandbox import SubprocessSandbox, ExecutionResult
 from modules.git_integration import GitIntegration
@@ -66,6 +66,9 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
+    llm_provider: str = "anthropic"        # anthropic | ollama
+    llm_model: Optional[str] = None        # provider default when unset
+    ollama_host: Optional[str] = None      # default http://localhost:11434
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
@@ -98,7 +101,12 @@ class AutonomousAgent:
 
         # Instantiate modules
         self.logger = AgentLogger(self.log_dir, self.run_id, verbose=True)
-        self.llm = LLMClient(api_key=cfg.anthropic_api_key)
+        self.llm = create_llm_client(
+            provider=cfg.llm_provider,
+            api_key=cfg.anthropic_api_key,
+            model=cfg.llm_model,
+            host=cfg.ollama_host,
+        )
         self.modifier = CodeModificationEngine(cfg.repo_root, self.backup_dir)
         self.sandbox = SubprocessSandbox(cfg.repo_root, timeout_seconds=cfg.timeout_seconds)
 

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -8,6 +8,8 @@ import json
 import os
 import re
 import time
+import urllib.error
+import urllib.request
 from dataclasses import dataclass
 from typing import Optional
 
@@ -19,6 +21,11 @@ except ImportError:
 
 MODEL = "claude-sonnet-4-20250514"
 MAX_TOKENS = 8192
+
+# Ollama defaults. The host is overridable because Ollama is commonly run on a
+# second machine with a GPU rather than the laptop driving the agent.
+OLLAMA_DEFAULT_HOST = "http://localhost:11434"
+OLLAMA_DEFAULT_MODEL = "llama3"
 
 # ─────────────────────────────────────────────
 # Prompt Templates
@@ -122,34 +129,20 @@ class LLMResponse:
 # Client
 # ─────────────────────────────────────────────
 
-class LLMClient:
-    def __init__(self, api_key: Optional[str] = None):
-        if not _ANTHROPIC_AVAILABLE:
-            raise RuntimeError(
-                "anthropic package not installed. Run: pip install anthropic"
-            )
-        key = api_key or os.environ.get("ANTHROPIC_API_KEY")
-        if not key:
-            raise ValueError("ANTHROPIC_API_KEY not set")
-        self.client = anthropic.Anthropic(api_key=key)
+class BaseLLMClient:
+    """Provider-agnostic half of the client.
+
+    Everything that is not an HTTP call lives here: prompt construction, the
+    markdown-fence stripping, JSON extraction and the recovery path when a model
+    returns something unparseable. Those behaviours took real effort to get right
+    and are worth *more* for a local model, not less — a 8B model wrapping its
+    JSON in prose is exactly what `_parse_response` already handles.
+
+    A provider supplies `_call(prompt) -> str` and inherits the rest.
+    """
 
     def _call(self, prompt: str, retries: int = 3) -> str:
-        """Raw API call with retry on transient errors."""
-        for attempt in range(retries):
-            try:
-                response = self.client.messages.create(
-                    model=MODEL,
-                    max_tokens=MAX_TOKENS,
-                    system=SYSTEM_PROMPT,
-                    messages=[{"role": "user", "content": prompt}],
-                )
-                return response.content[0].text
-            except Exception as e:
-                if attempt == retries - 1:
-                    raise
-                wait = 2 ** attempt
-                time.sleep(wait)
-        raise RuntimeError("LLM call failed after retries")
+        raise NotImplementedError("Subclasses must implement _call()")
 
     def _parse_response(self, raw: str) -> LLMResponse:
         """Extract and parse JSON from LLM output."""
@@ -224,3 +217,134 @@ class LLMClient:
         )
         raw = self._call(prompt)
         return self._parse_response(raw)
+
+
+class AnthropicLLMClient(BaseLLMClient):
+    """Anthropic provider. Unchanged behaviour from the original LLMClient."""
+
+    def __init__(self, api_key: Optional[str] = None, model: str = MODEL):
+        if not _ANTHROPIC_AVAILABLE:
+            raise RuntimeError(
+                "anthropic package not installed. Run: pip install anthropic"
+            )
+        key = api_key or os.environ.get("ANTHROPIC_API_KEY")
+        if not key:
+            raise ValueError("ANTHROPIC_API_KEY not set")
+        self.client = anthropic.Anthropic(api_key=key)
+        self.model = model
+
+    def _call(self, prompt: str, retries: int = 3) -> str:
+        """Raw API call with retry on transient errors."""
+        for attempt in range(retries):
+            try:
+                response = self.client.messages.create(
+                    model=self.model,
+                    max_tokens=MAX_TOKENS,
+                    system=SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return response.content[0].text
+            except Exception:
+                if attempt == retries - 1:
+                    raise
+                time.sleep(2 ** attempt)
+        raise RuntimeError("LLM call failed after retries")
+
+
+class OllamaLLMClient(BaseLLMClient):
+    """Local models via Ollama's HTTP API.
+
+    Uses urllib rather than the `ollama` or `requests` packages, matching the
+    choice already made in git_integration.py for the GitHub API — running
+    offline should not require installing anything beyond Ollama itself.
+    """
+
+    def __init__(
+        self,
+        model: str = OLLAMA_DEFAULT_MODEL,
+        host: str = OLLAMA_DEFAULT_HOST,
+        timeout: int = 300,
+    ):
+        self.model = model
+        self.host = host.rstrip("/")
+        # Generous default: a 70B model on CPU can take minutes for one
+        # response, and a timeout here discards work the loop cannot recover.
+        self.timeout = timeout
+
+    def _call(self, prompt: str, retries: int = 3) -> str:
+        payload = json.dumps({
+            "model": self.model,
+            "prompt": prompt,
+            "system": SYSTEM_PROMPT,
+            "stream": False,
+            "options": {
+                # Low temperature: the loop needs parseable JSON, not variety.
+                "temperature": 0.1,
+                "num_predict": MAX_TOKENS,
+            },
+        }).encode("utf-8")
+
+        last_error: Optional[Exception] = None
+        for attempt in range(retries):
+            try:
+                req = urllib.request.Request(
+                    f"{self.host}/api/generate",
+                    data=payload,
+                    headers={"Content-Type": "application/json"},
+                    method="POST",
+                )
+                with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                    body = json.loads(resp.read().decode("utf-8"))
+                return body.get("response", "")
+            except urllib.error.HTTPError as e:
+                # A 404 means the model is not pulled. Retrying cannot fix that,
+                # so fail immediately with the command that will.
+                if e.code == 404:
+                    raise RuntimeError(
+                        f"Ollama has no model named '{self.model}'. "
+                        f"Pull it first: ollama pull {self.model}"
+                    ) from e
+                last_error = e
+            except urllib.error.URLError as e:
+                # Connection refused on the first attempt almost always means
+                # the daemon is not running; say so rather than retrying blindly.
+                if attempt == 0 and isinstance(e.reason, ConnectionRefusedError):
+                    raise RuntimeError(
+                        f"Cannot reach Ollama at {self.host}. Is it running? "
+                        f"Start it with: ollama serve"
+                    ) from e
+                last_error = e
+            except Exception as e:
+                last_error = e
+
+            if attempt < retries - 1:
+                time.sleep(2 ** attempt)
+
+        raise RuntimeError(f"Ollama call failed after {retries} attempts: {last_error}")
+
+
+def create_llm_client(
+    provider: str = "anthropic",
+    api_key: Optional[str] = None,
+    model: Optional[str] = None,
+    host: Optional[str] = None,
+) -> BaseLLMClient:
+    """Build a client for the named provider."""
+    provider = (provider or "anthropic").lower()
+
+    if provider == "anthropic":
+        return AnthropicLLMClient(api_key=api_key, model=model or MODEL)
+    if provider == "ollama":
+        return OllamaLLMClient(
+            model=model or OLLAMA_DEFAULT_MODEL,
+            host=host or OLLAMA_DEFAULT_HOST,
+        )
+
+    raise ValueError(
+        f"Unknown LLM provider: '{provider}'. Supported: anthropic, ollama"
+    )
+
+
+# Backwards compatibility: LLMClient was the Anthropic client, and existing
+# callers (including tests and any downstream forks) construct it directly.
+LLMClient = AnthropicLLMClient


### PR DESCRIPTION
Closes #50

## Approach

Rather than writing a parallel Ollama client, `LLMClient` is split at the seam that was already there. Everything provider-agnostic moves to `BaseLLMClient`:

- prompt construction (`initial_request`, `retry_request`)
- markdown-fence stripping
- outermost-JSON extraction
- the `parse_error` recovery path that feeds malformed output back to the next iteration

A provider supplies one method — `_call(prompt) -> str` — and inherits the rest.

That matters more for local models than for Anthropic. An 8B model wrapping its JSON in prose and code fences is the normal case, not the exception, and `_parse_response` already handles it. Duplicating the client would have meant reimplementing that recovery logic, worse, for the provider that needs it most.

## What's added

```
BaseLLMClient        shared parsing and prompts
├── AnthropicLLMClient   behaviour unchanged
└── OllamaLLMClient      new

create_llm_client(provider=..., model=..., host=...)
LLMClient = AnthropicLLMClient    # back-compat alias
```

`urllib` rather than the `ollama` or `requests` packages — matching the choice already made in `git_integration.py` for the GitHub API. Running offline shouldn't require a `pip install`.

CLI:

```
--provider {anthropic,ollama}   default: anthropic
--model MODEL                   defaults per provider: claude-sonnet-4 / llama3
--ollama-host OLLAMA_HOST       default: http://localhost:11434
```

`--ollama-host` is exposed because Ollama is commonly run on a second machine with a GPU rather than the laptop driving the agent.

## Nothing existing changes

`LLMClient` remains importable and remains the Anthropic client, so `tests/`, `demo_run.py` and any downstream fork keep working. `--provider` defaults to `anthropic`, so an existing command line behaves identically.

## Error paths

The two failures a first-time Ollama user actually hits each name the fixing command, and neither burns retries on a condition retrying can't resolve:

```
daemon down    -> Cannot reach Ollama at http://localhost:11434. Is it running?
                  Start it with: ollama serve

model missing  -> Ollama has no model named 'qwen2.5-coder'.
                  Pull it first: ollama pull qwen2.5-coder
```

A 404 fails immediately rather than sleeping through three attempts, since pulling a model isn't something a retry accomplishes.

Two other choices worth flagging: `temperature: 0.1`, because the loop needs parseable JSON rather than variety; and a 300s default timeout, because a 70B model on CPU can take minutes for one response and a shorter timeout discards work the loop can't recover.

## Verification

Existing suite: **4 passed**. `main.py --help` shows all three flags. `demo_run.py` unaffected.

The Ollama path was exercised against a local HTTP stub that deliberately returns JSON wrapped in prose and markdown fences — the failure mode small models exhibit:

```
factory -> OllamaLLMClient
parsed analysis   : Fixed the bug
parsed changes    : 1 -> utils.py
confidence / done : 0.9 / True
parse_error       : none
request model     : llama3
system prompt sent: True
stream disabled   : True
back-compat: LLMClient is AnthropicLLMClient -> True
unknown provider  -> Unknown LLM provider: 'bogus'. Supported: anthropic, ollama
```

**I have not run this against a real Ollama daemon** — I don't have one available. The HTTP contract is straightforward (`POST /api/generate`, `stream: false`, response in `body["response"]`) and the stub matches it, but a run against a genuine `ollama serve` before merge would be worth doing, and I'd rather say that than imply I've done it.

## Follow-up

`retries=3` with exponential backoff carries over from the Anthropic client, where it exists for rate limits and transient 5xx. Local inference has different failure modes — OOM on a model too large for available VRAM being the common one — and retrying that three times just wastes minutes. Worth revisiting once there's real usage to learn from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing the LLM provider and model from the command line.
  * Added Ollama support, including configurable server address and model selection.
  * Added automatic retries and clearer error messages for unavailable Ollama servers or models.
* **Bug Fixes**
  * Preserved existing Anthropic behavior while improving provider-specific configuration.
  * Updated API key guidance for Ollama usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->