### PR TITLE
feat(agent): support non-interactive CI/CD with --yes flag (#14)

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,10 @@ Examples:
     parser.add_argument("--api-key", default=None,
                         help="Anthropic API key (default: ANTHROPIC_API_KEY env var)")
 
+    # Non-interactive / CI
+    parser.add_argument("--yes", "-y", action="store_true",
+                        help="Auto-approve file changes (bypass confirmation prompt)")
+
     return parser.parse_args()
 
 
@@ -108,10 +112,13 @@ def main():
         print(f"ERROR: Repository path does not exist: {repo_root}", file=sys.stderr)
         sys.exit(1)
 
+    yes_flag = args.yes or os.environ.get("CI") == "true"
+
     config = AgentConfig(
         repo_root=repo_root,
         task=args.task,
         dry_run=args.dry_run,
+        yes=yes_flag,
 
         # Execution
         test_runner=args.runner,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -38,6 +38,7 @@ class AgentConfig:
     repo_root: str
     task: str
     dry_run: bool = False
+    yes: bool = False
 
     # Execution
     test_runner: str = "pytest"            # pytest | npm_test | go | cargo | ...
@@ -296,7 +297,7 @@ class AutonomousAgent:
                         pr_url=None,
                     )
 
-                if not ask_confirmation(len(llm_resp.changes)):
+                if not (self.config.yes or ask_confirmation(len(llm_resp.changes))):
                     return AgentRunResult(
                         outcome="aborted",
                         run_id=self.run_id,


### PR DESCRIPTION
Closes #14

Adds a `--yes` / `-y` flag to bypass the interactive confirmation gate when modifying files.