### PR TITLE
feat(sandbox): add vitest and jest runners — Closes #53

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ python demo_run.py /path/to/sample_repo
 ```
 --repo          Path to git repository (required)
 --task          Task description (required)
---runner        Test runner: pytest|npm_test|go|cargo|... (default: pytest)
+--runner        Test runner: pytest|npm_test|vitest|jest|go|cargo|... (default: pytest)
 --runner-args   Extra args for runner
 --run-file      Run a specific file instead of test suite
 --timeout       Sandbox timeout in seconds (default: 120)
@@ -279,6 +279,15 @@ return MAX_RETRIES
 # In sandbox.py, add to ALLOWED_RUNNERS:
 "deno": ["deno", "test"],
 ```
+
+**JavaScript / TypeScript runners:** `vitest` and `jest` go through
+`npx --no-install`, which resolves the target project's own `node_modules/.bin`
+and fails if the package is missing rather than fetching it from the registry —
+so the sandbox stays hermetic and `DockerSandbox`'s `--network=none` is not
+quietly bypassed. Install the runner as a dev dependency of the repo under test
+first. `vitest` is invoked as `vitest run`: bare `vitest` starts a watch server
+when it believes it is interactive, which under the sandbox would sit until
+`timeout_seconds` elapsed and be reported as a test timeout.
 
 **Add a new file type to context scoring:**
 

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -43,11 +43,21 @@ class ExecutionResult:
         return "\n".join(lines)
 
 
+# `npx --no-install` resolves the project's own node_modules/.bin and fails if the
+# package is absent, rather than downloading it. That matters here: the sandbox
+# is meant to be hermetic, and a runner that silently fetches from the registry
+# would defeat DockerSandbox's --network=none and surprise offline users.
+#
+# vitest is invoked as `vitest run` on purpose. Bare `vitest` starts a watch
+# server when it thinks it is interactive; under this sandbox it would hold the
+# process open until timeout_seconds elapsed and be reported as a test timeout.
 ALLOWED_RUNNERS = {
     "python": [sys.executable],
     "pytest": [sys.executable, "-m", "pytest"],
     "node": ["node"],
     "npm_test": ["npm", "test", "--"],
+    "vitest": ["npx", "--no-install", "vitest", "run"],
+    "jest": ["npx", "--no-install", "jest"],
     "bash": ["bash"],
     "make": ["make"],
     "go": ["go", "test", "./..."],
@@ -61,6 +71,8 @@ DOCKER_RUNNERS = {
     "pytest": ["python", "-m", "pytest"],
     "node": ["node"],
     "npm_test": ["npm", "test", "--"],
+    "vitest": ["npx", "--no-install", "vitest", "run"],
+    "jest": ["npx", "--no-install", "jest"],
     "bash": ["bash"],
     "make": ["make"],
     "go": ["go", "test", "./..."],

--- a/tests/test_js_runners.py
+++ b/tests/test_js_runners.py
@@ -1,0 +1,221 @@
+"""
+Tests for the vitest and jest runners (modules/sandbox.py).
+
+The table entries carry two decisions that are easy to undo by accident, so
+both are pinned here: `--no-install`, which stops npx fetching a missing
+package from the registry, and vitest's `run` subcommand, which stops it
+starting a watch server that would sit until the sandbox timeout.
+
+The integration tests skip cleanly when node or the packages are absent, so
+this file is safe in a CI job that only installs Python.
+"""
+
+import shutil
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import (  # noqa: E402
+    ALLOWED_RUNNERS,
+    DOCKER_RUNNERS,
+    SubprocessSandbox,
+    _resolve_runner,
+)
+
+JS_RUNNERS = ("vitest", "jest")
+
+
+# ── table shape ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_runner_is_registered_in_both_tables(runner):
+    assert runner in ALLOWED_RUNNERS
+    assert runner in DOCKER_RUNNERS
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_subprocess_and_docker_commands_match(runner):
+    """A runner that behaves differently inside Docker is a debugging trap."""
+    assert ALLOWED_RUNNERS[runner] == DOCKER_RUNNERS[runner]
+
+
+def test_runner_tables_cover_the_same_names():
+    assert set(ALLOWED_RUNNERS) == set(DOCKER_RUNNERS)
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_runner_goes_through_npx(runner):
+    assert ALLOWED_RUNNERS[runner][0] == "npx"
+
+
+# ── the two decisions worth pinning ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_npx_may_not_auto_install(runner):
+    """
+    Without --no-install, npx downloads a missing package from the registry.
+    That would breach DockerSandbox's --network=none and surprise offline users.
+    """
+    assert "--no-install" in ALLOWED_RUNNERS[runner]
+    assert "--no-install" in DOCKER_RUNNERS[runner]
+
+
+def test_vitest_uses_the_run_subcommand():
+    """Bare `vitest` can start a watch server and hang until timeout_seconds."""
+    cmd = ALLOWED_RUNNERS["vitest"]
+    assert "run" in cmd
+    assert cmd.index("run") > cmd.index("vitest")
+
+
+def test_existing_runners_are_untouched():
+    assert ALLOWED_RUNNERS["pytest"] == [sys.executable, "-m", "pytest"]
+    assert ALLOWED_RUNNERS["npm_test"] == ["npm", "test", "--"]
+    assert ALLOWED_RUNNERS["go"] == ["go", "test", "./..."]
+
+
+# ── resolution ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_resolves_when_npx_is_on_path(runner, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda exe: "/usr/bin/npx")
+    assert _resolve_runner(runner) == ALLOWED_RUNNERS[runner]
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_returns_none_when_npx_is_missing(runner, monkeypatch):
+    """run_tests turns this into exit_code -3 rather than crashing."""
+    monkeypatch.setattr(shutil, "which", lambda exe: None)
+    assert _resolve_runner(runner) is None
+
+
+@pytest.mark.parametrize("runner", JS_RUNNERS)
+def test_missing_npx_yields_a_clean_failure(runner, monkeypatch, tmp_path):
+    monkeypatch.setattr(shutil, "which", lambda exe: None)
+    result = SubprocessSandbox(str(tmp_path)).run_tests(runner)
+    assert result.exit_code == -3
+    assert result.success is False
+    assert runner in result.stderr
+
+
+# ── integration (skipped when the toolchain is absent) ────────────────────
+#
+# These install the real packages once per session into a temp project. They
+# need node and network, so they skip cleanly on a Python-only CI job rather
+# than failing. Without a real install the runners can never be exercised --
+# an availability probe run inside an empty directory would always say "no".
+
+
+@pytest.fixture(scope="session")
+def js_project(tmp_path_factory):
+    """A temp project with vitest and jest installed, or a skip."""
+    if shutil.which("npm") is None:
+        pytest.skip("npm not available")
+
+    project = tmp_path_factory.mktemp("js_runners")
+    (project / "package.json").write_text('{"name":"t","private":true}')
+
+    try:
+        proc = subprocess.run(
+            ["npm", "install", "--no-audit", "--no-fund", "vitest", "jest"],
+            cwd=str(project), capture_output=True, text=True, timeout=600,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        pytest.skip(f"npm install failed: {exc}")
+
+    if proc.returncode != 0:
+        pytest.skip(f"npm install failed: {proc.stderr[-300:]}")
+
+    return project
+
+
+def _case_dir(js_project):
+    """
+    A fresh subdirectory of the installed project, so one test's failing file
+    cannot leak into another. A subdirectory rather than a symlink on purpose:
+    node resolves node_modules by walking up the tree, and symlinks need
+    Developer Mode or admin rights on Windows.
+    """
+    project = js_project / f"case_{uuid.uuid4().hex[:8]}"
+    project.mkdir()
+    return project
+
+
+@pytest.fixture
+def vitest_project(js_project):
+    project = _case_dir(js_project)
+    (project / "package.json").write_text(
+        '{"name":"c","private":true,"type":"module"}'
+    )
+    (project / "ok.test.js").write_text(
+        "import { test, expect } from 'vitest';\n"
+        "test('adds', () => { expect(1 + 1).toBe(2); });\n"
+    )
+    return project
+
+
+@pytest.fixture
+def jest_project(js_project):
+    project = _case_dir(js_project)
+    (project / "package.json").write_text('{"name":"c","private":true}')
+    (project / "ok.test.js").write_text(
+        "test('adds', () => { expect(1 + 1).toBe(2); });\n"
+    )
+    return project
+
+
+def test_vitest_passing_suite(vitest_project):
+    sandbox = SubprocessSandbox(str(vitest_project), timeout_seconds=300)
+    result = sandbox.run_tests("vitest")
+    assert result.success is True
+    assert result.timed_out is False
+
+
+def test_vitest_failing_suite_is_reported_as_failure(vitest_project):
+    (vitest_project / "bad.test.js").write_text(
+        "import { test, expect } from 'vitest';\n"
+        "test('fails', () => { expect(1).toBe(2); });\n"
+    )
+    sandbox = SubprocessSandbox(str(vitest_project), timeout_seconds=300)
+    result = sandbox.run_tests("vitest")
+    assert result.exit_code != 0
+    assert result.success is False
+    # The agent feeds this back to the LLM on the next iteration.
+    assert "fails" in (result.stdout + result.stderr)
+
+
+def test_vitest_does_not_hang_in_watch_mode(vitest_project):
+    """`run` must make vitest exit; a watch server would trip timed_out."""
+    sandbox = SubprocessSandbox(str(vitest_project), timeout_seconds=300)
+    result = sandbox.run_tests("vitest")
+    assert result.timed_out is False
+
+
+def test_jest_passing_suite(jest_project):
+    result = SubprocessSandbox(str(jest_project), timeout_seconds=300).run_tests("jest")
+    assert result.success is True
+    assert result.timed_out is False
+
+
+def test_jest_failing_suite_is_reported_as_failure(jest_project):
+    (jest_project / "bad.test.js").write_text(
+        "test('fails', () => { expect(1).toBe(2); });\n"
+    )
+    result = SubprocessSandbox(str(jest_project), timeout_seconds=300).run_tests("jest")
+    assert result.exit_code != 0
+    assert result.success is False
+    assert "fails" in (result.stdout + result.stderr)
+
+
+def test_extra_args_are_forwarded(vitest_project):
+    result = SubprocessSandbox(str(vitest_project), timeout_seconds=300).run_tests(
+        "vitest", ["--reporter=basic"]
+    )
+    assert "--reporter=basic" in result.command


### PR DESCRIPTION
Closes #53

## Summary

Adds `vitest` and `jest` to `ALLOWED_RUNNERS` and `DOCKER_RUNNERS`, so a JS/TS project can be driven with `--runner vitest` or `--runner jest` instead of going through `npm_test`.

Both go through `npx --no-install`, and vitest is invoked as `vitest run`. Both of those are load-bearing rather than stylistic — details below.

## Why `--no-install`

Plain `npx vitest` downloads the package from the registry when it is not installed locally. Inside this sandbox that is the wrong default twice over: `DockerSandbox` runs with `--network=none`, and an offline user would get a confusing hang rather than a clear error.

`--no-install` resolves the target project's own `node_modules/.bin` and refuses otherwise. Verified in a project without vitest installed:

```
npm error npx canceled due to missing packages and no YES option: ["vitest@4.1.10"]
```

No `node_modules` directory was created, i.e. nothing was fetched.

## Why `vitest run` rather than `vitest`

Bare `vitest` starts a watch server when it believes it is interactive. Under this sandbox that process never exits, so `subprocess.run(timeout=...)` fires and the run is reported as `timed_out=True` — the agent would read a working suite as a test timeout and start retrying against correct code. The `run` subcommand removes the dependency on TTY detection entirely.

`jest` needs no equivalent flag; it is single-run by default.

## On "output parsing"

The issue mentions configuring output parsing. There is no output-parsing layer in `sandbox.py` for any of the twelve runners — `ExecutionResult` captures `stdout`, `stderr` and `exit_code`, and the agent loop keys entirely off:

```python
success = self.exit_code == 0 and not self.timed_out
```

So adding a parser for only these two would be inconsistent with the rest. What I verified instead is that both runners honour that contract, since that is what the loop actually depends on. Through `SubprocessSandbox.run_tests`:

| runner | passing suite | failing suite |
| ------ | ------------- | ------------- |
| vitest | `exit=0 success=True` | `exit=1 success=False` |
| jest   | `exit=0 success=True` | `exit=1 success=False` |

Failure text also reaches `stdout`/`stderr`, which matters because that is what gets fed back to the LLM on the next iteration.

Happy to add structured parsing as a separate change if you want it, but it would make sense to do it for every runner at once rather than two of them.

## Verified

Ran with node v22.22.2 / npm 10.9.7, against real installed packages rather than mocks:

- `_resolve_runner("vitest")` → `['npx', '--no-install', 'vitest', 'run']`; same for jest; `shutil.which("npx")` gate works
- both runners executed through `SubprocessSandbox.run_tests()` on passing and failing suites — table above
- `--no-install` confirmed to refuse rather than download
- `extra_args` forwarded: `npx --no-install vitest run --reporter=json`
- 23 tests pass, no skips
- ruff on `modules/sandbox.py`: 3 findings before and after, i.e. none added; `npx prettier --check README.md` clean

Cross-checked against the open PR for #47 (env allowlist), since that touches the same file: the two auto-merge with no conflict, and both runners still pass under the allowlisted environment — `npx` needs only `PATH`, `HOME` and `npm_config_cache`, all of which are on it.

## Tests

`tests/test_js_runners.py` — 23 cases, split into table assertions that always run and integration tests that need the toolchain.

Table-level: both runners registered in `ALLOWED_RUNNERS` and `DOCKER_RUNNERS`; the two tables agree on every runner's command (a runner that behaves differently inside Docker is a debugging trap) and cover the same names; `--no-install` present in both entries; `vitest` has `run` positioned after the binary; existing runner entries unchanged; `_resolve_runner` returns the command when npx is on PATH and `None` when it is not; a missing npx produces `exit_code -3` rather than an exception.

Integration: a session fixture installs vitest and jest once into a temp project, then each test gets a fresh subdirectory of it. Passing and failing suites for both runners, an explicit assertion that vitest does not trip `timed_out`, and `extra_args` forwarding.

Two notes on how those are built, since both were mistakes I made first:

- The fixture does a real `npm install` and skips cleanly if npm is missing or the install fails. An earlier version probed availability with `npx --no-install` inside an empty directory, which by construction always answers "no" — the tests reported as passing while never running.
- Per-test isolation uses a subdirectory rather than a symlink to shared `node_modules`. Node resolves `node_modules` by walking up the tree, so a subdirectory works, and symlinks need Developer Mode or admin rights on Windows.

## Scope

`DOCKER_RUNNERS` gets the same entries for parity, but the default image is `python:3.11-slim`, which has no node — running these under Docker means passing a node-based `--image`. That is pre-existing behaviour for the `node`/`npm_test` entries too, not something this PR changes.

## Not touched, noticed while working

Both pre-existing on `main`:

- `python -m pytest` from the repo root fails collection outright — three files share the basename `test_utils.py` (`tests/`, `modules/`, `sample_repo/`) with no `__init__.py` and no pytest config. Targeted paths work; the new test file uses a unique basename.
- `npm run format:check` is already failing for `.github/workflows/agent-fix.yml`, `.github/workflows/prettier.yml` and `ARCHITECTURE.md`.