### PR TITLE
feat(modifier): add rename/move action with safe rollback — Closes #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ python demo_run.py /path/to/sample_repo
 
 - Validates paths (prevents directory traversal).
 - Backs up every file before modification.
-- Supports `modify`, `create`, `delete` actions.
+- Supports `modify`, `create`, `delete` and `rename` actions (`move` is accepted
+  as a synonym). A rename takes a `new_path`; include `content` only if the
+  file's contents change too. Renames refuse to overwrite an existing file, and
+  rolling one back removes the moved copy as well as restoring the original.
 - `rollback()` restores all backups on failure.
 
 ### Module 5 — `sandbox.py`

--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -14,6 +14,13 @@ from typing import Optional
 from modules.llm_client import FileChange
 
 
+# "rename" is the canonical name; "move" is accepted because it is the word a
+# model is just as likely to reach for, and rejecting it would send the agent
+# back around the loop for a synonym.
+RENAME_ACTIONS = ("rename", "move")
+VALID_ACTIONS = ("modify", "create", "delete") + RENAME_ACTIONS
+
+
 @dataclass
 class ApplyResult:
     path: str
@@ -21,6 +28,7 @@ class ApplyResult:
     success: bool
     backup_path: Optional[str]
     error: Optional[str]
+    new_path: Optional[str] = None   # destination, for "rename"
 
 
 class CodeModificationEngine:
@@ -110,6 +118,64 @@ class CodeModificationEngine:
                     success=True, backup_path=backup_path, error=None
                 )
 
+            elif change.action in RENAME_ACTIONS:
+                if not change.new_path:
+                    return ApplyResult(
+                        path=change.path, action=change.action,
+                        success=False, backup_path=None,
+                        error=f"'{change.action}' on {change.path} requires 'new_path'"
+                    )
+
+                try:
+                    dest_abs = self._safe_abs_path(change.new_path)
+                except ValueError as e:
+                    return ApplyResult(
+                        path=change.path, action=change.action,
+                        success=False, backup_path=None, error=str(e)
+                    )
+
+                if not os.path.exists(abs_path):
+                    return ApplyResult(
+                        path=change.path, action=change.action,
+                        success=False, backup_path=None,
+                        error=f"Cannot rename missing file: {change.path}"
+                    )
+
+                if os.path.normcase(dest_abs) == os.path.normcase(abs_path):
+                    return ApplyResult(
+                        path=change.path, action=change.action,
+                        success=False, backup_path=None,
+                        error=(
+                            "Rename source and destination are the same: "
+                            f"{change.path}"
+                        )
+                    )
+
+                if os.path.exists(dest_abs):
+                    # Silently clobbering a file the task never mentioned is the
+                    # kind of loss no backup here would cover.
+                    return ApplyResult(
+                        path=change.path, action=change.action,
+                        success=False, backup_path=None,
+                        error=f"Refusing to overwrite existing file: {change.new_path}"
+                    )
+
+                backup_path = self._backup(abs_path, change.path)
+                os.makedirs(os.path.dirname(dest_abs), exist_ok=True)
+                shutil.move(abs_path, dest_abs)
+
+                # A rename may also change the file's contents; omitting
+                # "content" moves it unchanged.
+                if change.content:
+                    with open(dest_abs, "w", encoding="utf-8") as fh:
+                        fh.write(change.content)
+
+                return ApplyResult(
+                    path=change.path, action=change.action,
+                    success=True, backup_path=backup_path, error=None,
+                    new_path=change.new_path
+                )
+
             else:
                 return ApplyResult(
                     path=change.path, action=change.action,
@@ -139,6 +205,17 @@ class CodeModificationEngine:
         """
         restored = []
         for result in results:
+            # A rename left a file at the destination. Restoring the backup to
+            # the original path is not enough on its own -- without this the
+            # revert leaves both copies behind.
+            if result.action in RENAME_ACTIONS and result.new_path:
+                try:
+                    dest_abs = self._safe_abs_path(result.new_path)
+                    if os.path.exists(dest_abs):
+                        os.remove(dest_abs)
+                except Exception:
+                    pass
+
             if result.backup_path and os.path.exists(result.backup_path):
                 try:
                     abs_path = self._safe_abs_path(result.path)
@@ -158,10 +235,20 @@ class CodeModificationEngine:
             if not change.path:
                 errors.append("Change has empty path")
                 continue
-            if change.action not in ("modify", "create", "delete"):
+            if change.action not in VALID_ACTIONS:
                 errors.append(f"Invalid action '{change.action}' for {change.path}")
             if change.action in ("modify", "create") and not change.content:
                 errors.append(f"Empty content for {change.action} on {change.path}")
+            if change.action in RENAME_ACTIONS:
+                if not change.new_path:
+                    errors.append(
+                        f"Missing 'new_path' for {change.action} on {change.path}"
+                    )
+                else:
+                    try:
+                        self._safe_abs_path(change.new_path)
+                    except ValueError as e:
+                        errors.append(f"{change.path}: invalid new_path - {e}")
             try:
                 self._safe_abs_path(change.path)
             except ValueError as e:

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -40,8 +40,9 @@ Return a JSON object with this exact schema:
   "changes": [
     {
       "path": "<relative file path from repo root>",
-      "action": "modify" | "create" | "delete",
+      "action": "modify" | "create" | "delete" | "rename",
       "content": "<full new file content (for modify/create)>",
+      "new_path": "<destination path, ONLY for rename>",
       "explanation": "<why this change>"
     }
   ],
@@ -52,6 +53,9 @@ Return a JSON object with this exact schema:
 RULES:
 - For "modify" and "create": always provide the COMPLETE file content, not diffs or snippets.
 - For "delete": omit "content".
+- To move or rename a file, use "rename" with "new_path" — do NOT emit a "create"
+  at the new path plus a "delete" at the old one. Include "content" with a rename
+  only if the file's contents also change; omit it to move the file unchanged.
 - Do NOT include markdown fences, explanation text, or anything outside the JSON object.
 - Paths must be relative (e.g., "src/utils.py"), never absolute.
 - If you cannot determine a fix, set confidence < 0.3 and done=false with a clear analysis.
@@ -103,9 +107,10 @@ Focus on the root cause of the failure. Return ONLY the JSON object.
 @dataclass
 class FileChange:
     path: str
-    action: str      # "modify" | "create" | "delete"
+    action: str      # "modify" | "create" | "delete" | "rename"
     content: str     # full file content
     explanation: str
+    new_path: Optional[str] = None   # destination, for "rename"
 
 
 @dataclass
@@ -183,6 +188,7 @@ class LLMClient:
                 action=c.get("action", "modify"),
                 content=c.get("content", ""),
                 explanation=c.get("explanation", ""),
+                new_path=c.get("new_path") or None,
             ))
 
         return LLMResponse(

--- a/tests/test_rename_action.py
+++ b/tests/test_rename_action.py
@@ -1,0 +1,253 @@
+"""
+Tests for the rename/move action (modules/code_modifier.py).
+
+Without it the model's only route to moving a file is a `create` at the new
+path plus a `delete` at the old one — two independent operations that can half
+apply. The rollback half matters as much as the apply half: restoring the
+backup to the original path leaves the moved copy behind unless the destination
+is removed too.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.code_modifier import (  # noqa: E402
+    RENAME_ACTIONS,
+    VALID_ACTIONS,
+    CodeModificationEngine,
+)
+from modules.llm_client import FileChange, LLMClient  # noqa: E402
+
+ORIGINAL = "def add(a, b):\n    return a + b\n"
+
+
+@pytest.fixture
+def engine(tmp_path):
+    (tmp_path / "old.py").write_text(ORIGINAL)
+    return CodeModificationEngine(
+        repo_root=str(tmp_path), backup_dir=str(tmp_path / ".backups")
+    )
+
+
+def rename(path="old.py", new_path="new.py", content="", action="rename"):
+    return FileChange(
+        path=path, action=action, content=content,
+        explanation="moving it", new_path=new_path,
+    )
+
+
+# ── applying ──────────────────────────────────────────────────────────────
+
+
+def test_file_moves_to_the_new_path(engine, tmp_path):
+    result = engine.apply_changes([rename()])[0]
+
+    assert result.success is True
+    assert (tmp_path / "new.py").exists()
+    assert not (tmp_path / "old.py").exists()
+
+
+def test_contents_survive_a_plain_rename(engine, tmp_path):
+    engine.apply_changes([rename()])
+    assert (tmp_path / "new.py").read_text() == ORIGINAL
+
+
+def test_destination_directories_are_created(engine, tmp_path):
+    engine.apply_changes([rename(new_path="pkg/sub/new.py")])
+    assert (tmp_path / "pkg" / "sub" / "new.py").read_text() == ORIGINAL
+
+
+def test_rename_can_also_change_content(engine, tmp_path):
+    """Moving and editing in one step, rather than a move then a modify."""
+    engine.apply_changes([rename(content="def add(a, b):\n    return a + b + 0\n")])
+    assert "a + b + 0" in (tmp_path / "new.py").read_text()
+
+
+def test_move_is_accepted_as_an_alias(engine, tmp_path):
+    result = engine.apply_changes([rename(action="move")])[0]
+    assert result.success is True
+    assert (tmp_path / "new.py").exists()
+
+
+def test_result_records_the_destination(engine):
+    """rollback needs it; without it the move cannot be undone."""
+    assert engine.apply_changes([rename()])[0].new_path == "new.py"
+
+
+def test_a_backup_is_taken(engine):
+    result = engine.apply_changes([rename()])[0]
+    assert result.backup_path is not None
+    assert os.path.exists(result.backup_path)
+
+
+# ── refusals ──────────────────────────────────────────────────────────────
+
+
+def test_missing_source_is_refused(engine):
+    result = engine.apply_changes([rename(path="nope.py")])[0]
+    assert result.success is False
+    assert "missing file" in result.error
+
+
+def test_missing_new_path_is_refused(engine, tmp_path):
+    result = engine.apply_changes([rename(new_path=None)])[0]
+    assert result.success is False
+    assert "new_path" in result.error
+    assert (tmp_path / "old.py").exists()  # untouched
+
+
+def test_renaming_onto_itself_is_refused(engine):
+    result = engine.apply_changes([rename(new_path="old.py")])[0]
+    assert result.success is False
+    assert "same" in result.error
+
+
+def test_existing_destination_is_not_clobbered(engine, tmp_path):
+    """No backup here would cover a file the task never mentioned."""
+    (tmp_path / "occupied.py").write_text("do not lose me\n")
+
+    result = engine.apply_changes([rename(new_path="occupied.py")])[0]
+
+    assert result.success is False
+    assert (tmp_path / "occupied.py").read_text() == "do not lose me\n"
+    assert (tmp_path / "old.py").exists()
+
+
+@pytest.mark.parametrize("escape", ["../../etc/passwd", "/etc/passwd"])
+def test_destination_cannot_escape_the_repo(engine, tmp_path, escape):
+    """new_path is model output and gets the same validation as path."""
+    result = engine.apply_changes([rename(new_path=escape)])[0]
+
+    assert result.success is False
+    assert (tmp_path / "old.py").exists()
+
+
+def test_a_refused_rename_leaves_no_partial_state(engine, tmp_path):
+    engine.apply_changes([rename(new_path="occupied.py")])  # dest does not exist
+    # It should have succeeded; now try a genuinely bad one on the moved file.
+    result = engine.apply_changes([rename(path="occupied.py", new_path="../out.py")])[0]
+
+    assert result.success is False
+    assert (tmp_path / "occupied.py").exists()
+    assert not (tmp_path.parent / "out.py").exists()
+
+
+# ── rollback ──────────────────────────────────────────────────────────────
+
+
+def test_rollback_restores_the_original_path(engine, tmp_path):
+    results = engine.apply_changes([rename()])
+    engine.rollback(results)
+
+    assert (tmp_path / "old.py").exists()
+    assert (tmp_path / "old.py").read_text() == ORIGINAL
+
+
+def test_rollback_removes_the_moved_copy(engine, tmp_path):
+    """
+    The half that is easy to miss. Restoring the backup alone would leave the
+    file at both paths, which is worse than not rolling back at all.
+    """
+    results = engine.apply_changes([rename()])
+    engine.rollback(results)
+
+    assert not (tmp_path / "new.py").exists()
+
+
+def test_rollback_after_a_nested_rename(engine, tmp_path):
+    results = engine.apply_changes([rename(new_path="pkg/sub/new.py")])
+    engine.rollback(results)
+
+    assert (tmp_path / "old.py").read_text() == ORIGINAL
+    assert not (tmp_path / "pkg" / "sub" / "new.py").exists()
+
+
+def test_rollback_of_a_content_changing_rename(engine, tmp_path):
+    results = engine.apply_changes([rename(content="changed\n")])
+    engine.rollback(results)
+
+    assert (tmp_path / "old.py").read_text() == ORIGINAL
+    assert not (tmp_path / "new.py").exists()
+
+
+def test_rollback_still_works_for_modify(engine, tmp_path):
+    """The rename branch must not disturb the existing actions."""
+    results = engine.apply_changes(
+        [FileChange(path="old.py", action="modify", content="broken\n", explanation="e")]
+    )
+    engine.rollback(results)
+    assert (tmp_path / "old.py").read_text() == ORIGINAL
+
+
+# ── pre-flight validation ─────────────────────────────────────────────────
+
+
+def test_rename_is_a_valid_action():
+    for action in RENAME_ACTIONS:
+        assert action in VALID_ACTIONS
+
+
+def test_verify_accepts_a_well_formed_rename(engine):
+    assert engine.verify_changes([rename()]) == []
+
+
+def test_verify_rejects_a_missing_new_path(engine):
+    errors = engine.verify_changes([rename(new_path=None)])
+    assert any("new_path" in e for e in errors)
+
+
+def test_verify_rejects_an_escaping_new_path(engine):
+    errors = engine.verify_changes([rename(new_path="../../etc/passwd")])
+    assert any("new_path" in e for e in errors)
+
+
+def test_verify_errors_name_the_source_path(engine):
+    """agent_loop filters changes by matching path substrings against errors."""
+    errors = engine.verify_changes([rename(new_path=None)])
+    assert all("old.py" in e for e in errors)
+
+
+def test_rename_does_not_require_content(engine):
+    """Only modify and create need content; a plain move has none."""
+    assert engine.verify_changes([rename(content="")]) == []
+
+
+def test_unknown_actions_are_still_rejected(engine):
+    errors = engine.verify_changes(
+        [FileChange(path="old.py", action="teleport", content="x", explanation="e")]
+    )
+    assert any("Invalid action" in e for e in errors)
+
+
+# ── the model has to know the action exists ───────────────────────────────
+
+
+def test_new_path_is_parsed_from_the_response():
+    response = LLMClient._parse_response(
+        object.__new__(LLMClient),
+        '{"analysis":"a","changes":[{"path":"old.py","action":"rename",'
+        '"new_path":"new.py","explanation":"e"}],"confidence":0.9,"done":true}',
+    )
+    assert response.changes[0].new_path == "new.py"
+
+
+def test_absent_new_path_parses_as_none():
+    response = LLMClient._parse_response(
+        object.__new__(LLMClient),
+        '{"analysis":"a","changes":[{"path":"a.py","action":"modify",'
+        '"content":"x","explanation":"e"}],"confidence":0.9,"done":true}',
+    )
+    assert response.changes[0].new_path is None
+
+
+def test_prompt_documents_the_action():
+    """Unreachable otherwise — the model only emits what the schema describes."""
+    from modules.llm_client import SYSTEM_PROMPT
+
+    assert "rename" in SYSTEM_PROMPT
+    assert "new_path" in SYSTEM_PROMPT


### PR DESCRIPTION
Closes #63

## Summary

`code_modifier.py` handled `modify`, `create` and `delete`. A rename had no representation, so the model's only route was a `create` at the new path plus a `delete` at the old one — two independent operations that can half-apply, and which frequently ended up as a create with no delete, leaving both copies.

This adds a `rename` action carrying a `new_path`, wires it through the schema, the parser and the prompt, and makes rollback undo it properly.

## The rollback half is the part that needed care

`rollback()` restores `backup_path` back to `result.path`. Applied naively to a rename, that recreates the original file — and leaves the moved copy sitting at the destination. You end up with the file at *both* paths, which is a worse outcome than not rolling back at all.

So `ApplyResult` gained a `new_path` field, and rollback removes the destination before restoring the source. Verified on real files rather than mocks:

```
before        : ['old.py']
after rename  : []            (+ pkg/new.py exists, content preserved)
after rollback: ['old.py']    destination removed: True, source restored: True
```

There is a dedicated test for it, because restoring the backup alone would silently pass a test that only checked the original path came back.

## The prompt change is not optional

The model only emits what the schema describes. Adding the action to `code_modifier` alone would have been unreachable code — nothing would ever produce a `rename`. `SYSTEM_PROMPT` now lists it, with an explicit instruction against the current workaround:

> To move or rename a file, use "rename" with "new_path" — do NOT emit a "create" at the new path plus a "delete" at the old one.

`_parse_response` reads `new_path`, defaulting to `None` so existing responses parse unchanged.

## Refusals

Each returns a failed `ApplyResult` with an explanatory error rather than raising, matching how the existing actions behave:

| condition | behaviour |
| --------- | --------- |
| source does not exist | refused, nothing touched |
| `new_path` missing | refused, nothing touched |
| source and destination are the same path | refused |
| destination already exists | refused, existing file untouched |
| `new_path` escapes the repo root | refused |

The overwrite refusal is the one worth pausing on. `new_path` is model output, and clobbering a file the task never mentioned is a loss no backup in this module would cover — the backup is keyed to the source path, not the destination. Refusing costs one iteration; overwriting costs the user's file.

Path traversal gets the same treatment as `path` does: `new_path` goes through `_safe_abs_path`, so `../../etc/passwd` and `/etc/passwd` are both rejected, at pre-flight and again at apply time.

## Two judgement calls

**`move` is accepted as a synonym for `rename`.** A model is about as likely to reach for either word, and rejecting the synonym just sends the agent back around the loop to rephrase. Both map to the same code path; `rename` is documented as canonical.

**A rename may carry `content`.** Omitting it moves the file unchanged; including it writes new contents at the destination. This makes move-and-edit one operation instead of a rename followed by a modify, which is a second chance to half-apply. Rollback handles it the same way — the destination is removed and the backup restored.

Happy to drop either if you would rather keep the surface smaller.

## Tests

`tests/test_rename_action.py` — 29 cases.

Applying: the file moves; contents survive a plain rename; destination directories are created; a rename can change content too; `move` works as an alias; the result records the destination; a backup is taken.

Refusals: all five conditions in the table above, each asserting the filesystem is left untouched, plus path traversal parametrised over relative and absolute escapes.

Rollback: the original path is restored; the moved copy is removed; both hold for a nested destination and for a content-changing rename; and `modify` rollback still behaves as it did, since the new branch must not disturb the existing actions.

Pre-flight: `verify_changes` accepts a well-formed rename, rejects a missing or escaping `new_path`, does not demand `content` for a rename, and still rejects unknown actions. One test asserts the error strings contain the source path — `agent_loop` filters changes by substring-matching paths against validation errors, so an error that omits the path would quietly fail to filter.

Plumbing: `new_path` parses from a real JSON response, absent `new_path` parses as `None`, and `SYSTEM_PROMPT` mentions both `rename` and `new_path` — that last one guards against the feature being made unreachable again by a future prompt edit.

## Verified

- the before/after filesystem traces above
- every refusal exercised against a real `CodeModificationEngine` on a temp repo
- 29 tests pass; `tests/test_utils.py` still 4 passed
- ruff: `modules/code_modifier.py` back to its baseline count of 2 findings (I introduced one long line and fixed it); `modules/llm_client.py` unchanged at 5
- `npx prettier --check README.md` clean
- merges clean against all nine other branches currently open

## Pre-existing, not touched

`rollback()` cannot undo a `create`. `_backup()` returns `None` when the file does not already exist, so there is no backup to restore from and nothing removes the created file. That is outside this issue and fixing it would change behaviour for an existing action, so I have left it — flagging it in case it deserves its own issue.

Also pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for renaming and moving files.
  * Rename operations can optionally update file contents and support nested destinations.
  * Added validation to prevent unsafe paths, overwrites, invalid sources, and same-path moves.
  * Added rollback support that restores the original file and removes the moved copy.

* **Documentation**
  * Updated the README with details about rename and move actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->