### PR TITLE
fix(sandbox): replace env denylist with allowlist — Closes #47

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,41 @@ python demo_run.py /path/to/sample_repo
 ### Module 5 — `sandbox.py`
 
 - `SubprocessSandbox`: runs commands via `subprocess.run()` with timeout, output
-  capture, and environment sanitization (blocks cloud credentials from leaking).
+  capture, and environment sanitization.
 - `DockerSandbox`: wraps Docker with `--network=none`, memory/CPU caps, read-only
   volume mount. Falls back to subprocess if Docker is unavailable.
+
+#### Environment sanitization
+
+The sandbox executes code the model wrote, so the environment it receives is an
+**allowlist**: only the variables named in `ALLOWED_ENV_VARS` reach the child
+process, and everything else is dropped. A denylist would only cover the names
+somebody thought of, leaving every newly adopted service unprotected by default.
+
+The allowlist covers what the runners actually need — `PATH`, `HOME`, locale and
+temp dirs, the Windows core (`SYSTEMROOT`, `COMSPEC`, …), and the Python, Node,
+Go, Rust, Ruby, Java and Docker-client toolchain variables. Credentials such as
+`ANTHROPIC_API_KEY`, `SSH_AUTH_SOCK` and `KUBECONFIG` are not on it, and neither
+are the GitHub Actions runner variables: `GITHUB_ENV` and `GITHUB_PATH` name
+writable files that inject state into later workflow steps.
+
+If a runner needs a variable that is not covered, add it at runtime rather than
+widening the defaults:
+
+```bash
+# comma-separated; logged whenever it takes effect
+export REPOPILOT_SANDBOX_ENV_PASSTHROUGH=GOPROXY,npm_config_registry
+```
+
+Set the log level to `DEBUG` to see exactly which variables were stripped from a
+given run (names only — values are never logged).
+
+> **Scope.** This closes the easiest exfiltration path, not every path. In
+> subprocess mode the filesystem is not isolated, so `~/.aws/credentials` and
+> `~/.npmrc` remain readable; use `DockerSandbox` for genuinely untrusted code.
+> Dropping `SSH_AUTH_SOCK` is the exception that is decisive on its own — a
+> forwarded agent socket signs with the private key without ever reading it, so
+> file permissions cannot help there.
 
 ### Module 6 — `agent_loop.py` (CORE)
 
@@ -260,6 +292,7 @@ return MAX_RETRIES
 | ---------------------------- | ----------------------------------- | -------------------------------------------------------------- |
 | `JSONDecodeError` from LLM   | Model adds markdown fences or prose | Regex strips fences; parse error fed back as context next iter |
 | Path traversal in LLM output | LLM outputs `../../etc/passwd`      | `_safe_abs_path()` validates all paths against repo root       |
+| Credentials reach LLM code   | Child process inherits `os.environ` | `_build_safe_env()` allowlist; only named toolchain vars pass  |
 | Empty content for modify     | LLM returns `""` for file content   | Validation rejects before apply; error logged                  |
 | Infinite test loop           | Test hangs                          | `timeout_seconds` in sandbox kills process                     |
 | Repo too large               | Monorepo with 10K files             | 8MB total budget + per-file 512KB cap; budget exhausted = skip |

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -8,6 +8,7 @@ Runs code in isolation using subprocess with:
 - Optional Docker support
 """
 
+import logging
 import os
 import shlex
 import shutil
@@ -69,17 +70,151 @@ DOCKER_RUNNERS = {
     "rspec": ["bundle", "exec", "rspec"],
 }
 
-BLOCKED_ENV_VARS = {
-    "AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY_ID",
-    "GITHUB_TOKEN", "GH_TOKEN",
-    "DATABASE_URL", "REDIS_URL",
+# ---------------------------------------------------------------------------
+# Environment sanitization
+#
+# Commands launched by this sandbox execute LLM-generated code that no human has
+# reviewed. The process environment is therefore treated the same way file paths
+# are treated elsewhere in this project: untrusted by default.
+#
+# This is an ALLOWLIST. Any variable not named below is dropped. A denylist only
+# protects the names somebody happened to think of, so every service a user
+# newly adopts is unprotected until someone remembers to extend the list.
+#
+# Adding a name here is a deliberate decision. Prefer the runtime passthrough
+# hook (see PASSTHROUGH_ENV_VAR) over widening the defaults for a local need.
+# ---------------------------------------------------------------------------
+
+# Core shell / OS. The Windows entries are not optional: CPython cannot
+# initialize sockets or SSL without SYSTEMROOT, so stripping it breaks any test
+# that touches the network stack, and subprocesses fail without COMSPEC.
+_CORE_ENV_VARS = {
+    "PATH", "HOME", "SHELL", "USER", "LOGNAME", "HOSTNAME",
+    "LANG", "LANGUAGE", "LC_ALL", "LC_CTYPE", "TZ", "TERM", "TMPDIR",
+    "SYSTEMROOT", "SYSTEMDRIVE", "WINDIR", "COMSPEC", "PATHEXT",
+    "TEMP", "TMP", "APPDATA", "LOCALAPPDATA", "PROGRAMDATA",
+    "PROGRAMFILES", "PROGRAMFILES(X86)", "USERPROFILE", "USERNAME",
+    "HOMEDRIVE", "HOMEPATH", "NUMBER_OF_PROCESSORS",
+    "PROCESSOR_ARCHITECTURE", "PROCESSOR_IDENTIFIER",
 }
+
+_PYTHON_ENV_VARS = {
+    "PYTHONPATH", "PYTHONHOME", "PYTHONDONTWRITEBYTECODE", "PYTHONUNBUFFERED",
+    "PYTHONHASHSEED", "PYTHONIOENCODING", "PYTHONUTF8", "PYTHONWARNINGS",
+    "VIRTUAL_ENV", "CONDA_PREFIX", "CONDA_DEFAULT_ENV",
+    "PYENV_ROOT", "PYENV_VERSION",
+    "PYTEST_ADDOPTS", "PY_COLORS", "PIP_CACHE_DIR",
+}
+
+_NODE_ENV_VARS = {
+    "NODE_PATH", "NODE_ENV", "NODE_OPTIONS",
+    "npm_config_cache", "npm_config_prefix",
+}
+
+_GO_ENV_VARS = {
+    "GOROOT", "GOPATH", "GOCACHE", "GOMODCACHE", "GOTMPDIR",
+    "GOFLAGS", "GOTOOLCHAIN", "GOOS", "GOARCH", "CGO_ENABLED",
+}
+
+_RUST_ENV_VARS = {
+    "CARGO_HOME", "RUSTUP_HOME", "RUSTC", "RUSTFLAGS", "CARGO_TARGET_DIR",
+}
+
+_RUBY_ENV_VARS = {
+    "GEM_HOME", "GEM_PATH", "RUBYOPT", "BUNDLE_PATH", "BUNDLE_GEMFILE",
+    "RBENV_ROOT", "RBENV_VERSION",
+}
+
+_BUILD_ENV_VARS = {
+    "JAVA_HOME", "MAKEFLAGS", "CC", "CXX",
+    # Generic CI markers. Many suites branch on these; none carry credentials.
+    # GITHUB_* is deliberately absent -- see the note in _build_safe_env.
+    "CI", "CONTINUOUS_INTEGRATION",
+}
+
+# DockerSandbox shells out to the `docker` CLI *through* SubprocessSandbox.run,
+# so the allowlist applies to the CLI itself. Without these, Docker Desktop,
+# colima, Rancher Desktop and remote-daemon setups all fail to find a daemon.
+# These configure the client on the host; `docker run` does not forward host
+# environment into the container, so they are not exposed to sandboxed code
+# when the Docker path is active.
+_DOCKER_CLI_ENV_VARS = {
+    "DOCKER_HOST", "DOCKER_CONTEXT", "DOCKER_CONFIG",
+    "DOCKER_CERT_PATH", "DOCKER_TLS_VERIFY", "DOCKER_BUILDKIT",
+}
+
+ALLOWED_ENV_VARS = (
+    _CORE_ENV_VARS
+    | _PYTHON_ENV_VARS
+    | _NODE_ENV_VARS
+    | _GO_ENV_VARS
+    | _RUST_ENV_VARS
+    | _RUBY_ENV_VARS
+    | _BUILD_ENV_VARS
+    | _DOCKER_CLI_ENV_VARS
+)
+
+# Escape hatch. Set to a comma-separated list of variable names to pass through
+# in addition to the defaults, e.g. for an authenticated module proxy:
+#   export REPOPILOT_SANDBOX_ENV_PASSTHROUGH=GOPROXY,npm_config_registry
+# Names added this way are logged, because widening the boundary should be
+# visible in the run log rather than silent.
+PASSTHROUGH_ENV_VAR = "REPOPILOT_SANDBOX_ENV_PASSTHROUGH"
+
+_LOG = logging.getLogger("agent.sandbox")
+
+
+def _passthrough_names() -> set[str]:
+    """Read additional allowed variable names from PASSTHROUGH_ENV_VAR."""
+    raw = os.environ.get(PASSTHROUGH_ENV_VAR, "")
+    return {name.strip() for name in raw.split(",") if name.strip()}
 
 
 def _build_safe_env(extra_env: Optional[dict] = None) -> dict:
-    """Build a safe environment dict, removing sensitive vars."""
-    env = {key: value for key, value in os.environ.items() if key not in BLOCKED_ENV_VARS}
+    """
+    Build the environment for a sandboxed command.
+
+    Only variables named in ALLOWED_ENV_VARS (plus any listed in
+    PASSTHROUGH_ENV_VAR) are passed through; everything else is dropped. This
+    keeps credentials such as ANTHROPIC_API_KEY, SSH_AUTH_SOCK and KUBECONFIG
+    out of reach of code the model wrote.
+
+    It also drops the GitHub Actions runner variables. GITHUB_ENV and
+    GITHUB_PATH name writable files that inject environment entries and PATH
+    entries into *subsequent workflow steps*, so leaking them lets sandboxed
+    code influence a job that holds contents:write and pull-requests:write.
+
+    Matching is case-insensitive because Windows normalizes environment keys to
+    upper case, which would otherwise drop lower-case entries like
+    ``npm_config_cache``. No allowlisted name collides with a credential name
+    under case folding.
+
+    ``extra_env`` is a trusted-caller override applied *after* filtering, so
+    callers inside RepoPilot can inject variables a runner needs. Never forward
+    model-supplied data into it -- doing so reopens the boundary this closes.
+    """
+    allowed = {name.lower() for name in ALLOWED_ENV_VARS}
+
+    extra_names = _passthrough_names()
+    if extra_names:
+        allowed |= {name.lower() for name in extra_names}
+        _LOG.info(
+            "sandbox: %s widened the environment allowlist with: %s",
+            PASSTHROUGH_ENV_VAR, ", ".join(sorted(extra_names)),
+        )
+
+    env = {key: value for key, value in os.environ.items() if key.lower() in allowed}
     env.setdefault("PATH", os.environ.get("PATH", ""))
+
+    stripped = sorted(set(os.environ) - set(env))
+    if stripped:
+        # Names only, never values. A test that fails because it cannot see a
+        # variable it needs is much easier to diagnose if the sandbox says so.
+        _LOG.debug(
+            "sandbox: stripped %d environment variable(s): %s",
+            len(stripped), ", ".join(stripped),
+        )
+
     if extra_env:
         env.update(extra_env)
     return env

--- a/tests/test_sandbox_env.py
+++ b/tests/test_sandbox_env.py
@@ -1,0 +1,201 @@
+"""
+Tests for sandbox environment sanitization (modules/sandbox.py).
+
+The sandbox executes LLM-generated code, so the environment handed to it is a
+security boundary. These tests pin that boundary in both directions: secrets
+must not survive, and the toolchain variables the runners need must.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# tests/ has no __init__.py and the project ships no pytest config, so the repo
+# root is only on sys.path when invoked as `python -m pytest`. Add it explicitly
+# so a bare `pytest tests/test_sandbox_env.py` works too.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import (  # noqa: E402
+    ALLOWED_ENV_VARS,
+    PASSTHROUGH_ENV_VAR,
+    _build_safe_env,
+)
+
+# Credentials and capability handles that must never reach sandboxed code.
+SECRETS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITLAB_TOKEN",
+    "DATABASE_URL",
+    "REDIS_URL",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "SSH_AUTH_SOCK",
+    "KUBECONFIG",
+    "NPM_TOKEN",
+    "PYPI_TOKEN",
+    "SLACK_TOKEN",
+    "STRIPE_SECRET_KEY",
+    "DOCKER_PASSWORD",
+    "AZURE_CLIENT_SECRET",
+    "HF_TOKEN",
+    "CARGO_REGISTRY_TOKEN",
+]
+
+# GitHub Actions runner variables. GITHUB_ENV and GITHUB_PATH name writable
+# files that inject env entries and PATH entries into subsequent workflow
+# steps, so leaking them escalates "runs code" into "controls the workflow".
+ACTIONS_VARS = [
+    "GITHUB_ENV",
+    "GITHUB_PATH",
+    "GITHUB_OUTPUT",
+    "ACTIONS_RUNTIME_TOKEN",
+    "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+    "ACTIONS_ID_TOKEN_REQUEST_URL",
+]
+
+# Variables the supported runners genuinely need.
+TOOLCHAIN = {
+    "PATH": "/usr/bin",
+    "HOME": "/home/dev",
+    "TMPDIR": "/tmp",
+    "LANG": "en_US.UTF-8",
+    "PYTHONPATH": "/src",
+    "VIRTUAL_ENV": "/src/.venv",
+    "NODE_PATH": "/usr/lib/node_modules",
+    "npm_config_cache": "/home/dev/.npm",
+    "GOPATH": "/home/dev/go",
+    "GOCACHE": "/home/dev/.cache/go-build",
+    "GOMODCACHE": "/home/dev/go/pkg/mod",
+    "GOROOT": "/usr/local/go",
+    "CARGO_HOME": "/home/dev/.cargo",
+    "RUSTUP_HOME": "/home/dev/.rustup",
+    "GEM_HOME": "/home/dev/.gem",
+    "JAVA_HOME": "/usr/lib/jvm/default",
+    "SYSTEMROOT": r"C:\Windows",
+    "COMSPEC": r"C:\Windows\system32\cmd.exe",
+    "CI": "true",
+}
+
+# DockerSandbox runs the `docker` CLI *through* SubprocessSandbox.run, so the
+# allowlist applies to the CLI. Dropping these breaks Docker Desktop, colima,
+# Rancher Desktop and any remote daemon.
+DOCKER_CLI = {
+    "DOCKER_HOST": "unix:///var/run/docker.sock",
+    "DOCKER_CONTEXT": "colima",
+    "DOCKER_CONFIG": "/home/dev/.docker",
+    "DOCKER_CERT_PATH": "/home/dev/.docker/certs",
+    "DOCKER_TLS_VERIFY": "1",
+}
+
+
+@pytest.fixture
+def fake_environ(monkeypatch):
+    """Replace os.environ with a controlled dict and return it."""
+
+    def _apply(**extra):
+        environ = {"PATH": "/usr/bin", "HOME": "/home/dev"}
+        environ.update(extra)
+        monkeypatch.setattr(os, "environ", environ)
+        return environ
+
+    return _apply
+
+
+@pytest.mark.parametrize("name", SECRETS)
+def test_secrets_are_stripped(fake_environ, name):
+    fake_environ(**{name: "sensitive-value"})
+    assert name not in _build_safe_env()
+
+
+@pytest.mark.parametrize("name", ACTIONS_VARS)
+def test_actions_runner_vars_are_stripped(fake_environ, name):
+    """Leaking these lets sandboxed code influence later workflow steps."""
+    fake_environ(**{name: "/runner/file"})
+    assert name not in _build_safe_env()
+
+
+@pytest.mark.parametrize("name,value", sorted(TOOLCHAIN.items()))
+def test_toolchain_vars_survive(fake_environ, name, value):
+    fake_environ(**{name: value})
+    assert _build_safe_env().get(name) == value
+
+
+@pytest.mark.parametrize("name,value", sorted(DOCKER_CLI.items()))
+def test_docker_cli_vars_survive(fake_environ, name, value):
+    """Regression guard for DockerSandbox, which shells out via SubprocessSandbox."""
+    fake_environ(**{name: value})
+    assert _build_safe_env().get(name) == value
+
+
+def test_unknown_vars_are_dropped_by_default(fake_environ):
+    """The default is deny: a brand-new service is protected without a code change."""
+    fake_environ(SOME_FUTURE_SERVICE_TOKEN="secret", ANOTHER_UNKNOWN_VAR="x")
+    env = _build_safe_env()
+    assert "SOME_FUTURE_SERVICE_TOKEN" not in env
+    assert "ANOTHER_UNKNOWN_VAR" not in env
+
+
+def test_path_is_always_present(fake_environ):
+    fake_environ()
+    assert "PATH" in _build_safe_env()
+
+
+def test_matching_is_case_insensitive(fake_environ):
+    """Windows upper-cases environment keys; npm_config_cache must still match."""
+    fake_environ(NPM_CONFIG_CACHE="/cache", Path="/usr/bin")
+    env = _build_safe_env()
+    assert env.get("NPM_CONFIG_CACHE") == "/cache"
+    assert env.get("Path") == "/usr/bin"
+
+
+def test_passthrough_hook_widens_the_allowlist(fake_environ):
+    fake_environ(
+        **{
+            PASSTHROUGH_ENV_VAR: "GOPROXY, MY_INTERNAL_VAR",
+            "GOPROXY": "https://proxy.internal",
+            "MY_INTERNAL_VAR": "value",
+            "ANTHROPIC_API_KEY": "sk-ant-secret",
+        }
+    )
+    env = _build_safe_env()
+    assert env.get("GOPROXY") == "https://proxy.internal"
+    assert env.get("MY_INTERNAL_VAR") == "value"
+    # Widening the hatch must not widen anything else.
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_passthrough_hook_ignores_blank_entries(fake_environ):
+    fake_environ(**{PASSTHROUGH_ENV_VAR: " , ,, ", "UNRELATED": "x"})
+    env = _build_safe_env()
+    assert "UNRELATED" not in env
+    assert "" not in env
+
+
+def test_extra_env_is_a_trusted_caller_override(fake_environ):
+    """extra_env is applied after filtering; it is documented as trusted-caller-only."""
+    fake_environ()
+    env = _build_safe_env({"PYTEST_ADDOPTS": "-q", "RUNNER_SPECIFIC": "1"})
+    assert env["PYTEST_ADDOPTS"] == "-q"
+    assert env["RUNNER_SPECIFIC"] == "1"
+
+
+def test_extra_env_does_not_mutate_os_environ(fake_environ):
+    environ = fake_environ()
+    _build_safe_env({"RUNNER_SPECIFIC": "1"})
+    assert "RUNNER_SPECIFIC" not in environ
+
+
+@pytest.mark.parametrize(
+    "marker", ["TOKEN", "SECRET", "PASSWORD", "PASSWD", "CREDENTIAL", "APIKEY", "AUTH"]
+)
+def test_allowlist_contains_no_credential_shaped_names(marker):
+    """Guards future widening: nothing credential-shaped belongs in the defaults."""
+    offenders = [n for n in ALLOWED_ENV_VARS if marker in n.upper().replace("_", "")]
+    assert offenders == [], f"credential-shaped name(s) in ALLOWED_ENV_VARS: {offenders}"


### PR DESCRIPTION
Closes #47

## Summary

`_build_safe_env` in `modules/sandbox.py` removed six named variables and passed the rest of `os.environ` through to executed code. Since that code is written by the LLM and run without review, every other credential on the machine was reachable — including `ANTHROPIC_API_KEY`, the variable the README instructs users to export.

This inverts the filter. Only variables named in `ALLOWED_ENV_VARS` reach the child process; everything else is dropped. The default is now deny, so a service a user adopts tomorrow is protected without anyone remembering to extend a list.

## Verified, not assumed

I reproduced the leak before changing anything, using a probe that stands in for LLM-written code and dumps the variables it can see.

**Before** — 3 blocked, 14 leaked:

```
BLOCKED (3): AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, GITHUB_TOKEN

LEAKED (14): ACTIONS_ID_TOKEN_REQUEST_TOKEN, ACTIONS_RUNTIME_TOKEN,
ANTHROPIC_API_KEY, AWS_SESSION_TOKEN, GITHUB_ENV, GITHUB_PATH,
GOOGLE_APPLICATION_CREDENTIALS, HF_TOKEN, KUBECONFIG, NPM_TOKEN,
OPENAI_API_KEY, SLACK_TOKEN, SSH_AUTH_SOCK, STRIPE_SECRET_KEY
```

**After** — 17 blocked, 0 leaked.

## Two things worth adding to the issue

**1. In CI this is privilege escalation, not just disclosure.**

`.github/workflows/agent-fix.yml` runs the agent on `ubuntu-latest` with `contents: write` and `pull-requests: write`. `GITHUB_ENV` and `GITHUB_PATH` name *writable files* — appending to them injects environment entries and PATH entries into every subsequent step of that job. Leaking those turns "the model's code ran in a sandbox" into "the model's code controls the rest of a workflow that can push branches and open PRs." `ACTIONS_RUNTIME_TOKEN` and `ACTIONS_ID_TOKEN_REQUEST_TOKEN` were leaking on the same path. All are now dropped, with tests pinning that.

**2. The allowlist as proposed in the issue would have broken `DockerSandbox`.**

`DockerSandbox.run_tests` builds a `docker run ...` argv and hands it to `SubprocessSandbox.run` (sandbox.py L259–260), so the filter applies to the **docker CLI itself**, not just to test code. Dropping `DOCKER_HOST`, `DOCKER_CONTEXT`, `DOCKER_CONFIG`, `DOCKER_CERT_PATH` and `DOCKER_TLS_VERIFY` means the CLI cannot locate a daemon under Docker Desktop, colima, Rancher Desktop, or any remote/TLS setup. Those five are in the allowlist with a comment explaining why. They are not thereby exposed to sandboxed code on the Docker path — `docker run` does not forward host environment into the container without `-e`.

The same check surfaced other gaps in a minimal list: `SYSTEMROOT` (CPython on Windows cannot initialise sockets or SSL without it, so `import ssl` fails), `COMSPEC`, `GOROOT`/`GOMODCACHE`, `RUSTUP_HOME`, `GEM_HOME`, `JAVA_HOME`, `CI`.

## The two details the issue flagged

**`extra_env` bypass.** No caller in the repo passes `extra_env` today, and it is supplied by RepoPilot's own code rather than by the model, so I kept it as a trusted-caller override applied after filtering — that is the point of the parameter. It is now documented as trusted-caller-only in the docstring, with an explicit warning never to forward model-supplied data into it. Happy to switch to filtering it instead if you'd rather not rely on the convention.

**Debug logging.** `_build_safe_env` logs the names of stripped variables at DEBUG under `agent.sandbox`. Names only, never values.

## Escape hatch

A static allowlist will eventually be wrong for somebody's runner, and the usual outcome is that they revert the whole thing. So there is a runtime widening hook:

```bash
export REPOPILOT_SANDBOX_ENV_PASSTHROUGH=GOPROXY,npm_config_registry
```

It logs at INFO whenever it takes effect, so widening the boundary shows up in the run log rather than happening silently.

Related judgment call, flagging it because you may disagree: I deliberately left `GOPROXY`, `GOPRIVATE` and `npm_config_registry` **out** of the defaults. They routinely carry credentials in URL form (`https://user:token@proxy/...`), and defaulting them on would contradict the "every entry is a deliberate decision" principle this PR is built around. Users of authenticated proxies add them via the hook above.

## Tests

`tests/test_sandbox_env.py` — 65 cases, all passing:

- every credential in a realistic list is stripped (21 parametrised)
- GitHub Actions runner variables are stripped (6 parametrised)
- toolchain variables survive (19 parametrised)
- Docker CLI variables survive — regression guard for the point above
- unknown variables dropped by default
- case-insensitive matching, so Windows upper-casing does not drop `npm_config_cache`
- passthrough hook widens only what it names
- `extra_env` override works and does not mutate `os.environ`
- no credential-shaped name (`*TOKEN*`, `*SECRET*`, `*PASSWORD*`, …) can sit in `ALLOWED_ENV_VARS` — guards against careless future widening

## What I ran, and what I did not

Executed on Linux x86_64 / CPython 3.12.3:

- the before/after leak probe above
- `pytest`, `python` (including `import ssl, socket`), `bash` and `node` runners through `SubprocessSandbox` — all exit 0 under the new allowlist
- `tests/test_sandbox_env.py` — 65 passed; `tests/test_utils.py` — 4 passed
- `npx prettier --check README.md` — clean

Not executed, and stated plainly rather than implied:

- **Windows.** `SYSTEMROOT`/`COMSPEC`/`PATHEXT` are included from documented CPython behaviour and reasoning, not from a Windows run.
- **go, cargo, ruby, docker** are not installed in the environment I used, so those allowlist entries are correct by construction rather than empirically exercised. The Docker claim above comes from reading the call path and asserting the variables survive `_build_safe_env` — not from a live `docker run`.

## Not touched, noticed while working

Both pre-existing on `main` and unrelated to this change — happy to open separate PRs, but deliberately kept out of a security diff:

- `python -m pytest` from the repo root fails collection outright: three files share the basename `test_utils.py` (`tests/`, `modules/`, `sample_repo/`) with no `__init__.py` and no pytest config. Targeted paths work. The new test file uses a unique basename to avoid it.
- `npm run format:check` is already failing on `main` for `.github/workflows/agent-fix.yml`, `.github/workflows/prettier.yml` and `ARCHITECTURE.md`.

## Scope

This closes the easiest exfiltration path, not every path. In subprocess mode the filesystem is not isolated, so `~/.aws/credentials` and `~/.npmrc` stay readable — `DockerSandbox` remains the answer for genuinely untrusted code, and the README now says so instead of describing the old behaviour as a boundary. Dropping `SSH_AUTH_SOCK` is the one that is decisive on its own: a forwarded agent socket signs with the private key without ever reading it, so no amount of file permission care substitutes for removing it.

## Files

- `modules/sandbox.py` — allowlist, passthrough hook, debug logging, docstring
- `tests/test_sandbox_env.py` — new
- `README.md` — Module 5 section rewritten (the old text described this as "blocks cloud credentials from leaking", which read as a guarantee it did not provide), plus a row in the mitigations table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved sandbox security by limiting subprocess environment variables to approved values.
  * Added configurable environment-variable passthrough for supported runtime needs.
  * Added logging for expanded passthrough settings and removed variables in debug mode.

* **Documentation**
  * Expanded sandbox guidance covering environment filtering, credential protection, runtime configuration, logging, and filesystem-isolation limitations.

* **Bug Fixes**
  * Prevented secrets, workflow variables, and unknown environment values from unintentionally reaching sandboxed processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->