### PR TITLE
fix(sandbox): remove leaked containers on timeout and interrupt — Closes #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,43 @@ python demo_run.py /path/to/sample_repo
 
 ---
 
+## Container Cleanup
+
+Every container `DockerSandbox` starts is given a unique `--name` and a
+`com.repopilot.sandbox` label, and is force-removed if the run does not end
+cleanly.
+
+`--rm` alone is not enough. The daemon honours it when a container _exits_, and
+on timeout `subprocess.run` kills the docker **CLI** with `SIGKILL` — a signal
+that cannot be caught, so it is never proxied to the container. The container
+keeps running, still holding its memory and CPU reservation, and never exits, so
+`--rm` never fires. Ctrl+C has the same shape: `KeyboardInterrupt` is a
+`BaseException`, which an `except Exception` would miss.
+
+Both paths now issue an explicit `docker rm --force`. A successful run does not,
+since `--rm` has already handled it.
+
+`DockerSandbox` also works as a context manager:
+
+```python
+with DockerSandbox(repo) as sandbox:
+    result = sandbox.run_tests("pytest")
+# any container this instance started is removed on the way out
+```
+
+For the case nothing in-process can cover — SIGKILL, or the machine losing
+power — there is an explicit sweep:
+
+```python
+DockerSandbox.sweep_orphaned_containers()   # returns the ids removed
+```
+
+It is deliberately not automatic. A sweep cannot tell a leaked container from
+one belonging to another agent running right now, so the decision stays with the
+caller.
+
+---
+
 ## Execution Loop Detail
 
 ```

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -8,13 +8,28 @@ Runs code in isolation using subprocess with:
 - Optional Docker support
 """
 
+import atexit
+import logging
 import os
 import shlex
 import shutil
 import subprocess
 import sys
+import uuid
 from dataclasses import dataclass
 from typing import Optional
+
+_LOG = logging.getLogger("agent.sandbox")
+
+# Every container this module starts is named and labelled, so a leaked one can
+# be found and removed. `--rm` alone is not enough: it is honoured by the daemon
+# when the container *exits*, and a container whose CLI was killed never does.
+CONTAINER_NAME_PREFIX = "repopilot-sandbox"
+CONTAINER_LABEL_KEY = "com.repopilot.sandbox"
+
+# Names of containers believed to be running right now, for the atexit sweep.
+_ACTIVE_CONTAINERS: set[str] = set()
+_ATEXIT_REGISTERED = False
 
 
 @dataclass
@@ -103,6 +118,57 @@ def _coerce_output(value) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return str(value)
+
+
+def _new_container_name() -> str:
+    return f"{CONTAINER_NAME_PREFIX}-{uuid.uuid4().hex[:12]}"
+
+
+def _force_remove_container(name: str, timeout: int = 30) -> bool:
+    """
+    Remove a container by name, tolerating the case where it is already gone.
+
+    `docker rm -f` exits non-zero with "No such container" when `--rm` already
+    cleaned up, and can transiently report "removal in progress". Neither is an
+    error worth surfacing, so this reports success/failure and never raises.
+    """
+    if shutil.which("docker") is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["docker", "rm", "--force", name],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        _LOG.debug("could not remove container %s: %s", name, exc)
+        return False
+
+    if proc.returncode == 0:
+        _LOG.debug("removed leaked container %s", name)
+        return True
+
+    _LOG.debug("container %s not removed (likely already gone): %s",
+               name, proc.stderr.strip()[:200])
+    return False
+
+
+def _cleanup_active_containers() -> None:
+    """atexit hook. Must never raise -- it runs during interpreter shutdown."""
+    for name in list(_ACTIVE_CONTAINERS):
+        try:
+            _force_remove_container(name)
+        except Exception:  # pragma: no cover - defensive during shutdown
+            pass
+        _ACTIVE_CONTAINERS.discard(name)
+
+
+def _register_atexit_once() -> None:
+    global _ATEXIT_REGISTERED
+    if not _ATEXIT_REGISTERED:
+        atexit.register(_cleanup_active_containers)
+        _ATEXIT_REGISTERED = True
 
 
 class SubprocessSandbox:
@@ -236,6 +302,7 @@ class DockerSandbox:
         self.image = image
         self.timeout = timeout_seconds
         self._docker_available = shutil.which("docker") is not None
+        self._containers: set[str] = set()
 
     def run_tests(self, runner: str = "pytest", extra_args: Optional[list[str]] = None) -> ExecutionResult:
         if not self._docker_available:
@@ -245,8 +312,11 @@ class DockerSandbox:
         runner_cmd = DOCKER_RUNNERS.get(runner) or ["python", "-m", "pytest"]
         inner_cmd = runner_cmd + (extra_args or [])
 
+        name = _new_container_name()
         docker_cmd = [
             "docker", "run", "--rm",
+            "--name", name,
+            "--label", f"{CONTAINER_LABEL_KEY}=1",
             "--network=none",
             "--memory=512m",
             "--cpus=1",
@@ -257,4 +327,70 @@ class DockerSandbox:
         ]
 
         sb = SubprocessSandbox(self.working_dir, self.timeout)
-        return sb.run(docker_cmd)
+
+        _register_atexit_once()
+        _ACTIVE_CONTAINERS.add(name)
+        self._containers.add(name)
+        try:
+            result = sb.run(docker_cmd)
+        except BaseException:
+            # KeyboardInterrupt and SystemExit reach here; the CLI is gone but
+            # the container is not, so remove it before the exception continues.
+            _force_remove_container(name)
+            raise
+        finally:
+            _ACTIVE_CONTAINERS.discard(name)
+            self._containers.discard(name)
+
+        if result.timed_out:
+            # subprocess.run kills the docker CLI with SIGKILL on timeout. That
+            # signal cannot be caught or proxied, so the container keeps running
+            # -- still holding its memory and CPU reservation -- and `--rm` will
+            # not fire because the container never exits. Remove it explicitly.
+            _LOG.warning(
+                "DockerSandbox: run timed out; force-removing container %s", name
+            )
+            _force_remove_container(name)
+
+        return result
+
+    # ── cleanup surface ───────────────────────────────────────────────
+
+    def cleanup(self) -> None:
+        """Remove any container this instance started that is still tracked."""
+        for name in list(self._containers):
+            _force_remove_container(name)
+            self._containers.discard(name)
+            _ACTIVE_CONTAINERS.discard(name)
+
+    def __enter__(self) -> "DockerSandbox":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.cleanup()
+        return False  # never swallow the exception
+
+    @classmethod
+    def sweep_orphaned_containers(cls) -> list[str]:
+        """
+        Remove every container this project has ever labelled, and return the
+        ids removed.
+
+        For the case nothing in-process can cover: the agent killed with
+        SIGKILL, or the machine losing power. Deliberately *not* automatic on
+        startup -- a sweep cannot tell a leaked container from one belonging to
+        another agent running right now, so it is the caller's decision.
+        """
+        if shutil.which("docker") is None:
+            return []
+        try:
+            listed = subprocess.run(
+                ["docker", "ps", "-aq", "--filter", f"label={CONTAINER_LABEL_KEY}"],
+                capture_output=True, text=True, timeout=30,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            _LOG.debug("could not list sandbox containers: %s", exc)
+            return []
+
+        ids = [line.strip() for line in listed.stdout.splitlines() if line.strip()]
+        return [cid for cid in ids if _force_remove_container(cid)]

--- a/tests/test_docker_cleanup.py
+++ b/tests/test_docker_cleanup.py
@@ -1,0 +1,310 @@
+"""
+Tests for DockerSandbox container cleanup (modules/sandbox.py).
+
+`--rm` is honoured by the daemon when a container *exits*. On timeout,
+`subprocess.run` kills the docker CLI with SIGKILL — uncatchable, so it is never
+proxied to the container, which keeps running and never exits, so `--rm` never
+fires. These pin the paths that clean up after that.
+
+No daemon required: docker invocations are recorded through a stub.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import sandbox as sandbox_mod  # noqa: E402
+from modules.sandbox import (  # noqa: E402
+    CONTAINER_LABEL_KEY,
+    CONTAINER_NAME_PREFIX,
+    DockerSandbox,
+    ExecutionResult,
+    _force_remove_container,
+    _new_container_name,
+)
+
+
+@pytest.fixture
+def docker_calls(monkeypatch):
+    """Record every docker subprocess invocation; report success by default."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, *a, **k):
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+    return calls
+
+
+@pytest.fixture
+def sandbox(tmp_path, monkeypatch):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    sb = DockerSandbox(str(tmp_path), timeout_seconds=5)
+    yield sb
+    sandbox_mod._ACTIVE_CONTAINERS.clear()
+
+
+def stub_result(**kwargs):
+    base = dict(
+        command="docker run", exit_code=0, stdout="", stderr="",
+        timed_out=False, duration_seconds=0.1,
+    )
+    base.update(kwargs)
+    return ExecutionResult(**base)
+
+
+def patch_execution(monkeypatch, result=None, raises=None):
+    """Replace SubprocessSandbox.run, capturing the docker argv it was given."""
+    seen: dict = {}
+
+    def fake_run(self, command, env=None, stdin_data=None):
+        seen["argv"] = list(command)
+        if raises is not None:
+            raise raises
+        return result if result is not None else stub_result()
+
+    monkeypatch.setattr(sandbox_mod.SubprocessSandbox, "run", fake_run)
+    return seen
+
+
+def removals(calls):
+    return [c for c in calls if c[:3] == ["docker", "rm", "--force"]]
+
+
+# ── the container is findable ─────────────────────────────────────────────
+
+
+def test_container_is_named(sandbox, monkeypatch, docker_calls):
+    seen = patch_execution(monkeypatch)
+    sandbox.run_tests("pytest")
+
+    argv = seen["argv"]
+    assert "--name" in argv
+    assert argv[argv.index("--name") + 1].startswith(CONTAINER_NAME_PREFIX)
+
+
+def test_container_is_labelled(sandbox, monkeypatch, docker_calls):
+    """The label is what makes a sweep possible after a SIGKILL."""
+    seen = patch_execution(monkeypatch)
+    sandbox.run_tests("pytest")
+    assert f"{CONTAINER_LABEL_KEY}=1" in seen["argv"]
+
+
+def test_names_are_unique_per_run():
+    """A reused name would collide with a container that outlived its run."""
+    assert len({_new_container_name() for _ in range(200)}) == 200
+
+
+def test_rm_flag_is_kept(sandbox, monkeypatch, docker_calls):
+    """Explicit removal complements --rm; it does not replace it."""
+    seen = patch_execution(monkeypatch)
+    sandbox.run_tests("pytest")
+    assert "--rm" in seen["argv"]
+
+
+# ── timeout: the case --rm cannot cover ───────────────────────────────────
+
+
+def test_timeout_forces_removal(sandbox, monkeypatch, docker_calls):
+    patch_execution(monkeypatch, result=stub_result(timed_out=True, exit_code=-1))
+    sandbox.run_tests("pytest")
+    assert len(removals(docker_calls)) == 1
+
+
+def test_timeout_removes_the_container_that_was_started(
+    sandbox, monkeypatch, docker_calls
+):
+    seen = patch_execution(
+        monkeypatch, result=stub_result(timed_out=True, exit_code=-1)
+    )
+    sandbox.run_tests("pytest")
+
+    started = seen["argv"][seen["argv"].index("--name") + 1]
+    assert removals(docker_calls)[0][3] == started
+
+
+def test_timeout_still_returns_the_result(sandbox, monkeypatch, docker_calls):
+    """Cleanup must not swallow the outcome the caller is waiting for."""
+    patch_execution(monkeypatch, result=stub_result(timed_out=True, exit_code=-1))
+    result = sandbox.run_tests("pytest")
+    assert result.timed_out is True
+    assert result.exit_code == -1
+
+
+def test_success_does_not_issue_a_redundant_removal(sandbox, monkeypatch, docker_calls):
+    """--rm already handled it; a second daemon round-trip is wasted work."""
+    patch_execution(monkeypatch)
+    sandbox.run_tests("pytest")
+    assert removals(docker_calls) == []
+
+
+# ── interrupts ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("exc", [KeyboardInterrupt(), SystemExit()])
+def test_interrupt_removes_the_container(sandbox, monkeypatch, docker_calls, exc):
+    """Ctrl+C raises BaseException, which `except Exception` would miss."""
+    patch_execution(monkeypatch, raises=exc)
+
+    with pytest.raises(type(exc)):
+        sandbox.run_tests("pytest")
+
+    assert len(removals(docker_calls)) == 1
+
+
+def test_interrupt_is_not_swallowed(sandbox, monkeypatch, docker_calls):
+    patch_execution(monkeypatch, raises=KeyboardInterrupt())
+    with pytest.raises(KeyboardInterrupt):
+        sandbox.run_tests("pytest")
+
+
+@pytest.mark.parametrize("exc", [KeyboardInterrupt(), SystemExit()])
+def test_registry_is_left_clean_after_an_interrupt(
+    sandbox, monkeypatch, docker_calls, exc
+):
+    patch_execution(monkeypatch, raises=exc)
+    with pytest.raises(type(exc)):
+        sandbox.run_tests("pytest")
+    assert sandbox_mod._ACTIVE_CONTAINERS == set()
+
+
+def test_registry_is_left_clean_after_success(sandbox, monkeypatch, docker_calls):
+    patch_execution(monkeypatch)
+    sandbox.run_tests("pytest")
+    assert sandbox_mod._ACTIVE_CONTAINERS == set()
+
+
+# ── context manager ───────────────────────────────────────────────────────
+
+
+def test_context_manager_returns_the_sandbox(sandbox):
+    with sandbox as entered:
+        assert entered is sandbox
+
+
+def test_context_manager_does_not_suppress_exceptions(sandbox, docker_calls):
+    with pytest.raises(ValueError):
+        with sandbox:
+            raise ValueError("boom")
+
+
+def test_cleanup_removes_tracked_containers(sandbox, docker_calls):
+    sandbox._containers.add("repopilot-sandbox-abc123")
+    sandbox.cleanup()
+
+    assert removals(docker_calls) == [
+        ["docker", "rm", "--force", "repopilot-sandbox-abc123"]
+    ]
+    assert sandbox._containers == set()
+
+
+def test_cleanup_is_idempotent(sandbox, docker_calls):
+    sandbox._containers.add("repopilot-sandbox-abc123")
+    sandbox.cleanup()
+    sandbox.cleanup()
+    assert len(removals(docker_calls)) == 1
+
+
+# ── removal is tolerant ───────────────────────────────────────────────────
+
+
+def test_removal_tolerates_a_container_that_is_already_gone(monkeypatch):
+    """`--rm` racing ahead of us is the normal case, not an error."""
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+
+    def fake_run(argv, *a, **k):
+        return subprocess.CompletedProcess(
+            argv, returncode=1, stdout="", stderr="Error: No such container: x"
+        )
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+    assert _force_remove_container("x") is False  # reported, not raised
+
+
+@pytest.mark.parametrize(
+    "exc", [OSError("nope"), subprocess.TimeoutExpired("docker", 1)]
+)
+def test_removal_survives_a_broken_or_hanging_cli(monkeypatch, exc):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+
+    def fake_run(*a, **k):
+        raise exc
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+    assert _force_remove_container("x") is False
+
+
+def test_removal_is_a_noop_without_docker(monkeypatch):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: None)
+    assert _force_remove_container("x") is False
+
+
+# ── orphan sweep ──────────────────────────────────────────────────────────
+
+
+def test_sweep_filters_on_the_project_label(monkeypatch):
+    """A sweep must not touch containers this project did not start."""
+    calls: list[list[str]] = []
+
+    def fake_run(argv, *a, **k):
+        calls.append(list(argv))
+        if argv[:2] == ["docker", "ps"]:
+            return subprocess.CompletedProcess(argv, 0, stdout="abc\ndef\n", stderr="")
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
+
+    removed = DockerSandbox.sweep_orphaned_containers()
+
+    assert removed == ["abc", "def"]
+    assert f"label={CONTAINER_LABEL_KEY}" in calls[0]
+
+
+def test_sweep_is_a_noop_without_docker(monkeypatch):
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: None)
+    assert DockerSandbox.sweep_orphaned_containers() == []
+
+
+def test_sweep_is_not_automatic():
+    """
+    It cannot distinguish a leaked container from one belonging to another
+    agent running right now, so it must stay an explicit call.
+    """
+    module = Path(__file__).resolve().parents[1] / "modules" / "sandbox.py"
+    source = module.read_text()
+    assert "atexit.register(_cleanup_active_containers)" in source
+    assert "atexit.register(DockerSandbox.sweep_orphaned_containers)" not in source
+
+
+# ── atexit hook ───────────────────────────────────────────────────────────
+
+
+def test_atexit_hook_clears_the_registry(docker_calls):
+    sandbox_mod._ACTIVE_CONTAINERS.add("repopilot-sandbox-leaked")
+    sandbox_mod._cleanup_active_containers()
+
+    assert removals(docker_calls) == [
+        ["docker", "rm", "--force", "repopilot-sandbox-leaked"]
+    ]
+    assert sandbox_mod._ACTIVE_CONTAINERS == set()
+
+
+def test_atexit_hook_never_raises(monkeypatch):
+    """It runs during interpreter shutdown, where an exception is unhelpful."""
+    monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+
+    def explode(*a, **k):
+        raise RuntimeError("interpreter is going away")
+
+    monkeypatch.setattr(sandbox_mod.subprocess, "run", explode)
+    sandbox_mod._ACTIVE_CONTAINERS.add("repopilot-sandbox-x")
+
+    sandbox_mod._cleanup_active_containers()  # must not raise
+    assert sandbox_mod._ACTIVE_CONTAINERS == set()


### PR DESCRIPTION
Closes #52

## Summary

`DockerSandbox` already passes `--rm`, so the first thing worth establishing is what actually leaks. It turns out to be the two cases the issue names — timeout and Ctrl+C — and for a reason that is not obvious from reading the code.

Every container is now given a unique `--name` and a project label, and is force-removed when a run does not end cleanly.

## Why `--rm` does not cover this

The daemon honours `--rm` when a container **exits**. On timeout, `subprocess.run` calls `process.kill()` — SIGKILL, which cannot be caught, so `docker run` never gets the chance to proxy anything to the container. The container keeps running, never exits, and `--rm` therefore never fires. It sits there holding its 512MB memory and 1-CPU reservation.

Reproduced on unmodified `main` with a stub `docker` on PATH that logs every invocation and sleeps on `run`:

```
timed_out: True | exit: -1

docker invocations during that run:
  run --rm --network=none --memory=512m --cpus=1 -v /tmp/...:/workspace:rw -w /workspace python:3.11-slim sh -c python -m pytest

rm/kill/stop calls: 0
```

One `run`, and nothing else. There was also no `--name`, so the orphan could not be located afterwards except by eyeballing `docker ps`.

The same run after this change issues `docker rm --force repopilot-sandbox-<id>`.

**Ctrl+C is a different shape.** `KeyboardInterrupt` is a `BaseException`, so an `except Exception` would miss it entirely. The cleanup catches `BaseException`, removes the container, and re-raises — the interrupt is never swallowed.

## What changed

**Containers are findable.** `--name repopilot-sandbox-<uuid12>` and `--label com.repopilot.sandbox=1`. The name is unique per run because reusing one would collide with a container that outlived its run.

**Two cleanup paths.** `except BaseException` covers interrupts; an explicit `result.timed_out` check covers the SIGKILL case. A successful run issues no removal at all — `--rm` has already handled it, and a second daemon round-trip is wasted work.

**Removal is tolerant.** `docker rm --force` exits non-zero with "No such container" when `--rm` won the race, and can transiently report "removal in progress". Neither is worth surfacing, so `_force_remove_container` reports success/failure and never raises.

**`atexit` hook** for containers still tracked at interpreter shutdown, registered lazily on first use. It must never raise — an exception during shutdown helps nobody — so it is wrapped.

**Context manager.**

```python
with DockerSandbox(repo) as sandbox:
    result = sandbox.run_tests("pytest")
# anything this instance started is removed on the way out
```

`__exit__` returns `False`, so it never suppresses the caller's exception.

## The sweep is deliberately not automatic

Nothing in-process can cover a SIGKILL of the agent itself, or the machine losing power. For that there is:

```python
DockerSandbox.sweep_orphaned_containers()   # returns the ids removed
```

I considered running it on startup and decided against it: a label-based sweep cannot distinguish a leaked container from one belonging to another agent running right now, so auto-sweeping would kill live work. It stays an explicit call, and there is a test asserting it is not wired into `atexit`.

## Tests

`tests/test_docker_cleanup.py` — 27 cases, no daemon required; docker invocations are recorded through a stub.

Findability: the container is named with the expected prefix and labelled; 200 generated names are unique; `--rm` is kept, since explicit removal complements it rather than replacing it.

Timeout: forces exactly one removal, of the container that was actually started, and still returns the caller's result — cleanup must not swallow the outcome. A successful run issues no removal.

Interrupts: parametrised over `KeyboardInterrupt` and `SystemExit`; each triggers removal, propagates rather than being swallowed, and leaves the active-container registry empty.

Context manager: returns the sandbox, does not suppress exceptions, `cleanup()` removes tracked containers and is idempotent.

Tolerance: "No such container" is reported, not raised; `OSError` and `TimeoutExpired` from the CLI are survived; removal is a no-op when docker is absent.

Sweep: filters on the project label so it cannot touch unrelated containers; no-op without docker; asserted not to be auto-registered.

`atexit`: clears the registry, and does not raise even when the removal call itself explodes.

## Verified

- the before/after stub-docker traces above
- Ctrl+C path: `KeyboardInterrupt` propagates, one removal issued, registry left clean
- success path: zero redundant removals
- 27 tests pass; `tests/test_utils.py` still 4 passed
- ruff on `modules/sandbox.py`: same 3 findings before and after, i.e. none added; `npx prettier --check README.md` clean

Not verified: no Docker daemon was available in the environment this was built in, so the container lifecycle is exercised against a stub that records argv. That proves the right commands are issued at the right times; it does not prove the daemon behaves as expected when it receives them. Stated rather than implied.

## Interaction with the other DockerSandbox PRs

This is the fourth PR touching `modules/sandbox.py` (#47, #48, #49, #52). It merges clean against #51, #53 and #54. Against the other three I measured each rather than guessing:

- **#47** — one import line. Resolves trivially; verified 96 tests pass on the merged tree.
- **#49** — `run_tests` needs real hand-resolution, since both restructure it. I did it and got 49 tests passing. One extra step: the `sandbox` fixture in `tests/test_docker_cleanup.py` patches `shutil.which`, and #49 replaces that call with `_docker_is_usable`, so the fixture needs one added line:

```python
  monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
```

  That is a fixture incompatibility, not a code conflict.
- **#48** — `__init__` plus the docker argv; same shape as #49.

So these four are a genuine stack rather than independent changes. Merge them in issue order and I will rebase after each, or say the word and I will fold #48, #49 and #52 into a single DockerSandbox PR so the whole class can be reviewed at once — that may well be easier to reason about than three interlocking diffs.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.