### PR TITLE
feat(ingestion): respect .gitignore and exclude secret files — Closes #54

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,8 +169,20 @@ python demo_run.py /path/to/sample_repo
 ### Module 1 — `repo_ingestion.py`
 
 - Recursively walks a directory, skipping `.git`, `node_modules`, `__pycache__`, etc.
+- Respects the repository's `.gitignore` and `.git/info/exclude` via `pathspec`,
+  so build output, caches and anything else the project already ignores stays
+  out of the context budget.
+- Never ingests credential-bearing filenames (`.env*`, `*.pem`, `*.key`,
+  `id_rsa`, `.npmrc`, `.netrc`, `credentials*`, …). Ingested content is sent
+  verbatim to the model, so this holds even when the project has no
+  `.gitignore`.
 - Ignores binary files, files > 512KB, and enforces an 8MB total repo budget.
 - Returns a `Repository` with `FileRecord[]` — path, content, language, checksum.
+
+> Only root-level ignore files are read; nested `.gitignore` files are not
+> resolved. If `pathspec` is not installed the walker degrades to the built-in
+> `IGNORE_DIRS`/`IGNORE_EXTENSIONS` rules — the secret-filename filter is
+> independent of it and always applies.
 
 ### Module 2 — `context_builder.py`
 

--- a/modules/repo_ingestion.py
+++ b/modules/repo_ingestion.py
@@ -3,11 +3,20 @@ Module 1: Repository Ingestion
 Recursively scans a project, ignores noise, stores file content + metadata.
 """
 
+import fnmatch
 import os
 import hashlib
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
+
+try:  # optional at runtime so an un-reinstalled checkout still works
+    import pathspec
+except ImportError:  # pragma: no cover - exercised via the fallback tests
+    pathspec = None
+
+_LOG = logging.getLogger("agent.repo_ingestion")
 
 IGNORE_DIRS = {
     ".git", ".svn", ".hg", "node_modules", "__pycache__", ".pytest_cache",
@@ -26,6 +35,19 @@ IGNORE_EXTENSIONS = {
     ".pdf", ".doc", ".docx", ".xls", ".xlsx",
     ".lock",  # package-lock.json etc. — too noisy
 }
+
+# Files that must never enter the LLM prompt, whether or not .gitignore lists
+# them. Ingested content is sent verbatim to the model, so a missing or
+# incomplete .gitignore should not be the only thing standing between a
+# developer's secrets and an outbound API call.
+SECRET_FILE_PATTERNS = (
+    ".env", ".env.*", "*.env",
+    "*.pem", "*.key", "*.p12", "*.pfx",
+    "id_rsa", "id_dsa", "id_ecdsa", "id_ed25519",
+    ".npmrc", ".pypirc", ".netrc", "_netrc",
+    "credentials", "credentials.json",
+    ".htpasswd", "*.keystore", "*.jks",
+)
 
 MAX_FILE_SIZE_BYTES = 512 * 1024  # 512 KB per file
 MAX_TOTAL_BYTES = 8 * 1024 * 1024  # 8 MB total repo budget
@@ -100,14 +122,62 @@ def _should_ignore_dir(dirname: str) -> bool:
     return dirname.lower() in IGNORE_DIRS or dirname.startswith(".")
 
 
+def _is_secret_file(filepath: str) -> bool:
+    """True if the filename matches a pattern that commonly holds credentials."""
+    name = os.path.basename(filepath).lower()
+    return any(fnmatch.fnmatch(name, pat) for pat in SECRET_FILE_PATTERNS)
+
+
 def _should_ignore_file(filepath: str) -> bool:
     ext = Path(filepath).suffix.lower()
     name = os.path.basename(filepath).lower()
+    if _is_secret_file(filepath):
+        return True
     if ext in IGNORE_EXTENSIONS:
         return True
-    if name.startswith(".") and name not in (".env", ".gitignore", ".dockerignore"):
+    if name.startswith(".") and name not in (".gitignore", ".dockerignore"):
         return True
     return False
+
+
+def load_ignore_spec(root: str):
+    """
+    Build a PathSpec from the repo's .gitignore and .git/info/exclude.
+
+    Returns None when pathspec is unavailable or there is nothing to parse, in
+    which case ingestion falls back to the hardcoded IGNORE_DIRS/EXTENSIONS
+    behaviour. Only root-level ignore files are read; nested .gitignore files
+    are not resolved (see the note in the README).
+    """
+    if pathspec is None:
+        _LOG.debug("pathspec not installed; falling back to hardcoded ignore rules")
+        return None
+
+    lines: list[str] = []
+    for candidate in (
+        os.path.join(root, ".gitignore"),
+        os.path.join(root, ".git", "info", "exclude"),
+    ):
+        try:
+            with open(candidate, "r", encoding="utf-8", errors="replace") as fh:
+                lines.extend(fh.read().splitlines())
+        except OSError:
+            continue
+
+    if not lines:
+        return None
+
+    # "gitignore" is the current factory name; "gitwildmatch" is its deprecated
+    # predecessor and is still the only one available on pathspec < 0.12.
+    for style in ("gitignore", "gitwildmatch"):
+        try:
+            return pathspec.PathSpec.from_lines(style, lines)
+        except (KeyError, LookupError):
+            continue
+        except Exception as exc:  # malformed patterns must not break ingestion
+            _LOG.warning("could not parse ignore patterns (%s); using defaults", exc)
+            return None
+    return None
 
 
 def ingest_repository(repo_root: str) -> Repository:
@@ -120,17 +190,36 @@ def ingest_repository(repo_root: str) -> Repository:
         raise ValueError(f"Not a directory: {root}")
 
     repo = Repository(root=root)
+    spec = load_ignore_spec(root)
+
+    def _rel(path: str) -> str:
+        return os.path.relpath(path, root).replace(os.sep, "/")
 
     for dirpath, dirnames, filenames in os.walk(root):
-        # Prune ignored directories in-place (modifies walk)
-        dirnames[:] = [d for d in dirnames if not _should_ignore_dir(d)]
+        # Prune ignored directories in-place (modifies walk). Directories are
+        # matched with a trailing slash so gitwildmatch honours "build/" style
+        # patterns, and pruning here means an ignored tree is never descended.
+        kept = []
+        for d in dirnames:
+            if _should_ignore_dir(d):
+                continue
+            rel_dir = _rel(os.path.join(dirpath, d))
+            if spec is not None and spec.match_file(rel_dir + "/"):
+                repo.skipped.append(f"{rel_dir}/ (gitignored)")
+                continue
+            kept.append(d)
+        dirnames[:] = kept
 
         for filename in sorted(filenames):
             abs_path = os.path.join(dirpath, filename)
-            rel_path = os.path.relpath(abs_path, root).replace(os.sep, "/")
+            rel_path = _rel(abs_path)
 
             if _should_ignore_file(abs_path):
                 repo.skipped.append(rel_path)
+                continue
+
+            if spec is not None and spec.match_file(rel_path):
+                repo.skipped.append(f"{rel_path} (gitignored)")
                 continue
 
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 anthropic>=0.18.0
 pytest>=8.0.0
+pathspec>=0.12.1

--- a/tests/test_repo_ingestion_gitignore.py
+++ b/tests/test_repo_ingestion_gitignore.py
@@ -1,0 +1,141 @@
+"""
+Tests for .gitignore-aware repository ingestion (modules/repo_ingestion.py).
+
+Ingested file content is sent verbatim to the LLM, so what the walker picks up
+is a disclosure boundary, not just a context-budget concern. These tests pin
+both halves: gitignored paths stay out, and credential-bearing filenames stay
+out whether or not .gitignore happens to mention them.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import repo_ingestion  # noqa: E402
+from modules.repo_ingestion import (  # noqa: E402
+    _is_secret_file,
+    ingest_repository,
+    load_ignore_spec,
+)
+
+pathspec = pytest.importorskip("pathspec", reason="pathspec drives the ignore spec")
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A small project with a .gitignore covering a file, a glob and a dir."""
+    (tmp_path / ".gitignore").write_text(
+        textwrap.dedent(
+            """\
+            .env
+            *.log
+            build_out/
+            secrets/
+            """
+        )
+    )
+    (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-ant-secret\n")
+    (tmp_path / "app.log").write_text("noise\n")
+    (tmp_path / "main.py").write_text("print('hi')\n")
+    (tmp_path / "README.md").write_text("# project\n")
+
+    (tmp_path / "secrets").mkdir()
+    (tmp_path / "secrets" / "creds.txt").write_text("AWS_SECRET=leaked\n")
+    (tmp_path / "build_out").mkdir()
+    (tmp_path / "build_out" / "bundle.txt").write_text("artifact\n")
+
+    return tmp_path
+
+
+def _paths(result):
+    return {f.path for f in result.files}
+
+
+def test_gitignored_file_is_excluded(repo):
+    assert "app.log" not in _paths(ingest_repository(str(repo)))
+
+
+def test_gitignored_directory_is_excluded(repo):
+    paths = _paths(ingest_repository(str(repo)))
+    assert "secrets/creds.txt" not in paths
+    assert "build_out/bundle.txt" not in paths
+
+
+def test_tracked_files_are_still_ingested(repo):
+    paths = _paths(ingest_repository(str(repo)))
+    assert "main.py" in paths
+    assert "README.md" in paths
+
+
+def test_gitignore_itself_remains_visible(repo):
+    """It is useful context and holds no secrets."""
+    assert ".gitignore" in _paths(ingest_repository(str(repo)))
+
+
+def test_env_file_never_reaches_the_model(repo):
+    result = ingest_repository(str(repo))
+    assert ".env" not in _paths(result)
+    assert all("sk-ant-secret" not in f.content for f in result.files)
+
+
+def test_env_excluded_even_without_a_gitignore(tmp_path):
+    """The secret filter must not depend on the project having a .gitignore."""
+    (tmp_path / ".env").write_text("DB_PASSWORD=hunter2\n")
+    (tmp_path / "main.py").write_text("print('hi')\n")
+
+    result = ingest_repository(str(tmp_path))
+    assert ".env" not in _paths(result)
+    assert "main.py" in _paths(result)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        ".env", ".env.local", ".env.production", "prod.env",
+        "server.pem", "private.key", "id_rsa", "id_ed25519",
+        ".npmrc", ".pypirc", ".netrc", "credentials", "credentials.json",
+    ],
+)
+def test_secret_filenames_are_recognised(name):
+    assert _is_secret_file(name) is True
+
+
+@pytest.mark.parametrize(
+    "name", ["main.py", "environment.md", "keyboard.js", ".gitignore"]
+)
+def test_ordinary_filenames_are_not_treated_as_secrets(name):
+    assert _is_secret_file(name) is False
+
+
+def test_skipped_entries_record_the_reason(repo):
+    skipped = ingest_repository(str(repo)).skipped
+    assert any("app.log" in s and "gitignored" in s for s in skipped)
+
+
+def test_missing_gitignore_yields_no_spec(tmp_path):
+    (tmp_path / "main.py").write_text("print('hi')\n")
+    assert load_ignore_spec(str(tmp_path)) is None
+
+
+def test_malformed_patterns_do_not_break_ingestion(tmp_path):
+    (tmp_path / ".gitignore").write_text("[unclosed\n***/bad\n")
+    (tmp_path / "main.py").write_text("print('hi')\n")
+    # Must not raise; worst case the spec is dropped and defaults apply.
+    assert "main.py" in _paths(ingest_repository(str(tmp_path)))
+
+
+def test_falls_back_cleanly_when_pathspec_is_absent(repo, monkeypatch):
+    """An un-reinstalled checkout must still ingest, just without .gitignore."""
+    monkeypatch.setattr(repo_ingestion, "pathspec", None)
+
+    result = ingest_repository(str(repo))
+    paths = _paths(result)
+
+    assert load_ignore_spec(str(repo)) is None
+    assert "main.py" in paths          # ingestion still works
+    assert ".env" not in paths         # secret filter is independent of pathspec
+    assert "app.log" in paths          # .gitignore is genuinely not applied


### PR DESCRIPTION
Closes #54

## Summary

`repo_ingestion.py` hardcodes its skip lists and never consults `.gitignore`, so ignored files are walked, read, and counted against the context budget. This adds `pathspec`-based parsing of the repository's `.gitignore` and `.git/info/exclude`.

While testing it I found the impact is larger than a budget concern, so the PR is scoped slightly wider than the issue text.

## Ingested content goes to the model verbatim

`_should_ignore_file` excludes dotfiles — except it explicitly whitelisted `.env`:

```python
if name.startswith(".") and name not in (".env", ".gitignore", ".dockerignore"):
    return True
```

On a fixture repo with a normal `.gitignore`, every ignored file was ingested:

```
before: .env, .gitignore, app.log, main.py, secrets/creds.txt, build_out/bundle.txt
after:  .gitignore, main.py
```

`.env` came through with `ANTHROPIC_API_KEY=...` in its content, and that content is sent to the Anthropic API as prompt context. So this is credential disclosure, not just wasted budget — which is why the PR also adds a filename filter that does not depend on `.gitignore` existing.

## What changed

**`.gitignore` support.** `load_ignore_spec()` reads root `.gitignore` and `.git/info/exclude` and builds a `PathSpec`. Directories are matched with a trailing slash so `build/`-style patterns work, and ignored trees are pruned during the walk rather than filtered per-file.

**Secret filenames.** `SECRET_FILE_PATTERNS` covers `.env*`, `*.env`, `*.pem`, `*.key`, `id_rsa`/`id_ed25519`, `.npmrc`, `.pypirc`, `.netrc`, `credentials*` and similar. Checked first, independent of `.gitignore`, so a project without one is still covered. `.env` was also removed from the dotfile whitelist above.

**Optional dependency.** `pathspec` is added to `requirements.txt` but imported inside a `try`, so an existing checkout that has not been reinstalled keeps working — it just falls back to the hardcoded `IGNORE_DIRS`/`IGNORE_EXTENSIONS` rules. The secret filter still applies in that mode. Malformed patterns are caught and the spec dropped rather than breaking ingestion. The factory name prefers `"gitignore"` and falls back to the deprecated `"gitwildmatch"` for `pathspec < 0.12`.

## Limitations, stated rather than glossed

- Only root-level ignore files are read. Nested `.gitignore` files are **not** resolved. Documented in the README.
- `.gitignore` and `.dockerignore` remain ingestible — useful context, no secrets.
- A file the agent needs but the project gitignores will no longer reach the model. That seems right, but it is a behaviour change worth flagging.

## Tests

`tests/test_repo_ingestion_gitignore.py` — 27 cases: gitignored files, globs and directories excluded; tracked files still ingested; `.env` excluded both with and without a `.gitignore`, and asserted absent from every file's *content*; 13 parametrised secret filenames recognised and 4 ordinary ones not; skip reasons recorded; missing `.gitignore` yields no spec; malformed patterns do not raise; and a fallback test that monkeypatches `pathspec` to `None` and asserts ingestion still works, `.env` is still excluded, and `.gitignore` genuinely stops being applied.

## Verified

- 27 new tests pass; `tests/test_utils.py` still 4 passed
- before/after fixture run above
- repopilot still ingests its own source: 26 files, all 13 core modules, `logs/` and `backups/` excluded
- `npx prettier --check README.md` clean; ruff clean on both changed files

## Pre-existing, not touched

`python -m pytest` from the repo root fails collection — three files share the basename `test_utils.py` with no `__init__.py` and no pytest config. The new test file uses a unique basename to avoid it. `npm run format:check` is already failing on `main` for two workflow files and `ARCHITECTURE.md`.