### PR TITLE
fix(sandbox): make Docker fallback loud and auditable — Closes #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,28 @@ return MAX_RETRIES
 
 ---
 
+### Knowing whether a run was isolated
+
+`DockerSandbox` falls back to `SubprocessSandbox` when Docker is unavailable,
+which means `--network=none`, the 512MB memory cap and the 1-CPU limit **do not
+apply to that run**. The fallback logs a warning when it happens, and every
+`ExecutionResult` records which executor produced it — `docker` (with
+`result.isolated` set), `subprocess`, or `subprocess-fallback` for the case
+where isolation was asked for and quietly not delivered.
+
+Pass `strict=True` to make that a hard failure instead:
+
+```python
+DockerSandbox(repo, strict=True).run_tests("pytest")
+# raises SandboxUnavailableError rather than running unisolated
+```
+
+"Unavailable" means either no `docker` on PATH or no daemon answering — an
+installed-but-not-running Docker Desktop is the common case, and it leaves the
+binary on PATH.
+
+---
+
 ## Extending the System
 
 **Add a new test runner:**

--- a/modules/logger.py
+++ b/modules/logger.py
@@ -146,8 +146,17 @@ class AgentLogger:
 
     def log_execution(self, exec_result):
         status = "PASS" if exec_result.success else ("TIMEOUT" if exec_result.timed_out else "FAIL")
-        self._logger.info(f"  {status} | exit={exec_result.exit_code} | {exec_result.duration_seconds:.1f}s")
+        sandbox = getattr(exec_result, "sandbox", "unknown")
+        self._logger.info(
+            f"  {status} | exit={exec_result.exit_code} | "
+            f"{exec_result.duration_seconds:.1f}s | sandbox={sandbox}"
+        )
         self._logger.info(f"     cmd: {exec_result.command}")
+        if sandbox == "subprocess-fallback":
+            self._logger.warning(
+                "     This run was NOT isolated - Docker was unavailable and the "
+                "command ran directly on the host."
+            )
         if exec_result.stdout.strip():
             self._logger.debug(f"     stdout:\n{exec_result.stdout[:1000]}")
         if exec_result.stderr.strip():

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -8,6 +8,7 @@ Runs code in isolation using subprocess with:
 - Optional Docker support
 """
 
+import logging
 import os
 import shlex
 import shutil
@@ -15,6 +16,24 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Optional
+
+_LOG = logging.getLogger("agent.sandbox")
+
+# Which executor actually ran a command. Recorded on every ExecutionResult so a
+# run log can be audited after the fact -- without this, a run that silently
+# lost its isolation is indistinguishable from one that kept it.
+SANDBOX_DOCKER = "docker"
+SANDBOX_SUBPROCESS = "subprocess"
+SANDBOX_SUBPROCESS_FALLBACK = "subprocess-fallback"
+
+
+class SandboxUnavailableError(RuntimeError):
+    """
+    Raised when DockerSandbox(strict=True) cannot provide isolation.
+
+    Degrading to an unisolated executor is a reasonable default for interactive
+    use and a bad one for CI, so strict mode turns it into a hard failure.
+    """
 
 
 @dataclass
@@ -25,15 +44,22 @@ class ExecutionResult:
     stderr: str
     timed_out: bool
     duration_seconds: float
+    sandbox: str = SANDBOX_SUBPROCESS
 
     @property
     def success(self) -> bool:
         return self.exit_code == 0 and not self.timed_out
 
+    @property
+    def isolated(self) -> bool:
+        """True only when the command actually ran inside a container."""
+        return self.sandbox == SANDBOX_DOCKER
+
     def summary(self) -> str:
         status = "PASS" if self.success else ("TIMEOUT" if self.timed_out else "FAIL")
         lines = [
-            f"{status} | exit={self.exit_code} | {self.duration_seconds:.2f}s",
+            f"{status} | exit={self.exit_code} | {self.duration_seconds:.2f}s "
+            f"| sandbox={self.sandbox}",
             f"  cmd: {self.command}",
         ]
         if self.stdout.strip():
@@ -94,6 +120,30 @@ def _resolve_runner(runner_name: str) -> Optional[list[str]]:
     if shutil.which(executable):
         return candidates
     return None
+
+
+def _docker_is_usable(probe_timeout: int = 15) -> bool:
+    """
+    True only if the docker CLI exists *and* a daemon answers it.
+
+    `shutil.which("docker")` alone is not enough. Docker Desktop installed but
+    not running is the common case on developer laptops, and it leaves the
+    binary on PATH. `docker run` then exits non-zero with "Cannot connect to the
+    Docker daemon", which is indistinguishable from a failing test suite once it
+    is wrapped in an ExecutionResult -- the agent reads it as a test failure and
+    starts rewriting working code.
+    """
+    if shutil.which("docker") is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True,
+            timeout=probe_timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
 
 
 def _coerce_output(value) -> str:
@@ -231,16 +281,34 @@ class DockerSandbox:
         working_dir: str,
         image: str = "python:3.11-slim",
         timeout_seconds: int = 120,
+        strict: bool = False,
     ):
+        """
+        `strict=True` raises SandboxUnavailableError instead of falling back to
+        an unisolated executor. Use it in CI, where losing isolation should stop
+        the run rather than quietly change what the guarantees are.
+        """
         self.working_dir = os.path.abspath(working_dir)
         self.image = image
         self.timeout = timeout_seconds
-        self._docker_available = shutil.which("docker") is not None
+        self.strict = strict
+        self._docker_available = _docker_is_usable()
 
     def run_tests(self, runner: str = "pytest", extra_args: Optional[list[str]] = None) -> ExecutionResult:
         if not self._docker_available:
+            reason = (
+                "Docker is unavailable (no CLI on PATH, or no daemon answering). "
+                "Network isolation, the 512MB memory cap and the 1-CPU limit are "
+                "NOT in effect."
+            )
+            if self.strict:
+                raise SandboxUnavailableError(reason)
+
+            _LOG.warning("DockerSandbox: %s Falling back to SubprocessSandbox.", reason)
             sb = SubprocessSandbox(self.working_dir, self.timeout)
-            return sb.run_tests(runner, extra_args)
+            result = sb.run_tests(runner, extra_args)
+            result.sandbox = SANDBOX_SUBPROCESS_FALLBACK
+            return result
 
         runner_cmd = DOCKER_RUNNERS.get(runner) or ["python", "-m", "pytest"]
         inner_cmd = runner_cmd + (extra_args or [])
@@ -257,4 +325,6 @@ class DockerSandbox:
         ]
 
         sb = SubprocessSandbox(self.working_dir, self.timeout)
-        return sb.run(docker_cmd)
+        result = sb.run(docker_cmd)
+        result.sandbox = SANDBOX_DOCKER
+        return result

--- a/tests/test_sandbox_fallback.py
+++ b/tests/test_sandbox_fallback.py
@@ -1,0 +1,192 @@
+"""
+Tests for DockerSandbox fallback visibility (modules/sandbox.py).
+
+DockerSandbox exists to provide `--network=none`, a memory cap and a CPU cap.
+When it cannot, the caller has to be able to tell — at the time, via a warning
+or a raise, and afterwards, from the recorded result.
+
+No test here needs a real Docker daemon; availability is monkeypatched.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import sandbox as sandbox_mod  # noqa: E402
+from modules.sandbox import (  # noqa: E402
+    SANDBOX_DOCKER,
+    SANDBOX_SUBPROCESS,
+    SANDBOX_SUBPROCESS_FALLBACK,
+    DockerSandbox,
+    ExecutionResult,
+    SandboxUnavailableError,
+    SubprocessSandbox,
+    _docker_is_usable,
+)
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "test_ok.py").write_text("def test_ok():\n    assert True\n")
+    return tmp_path
+
+
+@pytest.fixture
+def no_docker(monkeypatch):
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: False)
+
+
+@pytest.fixture
+def with_docker(monkeypatch):
+    """Docker reports usable; the CLI call itself is stubbed out."""
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
+
+    def fake_run(self, command, env=None, stdin_data=None):
+        return ExecutionResult(
+            command=" ".join(command), exit_code=0, stdout="", stderr="",
+            timed_out=False, duration_seconds=0.0,
+        )
+
+    monkeypatch.setattr(SubprocessSandbox, "run", fake_run)
+
+
+# ── provenance is recorded ────────────────────────────────────────────────
+
+
+def test_subprocess_runs_are_labelled(project):
+    result = SubprocessSandbox(str(project)).run_tests("pytest")
+    assert result.sandbox == SANDBOX_SUBPROCESS
+    assert result.isolated is False
+
+
+def test_container_runs_are_labelled(project, with_docker):
+    result = DockerSandbox(str(project)).run_tests("pytest")
+    assert result.sandbox == SANDBOX_DOCKER
+    assert result.isolated is True
+
+
+def test_fallback_runs_are_labelled_distinctly(project, no_docker):
+    """
+    Distinct from plain "subprocess": the caller asked for isolation and did
+    not get it, which is not the same as never having asked.
+    """
+    result = DockerSandbox(str(project)).run_tests("pytest")
+    assert result.sandbox == SANDBOX_SUBPROCESS_FALLBACK
+    assert result.isolated is False
+
+
+def test_only_docker_counts_as_isolated():
+    for kind in (SANDBOX_SUBPROCESS, SANDBOX_SUBPROCESS_FALLBACK):
+        result = ExecutionResult("c", 0, "", "", False, 0.0, sandbox=kind)
+        assert result.isolated is False
+
+
+def test_sandbox_appears_in_summary(project, no_docker):
+    result = DockerSandbox(str(project)).run_tests("pytest")
+    assert f"sandbox={SANDBOX_SUBPROCESS_FALLBACK}" in result.summary()
+
+
+def test_sandbox_field_defaults_for_positional_construction():
+    """Existing callers that build ExecutionResult positionally still work."""
+    result = ExecutionResult("cmd", 0, "out", "err", False, 1.0)
+    assert result.sandbox == SANDBOX_SUBPROCESS
+
+
+# ── the fallback is loud ──────────────────────────────────────────────────
+
+
+def test_fallback_logs_a_warning(project, no_docker, caplog):
+    with caplog.at_level("WARNING", logger="agent.sandbox"):
+        DockerSandbox(str(project)).run_tests("pytest")
+
+    assert any(r.levelname == "WARNING" for r in caplog.records)
+    text = caplog.text
+    assert "Docker is unavailable" in text
+    # The warning must say what was lost, not just that something changed.
+    assert "isolation" in text
+    assert "NOT in effect" in text
+
+
+def test_no_warning_when_docker_is_used(project, with_docker, caplog):
+    with caplog.at_level("WARNING", logger="agent.sandbox"):
+        DockerSandbox(str(project)).run_tests("pytest")
+    assert caplog.records == []
+
+
+def test_fallback_still_runs_the_tests(project, no_docker):
+    """Degrading loudly must not mean degrading into a broken run."""
+    result = DockerSandbox(str(project)).run_tests("pytest")
+    assert result.success is True
+
+
+# ── strict mode ───────────────────────────────────────────────────────────
+
+
+def test_strict_raises_instead_of_degrading(project, no_docker):
+    with pytest.raises(SandboxUnavailableError) as excinfo:
+        DockerSandbox(str(project), strict=True).run_tests("pytest")
+    assert "NOT in effect" in str(excinfo.value)
+
+
+def test_strict_is_off_by_default(project, no_docker):
+    result = DockerSandbox(str(project)).run_tests("pytest")
+    assert result.sandbox == SANDBOX_SUBPROCESS_FALLBACK
+
+
+def test_strict_does_not_raise_when_docker_works(project, with_docker):
+    result = DockerSandbox(str(project), strict=True).run_tests("pytest")
+    assert result.sandbox == SANDBOX_DOCKER
+
+
+def test_error_type_is_catchable_as_runtime_error():
+    assert issubclass(SandboxUnavailableError, RuntimeError)
+
+
+# ── the availability probe ────────────────────────────────────────────────
+
+
+def test_probe_false_when_cli_is_absent(monkeypatch):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: None)
+    assert _docker_is_usable() is False
+
+
+def test_probe_false_when_daemon_does_not_answer(monkeypatch):
+    """
+    The important case: Docker Desktop installed but not running leaves the
+    binary on PATH. Before this change that counted as available, and the
+    daemon error came back as a non-zero exit that looked like a test failure.
+    """
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+
+    def fake_run(*a, **k):
+        return subprocess.CompletedProcess(a, returncode=1, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+    assert _docker_is_usable() is False
+
+
+def test_probe_true_when_daemon_answers(monkeypatch):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+
+    def fake_run(*a, **k):
+        return subprocess.CompletedProcess(
+            a, returncode=0, stdout=b"24.0.7", stderr=b""
+        )
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+    assert _docker_is_usable() is True
+
+
+@pytest.mark.parametrize("exc", [OSError, subprocess.TimeoutExpired("docker", 1)])
+def test_probe_survives_a_hanging_or_broken_cli(monkeypatch, exc):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+
+    def fake_run(*a, **k):
+        raise exc if isinstance(exc, Exception) else exc()
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+    assert _docker_is_usable() is False


### PR DESCRIPTION
Closes #49

## Summary

`DockerSandbox.run_tests` delegated to `SubprocessSandbox` with no warning when Docker was unavailable. A caller who explicitly chose the isolated executor got no isolation and no indication anything had changed.

This makes the fallback loud, adds a `strict` mode that refuses to degrade, and records which executor actually ran on every `ExecutionResult`.

## The availability check was wrong in the other direction too

While reproducing this I found a second failure mode that is worse than the one filed.

`shutil.which("docker")` only checks the CLI is on PATH. It says nothing about whether a daemon is answering. Docker Desktop installed but not running — the ordinary state of a laptop that has not started it today — leaves the binary on PATH, so `_docker_available` was `True` and **no fallback happened at all**. `docker run` then failed, and the failure was wrapped in an `ExecutionResult` like any other command result.

Reproduced with a stub `docker` on PATH that exits non-zero with the daemon error:

```
_docker_available -> True   (binary exists, daemon is DOWN)
exit_code : 1
success   : False
stderr    : Cannot connect to the Docker daemon at unix:///var/run/docker.sock...
```

`exit_code=1, success=False` is exactly what a failing test suite looks like. The agent reads it as a test failure, feeds "Cannot connect to the Docker daemon" back to the LLM as build output, and starts rewriting code that was never broken.

So `_docker_is_usable()` now probes the daemon as well:

```python
docker version --format {{.Server.Version}}
```

Same stub after the change: `exit_code=0, success=True, sandbox=subprocess-fallback`, with a warning. The infrastructure problem is reported as an infrastructure problem.

## What changed

**The fallback is loud.** A WARNING naming what was lost, not just that something changed:

```
DockerSandbox: Docker is unavailable (no CLI on PATH, or no daemon answering).
Network isolation, the 512MB memory cap and the 1-CPU limit are NOT in effect.
Falling back to SubprocessSandbox.
```

**It is auditable afterwards.** `ExecutionResult` gains a `sandbox` field — `docker`, `subprocess`, or `subprocess-fallback` — plus an `isolated` property. The three values are deliberately distinct: `subprocess-fallback` means isolation was requested and not delivered, which is not the same as never having asked for it. It appears in `summary()` and in `log_execution`, which emits an extra WARNING line for a fallback run so a past run log shows it.

**Strict mode.** `DockerSandbox(..., strict=True)` raises `SandboxUnavailableError` instead of degrading. Default is `False`, so existing behaviour is unchanged for interactive use while CI can pin the guarantee.

## Trade-offs worth flagging

**Construction now shells out.** `_docker_is_usable()` runs `docker version` once per `DockerSandbox` instance, where the old check was a cheap `shutil.which`. That is the cost of the check being correct. It short-circuits with no subprocess when the binary is absent, and the probe has a 15s timeout with `OSError`/`TimeoutExpired` handled as "not usable". If per-instance cost matters somewhere, caching would be easy to add.

**Full JSONL wiring is deliberately not here.** Surfacing `sandbox` in the structured per-iteration record means adding a field to `IterationRecord` and setting it in `agent_loop.py` — and `agent_loop.py` has an open PR (#51). The human-readable run log covers the issue's "distinguishes an isolated run from an unisolated one after the fact", and `ExecutionResult` carries the data for anyone consuming it programmatically. Happy to do the JSONL half as a follow-up once #51 lands.

**`DockerSandbox` is not wired to anything.** `agent_loop.py:103` constructs `SubprocessSandbox` unconditionally and there is no CLI flag to select Docker, so nothing in this repo builds a `DockerSandbox` today. That makes the change low-risk, but it also means the README documents a sandbox the CLI cannot reach. Not something I touched here — flagging it in case it should be its own issue.

## Tests

`tests/test_sandbox_fallback.py` — 18 cases. No real daemon required; availability is monkeypatched.

Provenance: subprocess, container and fallback runs each labelled correctly; only `docker` counts as `isolated`; the label reaches `summary()`; positional `ExecutionResult(...)` construction still works, so the new field does not break existing call sites.

Loudness: a fallback logs a WARNING that names both "isolation" and "NOT in effect"; a successful Docker run logs nothing; and the fallback still actually runs the tests — degrading loudly must not mean degrading into a broken run.

Strict mode: raises when Docker is unavailable, off by default, does not raise when Docker works, and `SandboxUnavailableError` subclasses `RuntimeError` so it is catchable without importing the type.

The probe: false with no CLI; false when the daemon does not answer (the case above); true when it does; and false rather than propagating when the CLI raises `OSError` or times out.

## Verified

- both stub-daemon scenarios above, before and after
- healthy-daemon path still tags `sandbox=docker`, `isolated=True`, and logs no warning
- `log_execution` output checked for docker, fallback, and a legacy result with no `sandbox` attribute (falls back to `unknown` via `getattr`)
- existing sandbox paths unaffected: `run_tests`, unknown runner (`-3`), `run_file`, and timeout (`-1`, `timed_out=True`) all behave as before and label as `subprocess`
- 18 new tests pass; `tests/test_utils.py` still 4 passed
- ruff on `modules/sandbox.py` and `modules/logger.py`: same finding count before and after; `npx prettier --check README.md` clean

Not verified: no Docker daemon was available in the environment I built this in, so the container path is exercised against a stub rather than a real `docker run`. The stub covers the branch logic and the labelling; it does not prove a real container starts. Called out rather than implied.

## Note if #47 merges first

The open PR for #47 also adds `_LOG = logging.getLogger("agent.sandbox")` to `modules/sandbox.py`, in a different part of the file. The two branches auto-merge with no conflict and all 83 tests pass on the merged tree, but the result has the line twice. Same logger object, so it is harmless — whichever lands second should just drop the duplicate during rebase.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.