### PR TITLE
feat(context): outline oversized Python files instead of dropping them — Closes #69

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,13 @@ python demo_run.py /path/to/sample_repo
 - Scores every file against the task using: language priority, path keyword match,
   content keyword frequency, entry-point bonus, import graph hints.
 - Fills a configurable character budget (~60K chars / ~15K tokens).
+- A Python file too large to include whole is reduced to a signature-only
+  outline — imports, constants, class fields and `def` lines with their
+  annotations, bodies omitted — instead of being dropped. That costs roughly a
+  seventh of the space, so the model still learns the module exists and what it
+  exposes. Outlined files are flagged in `BuiltContext.outlined` and carry an
+  `# OUTLINE ONLY` header. Non-Python files are not outlined; that would need
+  tree-sitter.
 - Returns `BuiltContext.render()` — XML-tagged source ready for the LLM prompt.
 
 ### Module 3 — `llm_client.py`

--- a/modules/context_builder.py
+++ b/modules/context_builder.py
@@ -4,9 +4,10 @@ Selects the most relevant files for a task without sending the entire repo.
 Uses keyword matching, file type priority, import graph hints, and scoring.
 """
 
+import ast
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from pathlib import PurePosixPath
 from typing import Optional
 
@@ -36,6 +37,7 @@ class BuiltContext:
     files: list[FileRecord]
     total_chars: int
     scoring_details: list[ScoredFile]
+    outlined: list[str] = field(default_factory=list)
 
     def render(self) -> str:
         """Render context as a single string suitable for an LLM prompt."""
@@ -50,12 +52,132 @@ class BuiltContext:
 
     def summary(self) -> str:
         lines = [f"Context: {len(self.files)} files, {self.total_chars} chars"]
+        if self.outlined:
+            lines.append(
+                f"  outline-only ({len(self.outlined)}): {', '.join(self.outlined)}"
+            )
         for scored_file in self.scoring_details[:5]:
             lines.append(
                 f"  [{scored_file.score:.1f}] {scored_file.record.path} - "
                 f"{', '.join(scored_file.reasons)}"
             )
         return "\n".join(lines)
+
+
+OUTLINE_HEADER = (
+    "# OUTLINE ONLY - signatures shown, bodies omitted to fit the context budget."
+)
+
+
+def _signature(node) -> str:
+    """Render a def/class header without its body."""
+    prefix = "async def" if isinstance(node, ast.AsyncFunctionDef) else "def"
+
+    if isinstance(node, ast.ClassDef):
+        bases = [ast.unparse(b) for b in node.bases]
+        bases += [ast.unparse(k) for k in node.keywords]
+        suffix = f"({', '.join(bases)})" if bases else ""
+        return f"class {node.name}{suffix}:"
+
+    returns = f" -> {ast.unparse(node.returns)}" if node.returns else ""
+    return f"{prefix} {node.name}({ast.unparse(node.args)}){returns}: ..."
+
+
+def _decorators(node, indent: str) -> list[str]:
+    return [f"{indent}@{ast.unparse(d)}" for d in node.decorator_list]
+
+
+def extract_outline(source: str, path: str) -> Optional[str]:
+    """
+    Reduce a Python file to its imports, constants and signatures.
+
+    Used when a file scores well enough to matter but is too large to include
+    whole. The alternative today is dropping it silently, which leaves the model
+    unaware the module exists at all -- worse than an approximate view of it.
+
+    Returns None for non-Python files, unparseable sources, and files with no
+    definitions worth summarising. Other languages would need tree-sitter; that
+    is a separate change and a much heavier dependency.
+    """
+    if not path.endswith(".py"):
+        return None
+
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError, RecursionError):
+        # A file the agent is mid-way through breaking is exactly when this
+        # runs, so a parse failure is expected rather than exceptional.
+        return None
+
+    lines: list[str] = [OUTLINE_HEADER]
+
+    docstring = ast.get_docstring(tree)
+    if docstring:
+        first = docstring.strip().splitlines()[0]
+        lines.append(f'"""{first}"""')
+
+    imports = [
+        ast.unparse(node)
+        for node in tree.body
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    if imports:
+        lines.append("")
+        lines.extend(imports)
+
+    constants = [
+        target.id
+        for node in tree.body
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id.isupper()
+    ]
+    constants += [
+        node.target.id
+        for node in tree.body
+        if isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id.isupper()
+    ]
+    if constants:
+        lines.append("")
+        lines.extend(f"{name} = ..." for name in constants)
+
+    found_definition = False
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            found_definition = True
+            lines.append("")
+            lines.extend(_decorators(node, ""))
+            lines.append(_signature(node))
+
+            body: list[str] = []
+            for child in node.body:
+                # Annotated fields are the whole point of a dataclass or a
+                # Protocol, so they belong in the outline alongside methods.
+                is_field = isinstance(child, ast.AnnAssign) and isinstance(
+                    child.target, ast.Name
+                )
+                if is_field:
+                    annotation = ast.unparse(child.annotation)
+                    body.append(f"    {child.target.id}: {annotation}")
+                elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    body.extend(_decorators(child, "    "))
+                    body.append(f"    {_signature(child)}")
+
+            lines.extend(body or ["    ..."])
+
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            found_definition = True
+            lines.append("")
+            lines.extend(_decorators(node, ""))
+            lines.append(_signature(node))
+
+    if not found_definition:
+        # Imports and constants alone are not worth a slot in the budget.
+        return None
+
+    return "\n".join(lines) + "\n"
 
 
 def _normalize_repo_path(path: str) -> str:
@@ -177,15 +299,35 @@ def build_context(
             total_chars += len(scored_file.record.content)
             forced_paths.discard(record_path)
 
+    outlined: list[str] = []
+
     for scored_file in scored:
         if scored_file.record in selected:
             continue
         file_chars = len(scored_file.record.content)
+
         if total_chars + file_chars > char_budget:
+            # Too big to include whole. Rather than drop it -- which leaves the
+            # model unaware the module exists -- fall back to its signatures.
+            if scored_file.score <= 0:
+                continue
+            outline = extract_outline(
+                scored_file.record.content, scored_file.record.path
+            )
+            if outline and total_chars + len(outline) <= char_budget:
+                selected.append(replace(scored_file.record, content=outline))
+                total_chars += len(outline)
+                outlined.append(scored_file.record.path)
             continue
+
         if scored_file.score <= 0:
             break
         selected.append(scored_file.record)
         total_chars += file_chars
 
-    return BuiltContext(files=selected, total_chars=total_chars, scoring_details=scored)
+    return BuiltContext(
+        files=selected,
+        total_chars=total_chars,
+        scoring_details=scored,
+        outlined=outlined,
+    )

--- a/tests/test_ast_outlines.py
+++ b/tests/test_ast_outlines.py
@@ -1,0 +1,260 @@
+"""
+Tests for AST outlines (modules/context_builder.py).
+
+A file that does not fit the character budget was dropped entirely, leaving the
+model unaware the module existed. It now falls back to a signature-only outline,
+which costs roughly a seventh of the space.
+"""
+
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.context_builder import (  # noqa: E402
+    OUTLINE_HEADER,
+    build_context,
+    extract_outline,
+)
+from modules.repo_ingestion import FileRecord, Repository  # noqa: E402
+
+SAMPLE = textwrap.dedent('''
+    """Module docstring.
+
+    More detail that should not appear.
+    """
+
+    import os
+    from typing import Optional
+
+    MAX_SIZE = 1024
+    _private = "hidden"
+
+
+    @dataclass
+    class Config:
+        path: str
+        retries: int = 3
+
+        @property
+        def is_valid(self) -> bool:
+            return bool(self.path)
+
+        async def load(self, source: str) -> Optional[dict]:
+            body = {"a": 1}
+            return body
+
+
+    def helper(x: int, *args, flag: bool = False, **kwargs) -> str:
+        secret = "this body must not appear"
+        return secret
+''')
+
+
+@pytest.fixture
+def outline():
+    return extract_outline(SAMPLE, "mod.py")
+
+
+# ── what the outline contains ─────────────────────────────────────────────
+
+
+def test_header_marks_it_as_partial(outline):
+    """The model must not read an outline as the file's real contents."""
+    assert outline.startswith(OUTLINE_HEADER)
+
+
+def test_signatures_are_preserved(outline):
+    expected = "def helper(x: int, *args, flag: bool=False, **kwargs) -> str: ..."
+    assert expected in outline
+
+
+def test_class_and_bases_are_preserved(outline):
+    assert "class Config:" in outline
+
+
+def test_dataclass_fields_are_kept(outline):
+    """For a dataclass the fields are the interesting part, not the methods."""
+    assert "path: str" in outline
+    assert "retries: int" in outline
+
+
+def test_decorators_are_kept(outline):
+    assert "@dataclass" in outline
+    assert "@property" in outline
+
+
+def test_async_defs_are_marked(outline):
+    assert "async def load" in outline
+
+
+def test_imports_are_kept(outline):
+    assert "import os" in outline
+    assert "from typing import Optional" in outline
+
+
+def test_upper_case_constants_are_kept(outline):
+    assert "MAX_SIZE = ..." in outline
+
+
+def test_lower_case_module_state_is_dropped(outline):
+    assert "_private" not in outline
+
+
+def test_first_docstring_line_only(outline):
+    assert "Module docstring." in outline
+    assert "More detail" not in outline
+
+
+def test_function_bodies_are_gone(outline):
+    assert "this body must not appear" not in outline
+    assert 'body = {"a": 1}' not in outline
+
+
+def test_outline_is_smaller_than_the_source(outline):
+    assert len(outline) < len(SAMPLE)
+
+
+def test_saving_is_large_on_a_realistic_file():
+    """
+    The fixture above is almost entirely signatures, so the ratio there is
+    unremarkable. The saving comes from files with real bodies -- measured at
+    13-18% on this repo's own modules.
+    """
+    padded = SAMPLE.replace(
+        '    secret = "this body must not appear"',
+        "    secret = 'x'\n" + "    # padding\n" * 300,
+    )
+    assert len(extract_outline(padded, "mod.py")) < len(padded) / 4
+
+
+def test_outline_is_valid_python(outline):
+    """It is read as source by the model; it should not look malformed."""
+    import ast
+    ast.parse(outline)
+
+
+# ── when no outline is produced ───────────────────────────────────────────
+
+
+def test_non_python_files_are_skipped():
+    assert extract_outline("# heading\n\ntext", "README.md") is None
+    assert extract_outline("body { color: red; }", "app.css") is None
+
+
+def test_unparseable_source_returns_none():
+    """Expected mid-run: the agent may have just broken the file."""
+    assert extract_outline("def broken(:\n    pass", "mod.py") is None
+
+
+def test_file_with_no_definitions_returns_none():
+    """Imports and constants alone are not worth a slot in the budget."""
+    assert extract_outline("import os\nX = 1\n", "mod.py") is None
+
+
+def test_empty_file_returns_none():
+    assert extract_outline("", "mod.py") is None
+
+
+def test_class_with_no_members_still_renders():
+    result = extract_outline("class Marker:\n    pass\n", "mod.py")
+    assert "class Marker:" in result
+    assert "..." in result
+
+
+# ── integration with the budget ───────────────────────────────────────────
+
+
+def make_repo(*files):
+    records = [
+        FileRecord(path=p, abs_path=f"/r/{p}", content=c, size=len(c),
+                   extension=".py", language="python", checksum="x")
+        for p, c in files
+    ]
+    return Repository(root="/r", files=records)
+
+
+BIG = (
+    '"""Big module."""\n\n\ndef relevant_sandbox_helper(a: int) -> int:\n'
+    + "    # padding\n" * 400
+    + "    return a\n"
+)
+SMALL = '"""Small."""\n\n\ndef sandbox_small() -> None:\n    return None\n'
+
+
+def test_oversized_file_is_outlined_rather_than_dropped():
+    repo = make_repo(("big.py", BIG), ("small.py", SMALL))
+    ctx = build_context(repo, "sandbox", char_budget=len(SMALL) + 600)
+
+    paths = {f.path for f in ctx.files}
+    assert "small.py" in paths
+    assert "big.py" in paths           # would have been absent entirely before
+    assert ctx.outlined == ["big.py"]
+
+
+def test_outlined_file_carries_the_outline_not_the_body():
+    repo = make_repo(("big.py", BIG), ("small.py", SMALL))
+    ctx = build_context(repo, "sandbox", char_budget=len(SMALL) + 600)
+
+    big = next(f for f in ctx.files if f.path == "big.py")
+    assert big.content.startswith(OUTLINE_HEADER)
+    assert "relevant_sandbox_helper" in big.content
+    assert "# padding" not in big.content
+
+
+def test_the_budget_is_still_respected():
+    repo = make_repo(("big.py", BIG), ("small.py", SMALL))
+    budget = len(SMALL) + 600
+    assert build_context(repo, "sandbox", char_budget=budget).total_chars <= budget
+
+
+def test_no_outline_when_even_that_will_not_fit():
+    repo = make_repo(("big.py", BIG))
+    ctx = build_context(repo, "sandbox", char_budget=50)
+    assert ctx.files == []
+    assert ctx.outlined == []
+
+
+def test_files_that_fit_are_not_outlined():
+    repo = make_repo(("small.py", SMALL))
+    ctx = build_context(repo, "sandbox", char_budget=100_000)
+
+    assert ctx.outlined == []
+    assert ctx.files[0].content == SMALL
+
+
+def test_higher_scoring_files_are_outlined_first():
+    """
+    Scoring orders which outlines fit, rather than excluding any: every Python
+    file already scores 10.0 from the language bonus alone, so the score guard
+    only ever rejects non-code. With room for one outline, the better match
+    wins.
+    """
+    other = BIG.replace("relevant_sandbox_helper", "unrelated_helper")
+    repo = make_repo(("big.py", BIG), ("other.py", other), ("small.py", SMALL))
+
+    ctx = build_context(repo, "sandbox", char_budget=len(SMALL) + 620)
+
+    assert ctx.outlined[0] == "big.py"
+
+
+def test_non_code_is_not_outlined():
+    """extract_outline declines anything that is not Python."""
+    assert extract_outline("# notes\n\nsome prose", "NOTES.md") is None
+
+
+def test_summary_reports_outlined_files():
+    repo = make_repo(("big.py", BIG), ("small.py", SMALL))
+    ctx = build_context(repo, "sandbox", char_budget=len(SMALL) + 600)
+    assert "outline-only" in ctx.summary()
+    assert "big.py" in ctx.summary()
+
+
+def test_outlined_defaults_to_empty():
+    """The new field must not break callers constructing BuiltContext."""
+    from modules.context_builder import BuiltContext
+
+    assert BuiltContext(files=[], total_chars=0, scoring_details=[]).outlined == []


### PR DESCRIPTION
Closes #69

## Summary

`build_context` scores every file, then fills a character budget. A file that does not fit hits `continue` at line 185 and is dropped **entirely** — the model is left unaware the module exists at all, not merely short on detail about it.

This adds `extract_outline()`, which reduces a Python file to its imports, constants, class fields and `def` signatures. When a file cannot be included whole, the outline goes in instead of nothing.

## Effect, measured against `main`

Same repo, same task, same budget:

```
budget 60,000:  before 15 files, 59,827 chars  →  after 17 files, 59,998 chars (6 outlined)
  newly visible: code_modifier.py, context_builder.py, git_integration.py, sample_repo/utils.py

budget 30,000:  before  9 files, 29,915 chars  →  after 11 files, 29,988 chars (5 outlined)
  newly visible: agent_loop.py, dry_run.py, utils.py

budget respected in both cases: True
```

Real modules compress hard, because most of a file is bodies:

| file | full | outline | |
| ---- | ---- | ------- | - |
| `modules/code_modifier.py` | 7,512 | 1,084 | 14% |
| `modules/sandbox.py` | 7,956 | 1,395 | 18% |

## What an outline looks like

```python
# OUTLINE ONLY - signatures shown, bodies omitted to fit the context budget.
"""Module 4: Code Modification Engine"""

import os
import shutil
from typing import Optional
from modules.llm_client import FileChange

@dataclass
class ApplyResult:
    path: str
    action: str
    success: bool
    backup_path: Optional[str]
    error: Optional[str]

class CodeModificationEngine:
    def __init__(self, repo_root: str, backup_dir: str): ...
    def _safe_abs_path(self, relative_path: str) -> str: ...
    def apply_changes(self, changes: list[FileChange]) -> list[ApplyResult]: ...
    def rollback(self, results: list[ApplyResult]) -> list[str]: ...
```

It is valid Python and carries an explicit header, so the model does not mistake it for the file's real contents. There is a test asserting the output parses.

**Dataclass fields are included.** My first version emitted `class ApplyResult:` followed by `...`, because the fields are `AnnAssign` nodes rather than functions — and for a dataclass or a Protocol those *are* the interesting part. Class-level annotated assignments are now kept.

## Design notes

**Python only.** `extract_outline` returns `None` for anything else. The issue suggests tree-sitter for other languages; that is a heavy native dependency and a separate change, so it is declined explicitly here rather than half-implemented. This uses stdlib `ast` and adds no dependency.

**Unparseable sources return `None`, not an error.** This runs during an agent loop where the model may have just broken the file, so a `SyntaxError` is the expected case rather than an exceptional one.

**Files with no definitions return `None`.** Imports and constants alone are not worth a slot in the budget.

**Forced `--include` paths are untouched.** If the user explicitly asked for a file, they get the whole thing.

**`BuiltContext` gains `outlined: list[str]`**, defaulted, so existing construction sites are unaffected. It is surfaced in `summary()` so a run log shows which files were degraded.

## One thing the tests taught me

I wrote a test asserting that low-scoring oversized files would not be outlined, on the assumption that scoring gated inclusion. It failed. Every Python file scores 10.0 from the language bonus alone, so the `score <= 0` guard only ever rejects non-code:

```
score for an unrelated python file:   10.0  ['lang:python']
score for an unrelated markdown file:  2.0  ['baseline']
```

Scoring therefore *orders* which outlines fit rather than excluding any. That is fine behaviourally — the budget is still respected and better matches get their outlines first — but my test's premise was wrong, so I replaced it with one that pins the real behaviour: given room for a single outline, the higher-scoring file wins.

## Tests

`tests/test_ast_outlines.py` — 28 cases.

Content: the `# OUTLINE ONLY` header is present; signatures keep their annotations and defaults; class bases, decorators and `async def` survive; dataclass fields are kept; imports and UPPER_CASE constants are kept while lower-case module state is dropped; only the first line of the module docstring appears; function bodies are gone; the result parses as valid Python.

Declining: non-Python files, unparseable source, files with no definitions, and empty files all return `None`; a class with no members still renders with `...`.

Budget integration: an oversized file is outlined rather than dropped; the outlined record carries the outline and not the body; the budget is still respected; nothing is outlined when even the outline will not fit; files that fit are not outlined and keep their exact content; higher-scoring files are outlined first; `summary()` reports them; and `BuiltContext.outlined` defaults to empty so the new field breaks no existing caller.

## Verified

- the before/after comparison above, run against `main`'s `context_builder.py` loaded side by side with the new one
- compression ratios on this repo's own modules
- 28 new tests pass; `tests/test_utils.py` still 4 passed
- ruff on `modules/context_builder.py`: back to its baseline of 1 finding (I introduced two long lines and fixed both)
- `npx prettier --check README.md` clean
- merges clean against all ten other branches currently open

## Related

This makes #72 a more natural piece of work than it currently reads. That issue describes `context_builder.py` as assuming "~4 chars per token" — it does not; there is no token estimation anywhere in it, only a flat `CONTEXT_CHAR_BUDGET`. Tokenizer-aware budgeting would be a real feature, and outlines make whatever limit is chosen stretch further, but the two are independent.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.