### PR TITLE
fix(sandbox): drop capabilities and run containers as the invoking user — Closes #48

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,38 @@ return MAX_RETRIES
 
 ---
 
+## Container Hardening
+
+`DockerSandbox` runs each container with `--cap-drop ALL`,
+`--security-opt no-new-privileges`, a `--pids-limit` (256 by default) and, on
+POSIX hosts, `--user $(id -u):$(id -g)`.
+
+`--user` matters beyond privilege reduction: the workspace is a read-write bind
+mount, and bind mounts preserve UIDs, so a root container leaves root-owned
+files inside the user's own project. It is omitted on Windows and macOS, where
+`os.getuid` does not exist and Docker Desktop maps bind-mount ownership itself.
+
+Because `--user` leaves the process without a passwd entry, the container also
+gets a `--tmpfs /tmp` with `HOME` pointing at it — otherwise pytest's cache,
+npm and go all fail on an unwritable home.
+
+```python
+DockerSandbox(repo, pids_limit=1024)   # parallel runners on a large machine
+DockerSandbox(repo, read_only=True)    # read-only root filesystem
+```
+
+`read_only` is off by default: it breaks any runner that writes outside
+`/workspace` and `/tmp`. The workspace mount itself stays read-write, which is
+deliberate — plenty of suites create fixtures beside their tests.
+
+To check the flags against a real daemon rather than trusting the argv:
+
+```bash
+python scripts/verify_docker_sandbox.py
+```
+
+---
+
 ## Failure Cases & Mitigations
 
 | Failure                      | Cause                               | Mitigation                                                     |

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -220,6 +220,28 @@ class SubprocessSandbox:
         return self.run(cmd + [abs_path])
 
 
+def _docker_user_flags() -> list[str]:
+    """
+    Run the container as the invoking user, on platforms where that means
+    something.
+
+    Without --user the container runs as root over a read-write bind mount of
+    the user's repository. Bind mounts preserve UIDs, so anything the executed
+    code creates lands on the host owned by root -- files inside someone's own
+    project that they cannot edit or delete without sudo.
+
+    os.getuid/os.getgid do not exist on Windows, so the flag is omitted there.
+    That is not a gap being papered over: Docker Desktop on Windows and macOS
+    maps bind-mount ownership itself, so there is no host UID for the container
+    to match and passing one can break the mount instead of securing it.
+    """
+    getuid = getattr(os, "getuid", None)
+    getgid = getattr(os, "getgid", None)
+    if getuid is None or getgid is None:
+        return []
+    return ["--user", f"{getuid()}:{getgid()}"]
+
+
 class DockerSandbox:
     """
     Docker-based sandbox for untrusted code.
@@ -231,11 +253,63 @@ class DockerSandbox:
         working_dir: str,
         image: str = "python:3.11-slim",
         timeout_seconds: int = 120,
+        pids_limit: int = 256,
+        read_only: bool = False,
     ):
+        """
+        `pids_limit` caps process creation; a fork bomb is otherwise bounded
+        only by the memory limit. Raise it for parallel runners that spawn a
+        worker per core (pytest-xdist, jest) on a large machine.
+
+        `read_only` makes the container filesystem read-only apart from the
+        workspace mount and /tmp. Off by default because it breaks any runner
+        that writes outside those paths; see the note in the README.
+        """
         self.working_dir = os.path.abspath(working_dir)
         self.image = image
         self.timeout = timeout_seconds
+        self.pids_limit = pids_limit
+        self.read_only = read_only
         self._docker_available = shutil.which("docker") is not None
+
+    def _build_docker_command(self, inner_cmd: list[str]) -> list[str]:
+        """
+        Assemble the `docker run` argv.
+
+        Split out from run_tests so the flag set can be asserted on directly --
+        a security control that is only exercised when a daemon happens to be
+        present is a control nobody checks.
+        """
+        cmd = [
+            "docker", "run", "--rm",
+            "--network=none",
+            "--memory=512m",
+            "--cpus=1",
+            # Drop everything the container does not need. A test runner needs
+            # no Linux capabilities, and no-new-privileges stops a setuid binary
+            # inside the image from regaining any.
+            "--cap-drop", "ALL",
+            "--security-opt", "no-new-privileges",
+            f"--pids-limit={self.pids_limit}",
+        ]
+        cmd += _docker_user_flags()
+
+        if self.read_only:
+            cmd.append("--read-only")
+
+        # --user leaves the process without a passwd entry, so HOME is unset and
+        # anything that wants a writable home -- pytest's cache, npm, go's build
+        # cache -- fails in confusing ways. A tmpfs at /tmp plus HOME pointing at
+        # it restores that without granting any access to the host.
+        cmd += [
+            "--tmpfs", "/tmp:rw,nosuid,nodev,size=256m",
+            "-e", "HOME=/tmp",
+            "-v", f"{self.working_dir}:/workspace:rw",
+            "-w", "/workspace",
+            self.image,
+            "sh", "-c", shlex.join(inner_cmd),
+        ]
+        return cmd
 
     def run_tests(self, runner: str = "pytest", extra_args: Optional[list[str]] = None) -> ExecutionResult:
         if not self._docker_available:
@@ -244,17 +318,7 @@ class DockerSandbox:
 
         runner_cmd = DOCKER_RUNNERS.get(runner) or ["python", "-m", "pytest"]
         inner_cmd = runner_cmd + (extra_args or [])
-
-        docker_cmd = [
-            "docker", "run", "--rm",
-            "--network=none",
-            "--memory=512m",
-            "--cpus=1",
-            "-v", f"{self.working_dir}:/workspace:rw",
-            "-w", "/workspace",
-            self.image,
-            "sh", "-c", shlex.join(inner_cmd),
-        ]
+        docker_cmd = self._build_docker_command(inner_cmd)
 
         sb = SubprocessSandbox(self.working_dir, self.timeout)
         return sb.run(docker_cmd)

--- a/scripts/verify_docker_sandbox.py
+++ b/scripts/verify_docker_sandbox.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Verify DockerSandbox hardening against a real Docker daemon.
+
+tests/test_docker_hardening.py asserts the `docker run` argv without needing a
+daemon. That proves the flags are passed; it cannot prove a container still
+runs correctly with them applied. This script closes that gap.
+
+    python scripts/verify_docker_sandbox.py
+
+Exits 0 if every check passes, 1 otherwise. Skips cleanly if Docker is absent.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import DockerSandbox  # noqa: E402
+
+IMAGE = os.environ.get("REPOPILOT_VERIFY_IMAGE", "python:3.11-slim")
+
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, passed: bool, detail: str = "") -> None:
+    results.append((name, passed, detail))
+    print(f"  {'PASS' if passed else 'FAIL'}  {name}")
+    if detail:
+        print(f"        {detail}")
+
+
+def docker_ready() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True, timeout=30,
+        )
+        return proc.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def make_project(tmp: Path) -> Path:
+    """A suite that exercises the workspace mount and the tmpfs home."""
+    project = tmp / "proj"
+    project.mkdir()
+    (project / "test_sandbox_env.py").write_text(
+        "import os\n"
+        "\n"
+        "def test_can_write_to_workspace():\n"
+        "    with open('artifact.txt', 'w') as fh:\n"
+        "        fh.write('written from inside the container')\n"
+        "\n"
+        "def test_home_is_writable():\n"
+        "    home = os.environ.get('HOME')\n"
+        "    assert home, 'HOME is unset -- --user has no passwd entry'\n"
+        "    path = os.path.join(home, 'probe')\n"
+        "    with open(path, 'w') as fh:\n"
+        "        fh.write('ok')\n"
+        "\n"
+        "def test_network_is_off():\n"
+        "    import socket\n"
+        "    try:\n"
+        "        socket.create_connection(('1.1.1.1', 53), timeout=3)\n"
+        "    except OSError:\n"
+        "        return\n"
+        "    raise AssertionError('network reachable -- --network=none not applied')\n"
+    )
+    return project
+
+
+def main() -> int:
+    print(f"Verifying DockerSandbox hardening (image: {IMAGE})\n")
+
+    if not docker_ready():
+        print("  SKIP  Docker CLI or daemon unavailable - nothing verified.")
+        return 0
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        project = make_project(tmp)
+
+        sandbox = DockerSandbox(str(project), image=IMAGE, timeout_seconds=300)
+
+        argv = sandbox._build_docker_command(["python", "-m", "pytest", "-q"])
+        print("  argv:", " ".join(argv), "\n")
+
+        result = sandbox.run_tests("pytest", ["-q"])
+
+        check(
+            "suite passes with all hardening flags applied",
+            result.success,
+            "" if result.success else (result.stdout + result.stderr)[-1500:],
+        )
+        check(
+            "run did not hit the timeout",
+            not result.timed_out,
+        )
+
+        artifact = project / "artifact.txt"
+        check(
+            "container could write into the workspace mount",
+            artifact.exists(),
+            "" if artifact.exists() else "artifact.txt was not created",
+        )
+
+        # The point of --user: files must not come back owned by root.
+        if artifact.exists() and hasattr(os, "getuid"):
+            owner = artifact.stat().st_uid
+            check(
+                "workspace files are owned by the invoking user, not root",
+                owner == os.getuid(),
+                f"owner uid={owner}, invoking uid={os.getuid()}",
+            )
+        elif not hasattr(os, "getuid"):
+            print("  SKIP  ownership check (no getuid on this platform)")
+
+        # Opt-in read-only root filesystem.
+        ro = DockerSandbox(
+            str(project), image=IMAGE, timeout_seconds=300, read_only=True
+        )
+        ro_result = ro.run_tests("pytest", ["-q"])
+        check(
+            "read_only=True still runs the suite",
+            ro_result.success,
+            "" if ro_result.success
+            else "read_only is opt-in; a failure here is informational, "
+                 "not a regression: " + (ro_result.stdout + ro_result.stderr)[-800:],
+        )
+
+    print()
+    failed = [name for name, ok, _ in results if not ok]
+    if failed:
+        print(f"{len(failed)} check(s) failed: {', '.join(failed)}")
+        return 1
+    print(f"All {len(results)} checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_docker_hardening.py
+++ b/tests/test_docker_hardening.py
@@ -1,0 +1,161 @@
+"""
+Tests for DockerSandbox container hardening (modules/sandbox.py).
+
+The `docker run` argv is assembled by `_build_docker_command`, which is split
+out from `run_tests` precisely so these can run without a daemon. A security
+control that is only exercised when Docker happens to be installed is a control
+nobody checks.
+
+These assert the flag set. They do not prove a real container starts — that
+needs Docker, and `scripts/verify_docker_sandbox.py` covers it.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import DockerSandbox, _docker_user_flags  # noqa: E402
+
+
+@pytest.fixture
+def cmd(tmp_path):
+    sandbox = DockerSandbox(str(tmp_path))
+    return sandbox._build_docker_command(["python", "-m", "pytest"])
+
+
+def _flag_value(argv, flag):
+    """Value following a space-separated flag, or None."""
+    return argv[argv.index(flag) + 1] if flag in argv else None
+
+
+# ── the controls the issue asked for ──────────────────────────────────────
+
+
+def test_all_capabilities_are_dropped(cmd):
+    assert _flag_value(cmd, "--cap-drop") == "ALL"
+
+
+def test_no_new_privileges_is_set(cmd):
+    """Stops a setuid binary inside the image regaining what --cap-drop removed."""
+    assert _flag_value(cmd, "--security-opt") == "no-new-privileges"
+
+
+def test_pids_are_limited(cmd):
+    """Without this a fork bomb is bounded only by the memory cap."""
+    assert "--pids-limit=256" in cmd
+
+
+def test_pids_limit_is_configurable(tmp_path):
+    argv = DockerSandbox(str(tmp_path), pids_limit=1024)._build_docker_command(["x"])
+    assert "--pids-limit=1024" in argv
+    assert "--pids-limit=256" not in argv
+
+
+# ── --user and its platform guard ─────────────────────────────────────────
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX only")
+def test_runs_as_the_invoking_user_on_posix(cmd):
+    assert _flag_value(cmd, "--user") == f"{os.getuid()}:{os.getgid()}"
+
+
+def test_user_flag_is_omitted_when_getuid_is_unavailable(monkeypatch):
+    """
+    os.getuid does not exist on Windows. Referencing it unconditionally would
+    raise AttributeError before Docker was ever invoked.
+    """
+    monkeypatch.delattr(os, "getuid", raising=False)
+    monkeypatch.delattr(os, "getgid", raising=False)
+    assert _docker_user_flags() == []
+
+
+def test_command_still_builds_without_getuid(monkeypatch, tmp_path):
+    monkeypatch.delattr(os, "getuid", raising=False)
+    monkeypatch.delattr(os, "getgid", raising=False)
+
+    sandbox = DockerSandbox(str(tmp_path))
+    argv = sandbox._build_docker_command(["python", "-m", "pytest"])
+    assert argv[0] == "docker"
+    assert "--user" not in argv
+    # Everything that is not UID-dependent must still be applied.
+    assert "--cap-drop" in argv
+    assert "no-new-privileges" in argv
+    assert "--pids-limit=256" in argv
+
+
+def test_user_flag_uses_uid_gid_form(monkeypatch):
+    monkeypatch.setattr(os, "getuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(os, "getgid", lambda: 1001, raising=False)
+    assert _docker_user_flags() == ["--user", "1000:1001"]
+
+
+# ── compensating controls for --user ──────────────────────────────────────
+
+
+def test_tmp_is_writable(cmd):
+    """
+    --user leaves no passwd entry, so HOME is unset and pytest's cache, npm and
+    go all fail on a read-only home. A tmpfs restores that without host access.
+    """
+    tmpfs = _flag_value(cmd, "--tmpfs")
+    assert tmpfs is not None
+    assert tmpfs.startswith("/tmp:")
+    assert "nosuid" in tmpfs
+    assert "nodev" in tmpfs
+
+
+def test_home_points_at_the_tmpfs(cmd):
+    assert "HOME=/tmp" in cmd
+
+
+# ── read-only root filesystem (opt-in) ────────────────────────────────────
+
+
+def test_read_only_is_off_by_default(cmd):
+    """It breaks any runner writing outside /workspace and /tmp."""
+    assert "--read-only" not in cmd
+
+
+def test_read_only_can_be_enabled(tmp_path):
+    argv = DockerSandbox(str(tmp_path), read_only=True)._build_docker_command(["x"])
+    assert "--read-only" in argv
+
+
+# ── existing guarantees must survive ──────────────────────────────────────
+
+
+def test_existing_isolation_flags_are_preserved(cmd):
+    assert "--network=none" in cmd
+    assert "--memory=512m" in cmd
+    assert "--cpus=1" in cmd
+    assert "--rm" in cmd
+
+
+def test_workspace_stays_writable(cmd, tmp_path):
+    """Made rw in #8 so tests can create fixtures; that is not reverted here."""
+    assert f"{os.path.abspath(str(tmp_path))}:/workspace:rw" in cmd
+    assert _flag_value(cmd, "-w") == "/workspace"
+
+
+def test_inner_command_is_not_string_interpolated(tmp_path):
+    """shlex.join, so a path with spaces or quotes cannot break out of sh -c."""
+    argv = DockerSandbox(str(tmp_path))._build_docker_command(
+        ["pytest", "-k", "weird name'; rm -rf /"]
+    )
+    assert argv[-2] == "-c"
+    assert "'weird name'\"'\"'; rm -rf /'" in argv[-1]
+
+
+def test_image_precedes_the_inner_command(cmd):
+    """Flags after the image name are passed to the container, not to docker."""
+    assert cmd.index("python:3.11-slim") < cmd.index("sh")
+
+
+def test_custom_image_is_honoured(tmp_path):
+    sandbox = DockerSandbox(str(tmp_path), image="node:20-slim")
+    argv = sandbox._build_docker_command(["x"])
+    assert "node:20-slim" in argv


### PR DESCRIPTION
Closes #48

## Summary

`DockerSandbox.run_tests` started containers with no `--user`, so LLM-generated code ran as root over a read-write bind mount of the user's repository, with the full default capability set and no PID limit.

This adds `--user` (platform-guarded), `--cap-drop ALL`, `--security-opt no-new-privileges` and `--pids-limit`, plus the compensating controls those need.

Resulting argv:

```
docker run --rm --network=none --memory=512m --cpus=1
  --cap-drop ALL --security-opt no-new-privileges --pids-limit=256
  --user 1000:1000
  --tmpfs /tmp:rw,nosuid,nodev,size=256m -e HOME=/tmp
  -v <repo>:/workspace:rw -w /workspace python:3.11-slim sh -c '...'
```

## The flags are testable without a daemon

The argv is now built by `_build_docker_command()`, split out from `run_tests` on purpose. A security control that can only be exercised when Docker happens to be installed is a control nobody checks — extracting it means the flag set is asserted on every CI run, on any machine.

## The two caveats the issue said to test rather than assume

**`os.getuid()` on Windows.** Confirmed real. `_docker_user_flags()` uses `getattr(os, "getuid", None)` and returns `[]` when absent, so the rest of the hardening still applies and nothing raises before Docker is ever invoked. Running the suite on Windows skips the POSIX-only ownership assertion and passes the rest (16 passed, 1 skipped) — the skip is itself the evidence that `os.getuid` genuinely does not exist there.

The flag is omitted rather than emulated on Windows and macOS deliberately: Docker Desktop maps bind-mount ownership itself, so there is no host UID for the container to match and passing one can break the mount rather than secure it.

**`--user` breaking images that write outside the mount.** This is real, and it is why two flags appear here that the issue did not list. `--user` leaves the process with no passwd entry, so `HOME` is unset — pytest's cache, npm and go's build cache all fail in confusing ways. The container therefore also gets `--tmpfs /tmp:rw,nosuid,nodev,size=256m` with `HOME` pointed at it, which restores a writable home without granting any access to the host.

## Two judgement calls, flagged because you may disagree

**`--read-only` is opt-in, not on by default.** The issue lists it as absent and it is. But enabling it breaks any runner that writes outside `/workspace` and `/tmp`, and I could not test which of the ten `DOCKER_RUNNERS` entries that affects (see the verification section). Turning it on by default would be exactly the untested change the issue is complaining about. It is available as `DockerSandbox(repo, read_only=True)`.

**`--pids-limit` is configurable.** 256 by default. Parallel runners spawn a worker per core — pytest-xdist and jest on a large machine could plausibly want more, so it is a constructor arg rather than a constant.

## A limitation worth stating

`--user` matches the *invoking* user. On a CI runner executing as root that yields `--user 0:0`, which is no privilege reduction at all. File ownership stays consistent, but on a root-invoked run this is not a privilege boundary. Forcing a non-root UID instead would break writes to the root-owned workspace mount, so matching the invoker is the correct behaviour — it is just worth being explicit that it does nothing when the invoker is root.

## `:rw` is not reverted

The mount stays read-write. It was changed from `:ro` in #8 for a legitimate reason — plenty of suites create fixtures beside their tests — and the issue's framing is right: the problem was that it landed without compensating controls, not that it was wrong. This PR adds the controls.

## Tests

`tests/test_docker_hardening.py` — 17 cases, no daemon required.

Controls: `--cap-drop ALL`; `--security-opt no-new-privileges`; `--pids-limit=256` and configurable; `--user` in `uid:gid` form matching `os.getuid()`/`os.getgid()` on POSIX.

Platform guard: `_docker_user_flags()` returns `[]` when `os.getuid` is deleted, and the full argv still builds with every non-UID-dependent flag intact.

Compensating controls: `--tmpfs` present for `/tmp` with `nosuid` and `nodev`; `HOME=/tmp` set.

Regressions: `--network=none`, `--memory=512m`, `--cpus=1` and `--rm` all preserved; the workspace is still mounted `:rw` at `/workspace`; the image name still precedes `sh` so flags are not passed to the container by mistake; a custom `image=` is honoured; and `shlex.join` still prevents an inner argument like `-k "weird name'; rm -rf /"` from breaking out of `sh -c`.

## Verified — and what was not

Verified: the argv above; the Windows guard on a real Windows machine (16 passed, 1 skipped); 17 tests pass; `tests/test_utils.py` still 4 passed; ruff on `modules/sandbox.py` reports the same 3 findings before and after, i.e. none added; `npx prettier --check README.md` clean.

**Not verified: no container was ever started with these flags.** No Docker daemon was available on either machine this was developed or tested on. The argv assertions are real; the runtime behaviour is not proven. Specifically unproven: whether `python:3.11-slim` runs pytest correctly under `--user`, whether the tmpfs home is sufficient for every runner, and whether `read_only=True` is usable at all.

`scripts/verify_docker_sandbox.py` exists so that gap can be closed in one command by anyone with a daemon:

```bash
python scripts/verify_docker_sandbox.py
```

It runs a real container and checks the suite passes with every flag applied, that files created in the workspace come back owned by the invoking user rather than root, that `HOME` is writable, and that `--network=none` actually blocks. It exits 0 and prints `SKIP` when Docker is absent, so it is safe to wire into CI. I would rather ship the means to check than assert something I could not run.

## Interaction with #49

Conflicts with the open PR for #49 on `modules/sandbox.py` — both add parameters to `DockerSandbox.__init__`. That one is genuine and not avoidable by rearranging; the README and helper-function collisions were, and have been moved so those merge clean.

I resolved it locally and ran the combined tree: 39 tests pass. The resolution is mechanical — keep all three parameters:

```python
    strict: bool = False,       # from #49
    pids_limit: int = 256,      # from #48
    read_only: bool = False,    # from #48
):
    ...
    self.strict = strict
    self.pids_limit = pids_limit
    self.read_only = read_only
    self._docker_available = _docker_is_usable()   # from #49, not shutil.which
```

Happy to rebase whichever way round you merge them, or to fold both into a single PR if you would rather review the DockerSandbox changes together.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.