### PR TITLE
feat(agent): add --interactive commit confirmation — Closes #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,28 @@ python demo_run.py /path/to/sample_repo
 --log-dir       Log output dir (default: logs/)
 --backup-dir    Backup dir (default: backups/)
 --quiet         Suppress verbose output
+--yes, -y       Auto-approve changes (bypasses every prompt; implied by CI=true)
+--interactive   After tests pass, print the diff and confirm before committing
 ```
+
+### Reviewing before a commit
+
+By default the agent commits as soon as the suite goes green. `--interactive`
+inserts a review gate at that point — it prints the working-tree diff the agent
+produced and asks:
+
+```
+Commit these 3 change(s)? [Y/n]:
+```
+
+Declining leaves the changes on disk, uncommitted and unpushed, so they can be
+inspected and committed by hand — or discarded with `--rollback`. The run exits
+with outcome `aborted`.
+
+This is distinct from the existing prompt, which fires _before_ files are
+written and shows a manifest of paths rather than a diff. `--yes` (and `CI=true`,
+which sets it automatically) bypasses both, so unattended runs never block on
+stdin.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -94,6 +94,9 @@ Examples:
     # Non-interactive / CI
     parser.add_argument("--yes", "-y", action="store_true",
                         help="Auto-approve file changes (bypass confirmation prompt)")
+    parser.add_argument("--interactive", "-i", action="store_true",
+                        help="After tests pass, show the diff and confirm before "
+                             "committing. Ignored when --yes is set or CI=true.")
 
     return parser.parse_args()
 
@@ -137,6 +140,7 @@ def main():
         task=task,
         dry_run=args.dry_run,
         yes=yes_flag,
+        interactive=args.interactive,
 
         # Execution
         test_runner=args.runner,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -39,6 +39,7 @@ class AgentConfig:
     task: str
     dry_run: bool = False
     yes: bool = False
+    interactive: bool = False   # pause for review after tests pass, before commit
 
     # Execution
     test_runner: str = "pytest"            # pytest | npm_test | go | cargo | ...
@@ -74,7 +75,7 @@ class AgentConfig:
 @dataclass
 class AgentRunResult:
     run_id: str
-    outcome: str        # success | failed | max_retries | error
+    outcome: str        # success | failed | max_retries | error | aborted | dry_run
     branch_name: Optional[str]
     pr_url: Optional[str]
     iterations_used: int
@@ -121,6 +122,49 @@ class AutonomousAgent:
             return self.sandbox.run_file(cfg.run_file, cfg.run_file_runner)
         else:
             return self.sandbox.run_tests(cfg.test_runner, cfg.test_args)
+
+    # Cap the review diff so a large refactor cannot flood the terminal.
+    _MAX_DIFF_LINES = 400
+
+    def _confirm_commit(self, changed_paths: list[str]) -> bool:
+        """
+        Show what the agent wrote and ask before committing.
+
+        Only runs under --interactive. --yes bypasses it (and main.py sets that
+        automatically when CI=true), matching how the pre-apply prompt behaves,
+        so unattended runs are never left waiting on stdin.
+        """
+        cfg = self.config
+        if not cfg.interactive or cfg.yes:
+            return True
+
+        from modules.dry_run import ask_confirmation
+
+        print("\n" + "=" * 60)
+        print("  TESTS PASSED - REVIEW BEFORE COMMIT")
+        print("=" * 60)
+
+        diff = self.git.diff_unstaged() if self.git else ""
+        if diff.strip():
+            lines = diff.splitlines()
+            for line in lines[: self._MAX_DIFF_LINES]:
+                print(line)
+            if len(lines) > self._MAX_DIFF_LINES:
+                print(
+                    f"\n  ... diff truncated at {self._MAX_DIFF_LINES} lines "
+                    f"({len(lines) - self._MAX_DIFF_LINES} more). "
+                    f"Run `git diff` in another shell for the full text."
+                )
+        else:
+            # No git, or git reported nothing. Fall back to the file list so the
+            # prompt is never shown without context.
+            reason = "Git is disabled" if not self.git else "Git reported no diff"
+            print(f"  {reason}. Files the agent changed:")
+            for path in changed_paths:
+                print(f"    {path}")
+
+        print("=" * 60)
+        return ask_confirmation(len(changed_paths), action="Commit")
 
     def _commit_changes(self, iteration: int, changed_paths: list[str]) -> bool:
         """Stage and commit the modified files."""
@@ -332,7 +376,16 @@ class AutonomousAgent:
             # ── Early exit if LLM says done (optional) ──
             if cfg.success_on_llm_done and llm_resp.done and llm_resp.confidence >= 0.8:
                 self.logger.info("  LLM reports task complete. Skipping execution (success_on_llm_done=True).")
-                self._commit_changes(iteration, [c.path for c in last_changes])
+                changed_paths = [c.path for c in last_changes]
+                if not self._confirm_commit(changed_paths):
+                    self.logger.warning(
+                        "  Commit declined. Changes are left in the working tree."
+                    )
+                    outcome = "aborted"
+                    self.logger.record_iteration(iter_record)
+                    break
+
+                self._commit_changes(iteration, changed_paths)
                 outcome = "success"
                 iter_record.execution_success = True
                 self.logger.record_iteration(iter_record)
@@ -355,7 +408,16 @@ class AutonomousAgent:
             # ── Step 6: Success check ──
             if exec_result.success:
                 self.logger.info(f"  Tests passed on iteration {iteration}")
-                self._commit_changes(iteration, [c.path for c in last_changes])
+
+                changed_paths = [c.path for c in last_changes]
+                if not self._confirm_commit(changed_paths):
+                    self.logger.warning(
+                        "  Commit declined. Changes are left in the working tree."
+                    )
+                    outcome = "aborted"
+                    break
+
+                self._commit_changes(iteration, changed_paths)
                 outcome = "success"
                 break
 
@@ -406,6 +468,11 @@ class AutonomousAgent:
             "failed": "Task could not be completed. Check logs.",
             "max_retries": f"Exhausted {cfg.max_iterations} iterations without passing tests.",
             "error": "Agent encountered an unrecoverable error.",
+            "aborted": (
+                "Commit declined at the review prompt. Tests passed and the "
+                "changes are still in the working tree - commit them manually, "
+                "or run with --rollback to discard them."
+            ),
         }.get(outcome, "Unknown outcome")
 
         self.logger.finish_run(outcome, self.branch_name, pr_url)

--- a/modules/dry_run.py
+++ b/modules/dry_run.py
@@ -48,10 +48,15 @@ def save_manifest(changes: list, log_dir: str, run_id: str) -> str:
     return path
 
 
-def ask_confirmation(n: int) -> bool:
-    """Prompt user to confirm before applying changes. Returns True if approved."""
+def ask_confirmation(n: int, action: str = "Apply") -> bool:
+    """
+    Prompt the user to confirm an action on n changes. Returns True if approved.
+
+    `action` is the verb shown in the prompt. It defaults to "Apply" so the
+    existing pre-apply prompt is unchanged; --interactive passes "Commit".
+    """
     try:
-        answer = input(f"\nApply these {n} change(s)? [Y/n]: ").strip().lower()
+        answer = input(f"\n{action} these {n} change(s)? [Y/n]: ").strip().lower()
         return answer not in ("n", "no")
     except (KeyboardInterrupt, EOFError):
         print("\nAborted.")

--- a/modules/git_integration.py
+++ b/modules/git_integration.py
@@ -139,6 +139,17 @@ class GitIntegration:
         result = self._run(["git", "diff", "--cached", "--stat"])
         return result.output
 
+    def diff_unstaged(self, stat_only: bool = False) -> str:
+        """
+        Return the working-tree diff for changes that are not yet staged.
+
+        Used by --interactive to show what the agent actually wrote before
+        anything is committed. `git_stash_before_apply` stashes any pre-existing
+        local edits first, so this diff contains only the agent's own changes.
+        """
+        cmd = ["git", "diff", "--stat"] if stat_only else ["git", "diff"]
+        return self._run(cmd).output
+
     def get_remote_url(self, remote: str = "origin") -> Optional[str]:
         result = self._run(["git", "remote", "get-url", remote])
         return result.output if result.success else None

--- a/tests/test_interactive_commit.py
+++ b/tests/test_interactive_commit.py
@@ -1,0 +1,200 @@
+"""
+Tests for --interactive commit confirmation (modules/agent_loop.py).
+
+The agent commits automatically once the suite goes green. --interactive adds a
+review gate between "tests passed" and "git commit", which is the point the
+issue asks for: after changes are applied, before anything is committed.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig, AutonomousAgent  # noqa: E402
+from modules.dry_run import ask_confirmation  # noqa: E402
+
+
+class FakeGit:
+    """Minimal stand-in for GitIntegration."""
+
+    def __init__(self, diff=""):
+        self._diff = diff
+
+    def diff_unstaged(self, stat_only=False):
+        return self._diff
+
+
+def make_agent(monkeypatch, *, interactive, yes, git=None, answer="y"):
+    """Build an AutonomousAgent without running __init__ side effects."""
+    agent = object.__new__(AutonomousAgent)
+    agent.config = AgentConfig(
+        repo_root=".",
+        task="t",
+        interactive=interactive,
+        yes=yes,
+    )
+    agent.git = git
+    agent.logger = SimpleNamespace(
+        info=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **k: answer)
+    return agent
+
+
+# ── gating ────────────────────────────────────────────────────────────────
+
+
+def test_no_prompt_when_interactive_is_off(monkeypatch):
+    """Default behaviour is unchanged: commit proceeds with no prompt."""
+
+    def explode(*a, **k):
+        raise AssertionError("input() must not be called without --interactive")
+
+    monkeypatch.setattr("builtins.input", explode)
+    agent = make_agent(monkeypatch, interactive=False, yes=False)
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert agent._confirm_commit(["a.py"]) is True
+
+
+def test_yes_bypasses_the_prompt(monkeypatch):
+    """--yes wins over --interactive so CI never blocks on stdin."""
+
+    def explode(*a, **k):
+        raise AssertionError("input() must not be called when --yes is set")
+
+    agent = make_agent(monkeypatch, interactive=True, yes=True)
+    monkeypatch.setattr("builtins.input", explode)
+
+    assert agent._confirm_commit(["a.py"]) is True
+
+
+# ── answers ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("answer", ["y", "Y", "yes", "", "  "])
+def test_affirmative_answers_approve(monkeypatch, answer):
+    agent = make_agent(monkeypatch, interactive=True, yes=False, answer=answer)
+    assert agent._confirm_commit(["a.py"]) is True
+
+
+@pytest.mark.parametrize("answer", ["n", "N", "no", "No"])
+def test_negative_answers_decline(monkeypatch, answer):
+    agent = make_agent(monkeypatch, interactive=True, yes=False, answer=answer)
+    assert agent._confirm_commit(["a.py"]) is False
+
+
+@pytest.mark.parametrize("exc", [KeyboardInterrupt, EOFError])
+def test_interrupt_declines_rather_than_crashing(monkeypatch, exc):
+    agent = make_agent(monkeypatch, interactive=True, yes=False)
+
+    def raise_it(*a, **k):
+        raise exc()
+
+    monkeypatch.setattr("builtins.input", raise_it)
+    assert agent._confirm_commit(["a.py"]) is False
+
+
+# ── what the reviewer is shown ────────────────────────────────────────────
+
+
+def test_diff_is_printed_for_review(monkeypatch, capsys):
+    diff = "diff --git a/x.py b/x.py\n+added line\n"
+    agent = make_agent(monkeypatch, interactive=True, yes=False, git=FakeGit(diff))
+
+    agent._confirm_commit(["x.py"])
+    out = capsys.readouterr().out
+    assert "REVIEW BEFORE COMMIT" in out
+    assert "+added line" in out
+
+
+def test_long_diff_is_truncated(monkeypatch, capsys):
+    diff = "\n".join(f"+line {i}" for i in range(1000))
+    agent = make_agent(monkeypatch, interactive=True, yes=False, git=FakeGit(diff))
+
+    agent._confirm_commit(["x.py"])
+    out = capsys.readouterr().out
+    assert "diff truncated" in out
+    assert "+line 0" in out
+    assert "+line 999" not in out
+
+
+def test_falls_back_to_file_list_without_git(monkeypatch, capsys):
+    agent = make_agent(monkeypatch, interactive=True, yes=False, git=None)
+
+    agent._confirm_commit(["alpha.py", "beta.py"])
+    out = capsys.readouterr().out
+    assert "Git is disabled" in out
+    assert "alpha.py" in out
+    assert "beta.py" in out
+
+
+def test_falls_back_to_file_list_when_diff_is_empty(monkeypatch, capsys):
+    agent = make_agent(monkeypatch, interactive=True, yes=False, git=FakeGit(""))
+
+    agent._confirm_commit(["alpha.py"])
+    out = capsys.readouterr().out
+    assert "Git reported no diff" in out
+    assert "alpha.py" in out
+
+
+# ── the shared prompt helper ──────────────────────────────────────────────
+
+
+def test_default_prompt_wording_is_unchanged(monkeypatch, capsys):
+    """The pre-apply prompt must read exactly as it did before."""
+    monkeypatch.setattr("builtins.input", lambda prompt="": print(prompt) or "y")
+    ask_confirmation(3)
+    assert "Apply these 3 change(s)? [Y/n]:" in capsys.readouterr().out
+
+
+def test_commit_prompt_uses_the_commit_verb(monkeypatch, capsys):
+    monkeypatch.setattr("builtins.input", lambda prompt="": print(prompt) or "y")
+    ask_confirmation(2, action="Commit")
+    assert "Commit these 2 change(s)? [Y/n]:" in capsys.readouterr().out
+
+
+# ── config surface ────────────────────────────────────────────────────────
+
+
+def test_interactive_defaults_to_off():
+    assert AgentConfig(repo_root=".", task="t").interactive is False
+
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+
+def test_aborted_outcome_has_a_real_message():
+    """`aborted` must not fall through to the 'Unknown outcome' default."""
+    source = AGENT_LOOP.read_text()
+    assert '"aborted": (' in source
+    assert "still in the working tree" in source
+
+
+def test_every_commit_path_is_gated():
+    """
+    run() commits from two places: the normal tests-passed exit and the
+    success_on_llm_done early exit. Both must go through _confirm_commit, or
+    --interactive silently does nothing on one of them.
+    """
+    lines = AGENT_LOOP.read_text().splitlines()
+    call_sites = [
+        i for i, line in enumerate(lines)
+        if "self._commit_changes(" in line and "def " not in line
+    ]
+
+    assert len(call_sites) == 2, (
+        f"expected 2 commit call sites, found {len(call_sites)}"
+    )
+
+    for i in call_sites:
+        preceding = "\n".join(lines[max(0, i - 12):i])
+        assert "_confirm_commit" in preceding, (
+            f"_commit_changes at line {i + 1} is not gated by _confirm_commit"
+        )


### PR DESCRIPTION
Closes #51

## Summary

`AutonomousAgent` commits the moment the suite goes green. `agent_loop.py:358` calls `_commit_changes()` directly off `if exec_result.success`, and push/PR follow from the post-loop block. There is no gate between "tests passed" and "git commit".

This adds `--interactive` / `-i`, which prints the working-tree diff the agent produced and asks before committing.

## What already existed, and what is new

Worth stating up front, because grepping for `[Y/n]` finds an existing prompt and it would be easy to read this as a duplicate.

`dry_run.py:54` already prints `Apply these N change(s)? [Y/n]:`, called from `agent_loop.py:300`. That prompt fires **before** `apply_changes()` and shows a manifest of paths and actions — it is asking "should I write these files?".

The gate this PR adds fires **after** files are applied and tests pass, and shows the actual diff — it asks "should I commit what you can now see?". That is the point the issue specifies ("after applying changes", "before they are committed"), and it did not exist.

Both prompts are bypassed by `--yes` / `-y`, which `main.py` already sets automatically when `CI=true`, so unattended runs never block on stdin. `agent-fix.yml` passes `--yes` and is unaffected.

## Both commit paths are gated

`run()` commits from two places, not one:

- `agent_loop.py:358` — the normal tests-passed exit
- `agent_loop.py:379` — the `success_on_llm_done` early exit, which commits without running tests at all

Gating only the first would have made `--interactive` silently do nothing on the second. Both go through `_confirm_commit` now, and `test_every_commit_path_is_gated` asserts the call-site count stays at two with a gate above each, so a future commit path cannot be added without noticing.

## Declining

Declining leaves the applied changes in the working tree, uncommitted and unpushed, and returns `outcome="aborted"`:

- push and PR creation both require `outcome == "success"`, so neither runs
- the rollback block covers `failed`/`max_retries`/`error`, so a decline does **not** discard passing work — the user can inspect and commit by hand, or use `--rollback`

One thing that needed fixing to make this work: the `final_message` map had no `aborted` key and falls through to `.get(outcome, "Unknown outcome")`. The existing pre-apply abort dodges this by returning early rather than breaking out of the loop. Added a real message that tells the user their changes are still on disk.

## Implementation notes

- `GitIntegration.diff_unstaged(stat_only=False)` is new. `git_stash_before_apply` stashes any pre-existing local edits before the agent writes, so the working-tree diff contains only the agent's own changes.
- The diff is capped at 400 lines with a "run `git diff` for the full text" note, so a large refactor cannot flood the terminal.
- With `--no-git`, or if git reports no diff, it falls back to listing the changed paths — the prompt is never shown without context.
- `ask_confirmation` gained an `action` parameter defaulting to `"Apply"`, so the existing prompt string is byte-identical and `--interactive` passes `"Commit"`.
- Exit-code semantics are untouched: `main.py` already exits 1 for any non-`success` outcome, and `aborted` was already in use.

## Tests

`tests/test_interactive_commit.py` — 22 cases:

- no prompt without `--interactive`; `--yes` bypasses it (both assert `input()` is never called)
- affirmative answers `y`/`Y`/`yes`/empty approve; `n`/`N`/`no` decline
- `KeyboardInterrupt` and `EOFError` decline rather than crash
- the diff is printed; a 1000-line diff is truncated
- fallback to the file list with no git, and when the diff is empty
- the default prompt still reads `Apply these 3 change(s)? [Y/n]:` exactly
- `--interactive` defaults to off; `aborted` has a real message
- every `_commit_changes` call site is gated

## Verified

- 22 new tests pass; `tests/test_utils.py` still 4 passed
- `diff_unstaged()` exercised against a real git repo — returns a correct working-tree diff
- `python main.py --help` renders the new flag
- `npx prettier --check README.md` clean
- ruff on `agent_loop.py`: 19 findings before and after this change, i.e. none added

Not verified: the full `run()` loop needs a live `ANTHROPIC_API_KEY`, so `_confirm_commit` is covered at unit level plus the static call-site assertion, not by an end-to-end agent run.

## Pre-existing, not touched

`python -m pytest` from the repo root fails collection — three files share the basename `test_utils.py` with no `__init__.py` and no pytest config. Targeted paths work; the new test file uses a unique basename. `npm run format:check` is also already failing on `main` for two workflow files and `ARCHITECTURE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive review before committing changes after tests pass.
  * Displays the pending diff or changed-file summary for approval.
  * Added `--interactive`/`-i` and `--yes`/`-y` CLI options.
  * Supports bypassing approval prompts with `--yes` or `CI=true`.

* **Behavior Changes**
  * Declining review leaves changes uncommitted and reports an aborted run.
  * Dry-run outcomes are now documented.

* **Documentation**
  * Documented interactive review, approval prompts, and bypass behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->