### PR TITLE
fix(git): refuse stale branch reuse and recover from rejected pushes — Closes #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,15 @@ python demo_run.py /path/to/sample_repo
 - Wraps `git` subprocess calls: `create_branch`, `stage_files`, `commit`, `push`.
 - GitHub PR creation via REST API (no extra dependencies — uses `urllib`).
 - `rollback` is handled by `code_modifier.py`; git ops are only for success path.
+- `create_branch` refuses to reuse an existing branch that does not already
+  contain the base branch, rather than checking it out and running the agent
+  against a stale tree.
+- A push rejected because the remote branch moved is retried once after
+  `git rebase`. A rebase that conflicts is aborted, leaving the working tree
+  untouched — an unattended agent cannot resolve conflicts, and a repository
+  left mid-rebase is worse than a failed push. Pass `retry_with_rebase=False`
+  to skip it. Other push failures (missing remote, auth, network, protected
+  branch) are classified and get a specific remedy appended to the error.
 
 ### Module 8 — `logger.py`
 

--- a/modules/git_integration.py
+++ b/modules/git_integration.py
@@ -22,6 +22,55 @@ class GitResult:
     error: str
 
 
+PUSH_REMEDIES = {
+    "non-fast-forward": (
+        "The remote branch has commits this one does not. A rebase was either "
+        "not attempted or did not resolve it -- fetch and rebase manually, or "
+        "push to a new branch name."
+    ),
+    "no-remote": (
+        "No such remote. Add one with `git remote add origin <url>`, or run "
+        "without --push."
+    ),
+    "auth": (
+        "Authentication failed. Check your SSH key or that GITHUB_TOKEN is set "
+        "and has push access to this repository."
+    ),
+    "network": (
+        "Could not reach the remote. Check connectivity and try again; the "
+        "commit is safe locally."
+    ),
+    "protected": (
+        "The remote refused the update -- the branch is likely protected, or a "
+        "hook rejected it. Push to a different branch and open a PR."
+    ),
+    "unknown": (
+        "Push failed. The commit is safe locally; push manually to inspect."
+    ),
+}
+
+
+def classify_push_failure(stderr: str) -> str:
+    """Map git's push error text onto a remedy key."""
+    text = (stderr or "").lower()
+    # Checked first: a protected-branch refusal may or may not also say
+    # "rejected", and rebasing would not help either way.
+    if any(k in text for k in ("protected branch", "pre-receive hook",
+                               "gh006", "protected")):
+        return "protected"
+    if "non-fast-forward" in text or "fetch first" in text or "rejected" in text:
+        return "non-fast-forward"
+    if "does not appear to be a git repository" in text or "no such remote" in text:
+        return "no-remote"
+    if any(k in text for k in ("permission denied", "authentication failed",
+                              "could not read username", "403")):
+        return "auth"
+    if any(k in text for k in ("could not resolve host", "connection timed out",
+                               "network is unreachable", "operation timed out")):
+        return "network"
+    return "unknown"
+
+
 class GitIntegration:
     def __init__(self, repo_root: str):
         self.repo_root = os.path.abspath(repo_root)
@@ -73,17 +122,53 @@ class GitIntegration:
         result = self._run(["git", "branch", "--show-current"])
         return result.output or "unknown"
 
+    def branch_exists(self, branch: str) -> bool:
+        return self._run(
+            ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"]
+        ).success
+
+    def _contains(self, ancestor: str, descendant: str) -> bool:
+        """True if `descendant` already contains every commit in `ancestor`."""
+        return self._run(
+            ["git", "merge-base", "--is-ancestor", ancestor, descendant]
+        ).success
+
     def create_branch(self, branch_name: str, from_branch: str = "main") -> GitResult:
-        """Create and checkout a new branch."""
+        """
+        Create and checkout a new branch off `from_branch`.
+
+        If the branch already exists, it is only reused when it already contains
+        the base branch's tip. Falling back to a plain checkout unconditionally
+        looks like success while silently putting the agent on a stale branch --
+        it then works against an out-of-date base and opens a PR from it.
+        """
         base = self._run(["git", "rev-parse", "--verify", from_branch])
         if not base.success:
             base = self._run(["git", "rev-parse", "--verify", "master"])
             from_branch = "master" if base.success else "HEAD"
 
         result = self._run(["git", "checkout", "-b", branch_name, from_branch])
-        if not result.success:
-            result = self._run(["git", "checkout", branch_name])
-        return result
+        if result.success:
+            return result
+
+        if not self.branch_exists(branch_name):
+            # Failed for some other reason -- uncommitted changes in the way,
+            # an invalid name. Report it rather than papering over it.
+            return result
+
+        if not self._contains(from_branch, branch_name):
+            return GitResult(
+                command=f"git checkout -b {branch_name} {from_branch}",
+                success=False,
+                output="",
+                error=(
+                    f"Branch '{branch_name}' already exists and does not contain "
+                    f"'{from_branch}'. Checking it out would run the agent against "
+                    f"a stale base. Delete it, or choose another branch name."
+                ),
+            )
+
+        return self._run(["git", "checkout", branch_name])
 
     def stage_all(self) -> GitResult:
         """Stage all modified and new files."""
@@ -127,12 +212,83 @@ class GitIntegration:
         except Exception as exc:
             return GitResult(command=" ".join(cmd), success=False, output="", error=str(exc))
 
-    def push(self, branch: str, remote: str = "origin", force: bool = False) -> GitResult:
-        """Push branch to remote."""
-        cmd = ["git", "push", remote, branch]
+    def rebase_onto_remote(self, branch: str, remote: str = "origin") -> GitResult:
+        """
+        Fetch the remote branch and rebase onto it.
+
+        A rebase that hits conflicts is aborted rather than left half-applied --
+        an unattended agent has no way to resolve them, and stopping mid-rebase
+        would leave the user's working tree in a state they did not ask for.
+        """
+        fetch = self._run(["git", "fetch", remote, branch])
+        if not fetch.success:
+            return fetch
+
+        rebase = self._run(["git", "rebase", f"{remote}/{branch}"])
+        if rebase.success:
+            return rebase
+
+        self._run(["git", "rebase", "--abort"])
+        return GitResult(
+            command=f"git rebase {remote}/{branch}",
+            success=False,
+            output=rebase.output,
+            error=(
+                f"Rebase onto {remote}/{branch} hit conflicts and was aborted; "
+                f"the working tree is unchanged. Resolve manually, or push to a "
+                f"new branch name.\n{rebase.error}"
+            ),
+        )
+
+    def push(
+        self,
+        branch: str,
+        remote: str = "origin",
+        force: bool = False,
+        retry_with_rebase: bool = True,
+        set_upstream: bool = True,
+    ) -> GitResult:
+        """
+        Push `branch` to `remote`, recovering from a diverged remote branch.
+
+        A rejected push is the one git failure worth retrying automatically: it
+        means the remote branch moved, and rebasing on top is what a person
+        would do. Everything else (missing remote, auth, network) gets a
+        diagnosis appended instead, because retrying will not help.
+        """
+        cmd = ["git", "push"]
+        if set_upstream:
+            cmd.append("--set-upstream")
+        cmd += [remote, branch]
         if force:
             cmd.append("--force-with-lease")
-        return self._run(cmd)
+
+        result = self._run(cmd)
+        if result.success:
+            return result
+
+        reason = classify_push_failure(result.error)
+
+        if reason == "non-fast-forward" and retry_with_rebase and not force:
+            rebase = self.rebase_onto_remote(branch, remote)
+            if rebase.success:
+                retried = self._run(cmd)
+                if retried.success:
+                    return retried
+                result = retried
+                reason = classify_push_failure(retried.error)
+            else:
+                return GitResult(
+                    command=" ".join(cmd), success=False,
+                    output=result.output, error=rebase.error,
+                )
+
+        return GitResult(
+            command=" ".join(cmd),
+            success=False,
+            output=result.output,
+            error=f"{result.error}\n\n{PUSH_REMEDIES[reason]}",
+        )
 
     def diff_staged(self) -> str:
         """Return the staged diff as a string for PR descriptions."""

--- a/tests/test_git_failures.py
+++ b/tests/test_git_failures.py
@@ -1,0 +1,274 @@
+"""
+Tests for git failure handling (modules/git_integration.py).
+
+Two real failures are covered. `create_branch` used to fall back to a plain
+checkout when `checkout -b` failed, which reported success while putting the
+agent on a pre-existing branch that did not contain the base — it then worked
+against a stale tree. And a rejected push returned git's raw stderr with no
+diagnosis and no recovery.
+
+The integration tests drive real repositories; they skip if git is unavailable.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.git_integration import (  # noqa: E402
+    PUSH_REMEDIES,
+    GitIntegration,
+    classify_push_failure,
+)
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+
+
+def run(cwd, *args):
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def remote(tmp_path):
+    path = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(path)], check=True)
+    return path
+
+
+@pytest.fixture
+def repo(tmp_path, remote):
+    """A clone with one commit on `main`, pushed."""
+    path = tmp_path / "work"
+    subprocess.run(["git", "clone", "-q", str(remote), str(path)], check=True)
+    run(path, "config", "user.email", "t@example.com")
+    run(path, "config", "user.name", "Test")
+    run(path, "checkout", "-qb", "main")
+    (path / "f.txt").write_text("v1\n")
+    run(path, "add", "-A")
+    run(path, "commit", "-qm", "init")
+    run(path, "push", "-q", "-u", "origin", "main")
+    return path
+
+
+@pytest.fixture
+def git(repo):
+    return GitIntegration(str(repo))
+
+
+def commit(git_obj, repo_path, name, content):
+    (repo_path / name).write_text(content)
+    git_obj.stage_all()
+    git_obj.commit(f"add {name}")
+
+
+# ── classifying push failures ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stderr,expected",
+    [
+        ("! [rejected] main -> main (fetch first)", "non-fast-forward"),
+        ("Updates were rejected because the remote contains work", "non-fast-forward"),
+        ("remote: error: GH006: Protected branch update failed", "protected"),
+        ("'origin' does not appear to be a git repository", "no-remote"),
+        ("Permission denied (publickey).", "auth"),
+        ("fatal: Authentication failed for 'https://github.com/x'", "auth"),
+        ("could not read Username for 'https://github.com'", "auth"),
+        ("ssh: Could not resolve hostname github.com", "network"),
+        ("something nobody has seen before", "unknown"),
+        ("", "unknown"),
+    ],
+)
+def test_push_failures_are_classified(stderr, expected):
+    assert classify_push_failure(stderr) == expected
+
+
+def test_every_reason_has_a_remedy():
+    """A classification with no advice attached is no better than raw stderr."""
+    for reason in set(PUSH_REMEDIES):
+        assert PUSH_REMEDIES[reason].strip()
+
+
+# ── create_branch ─────────────────────────────────────────────────────────
+
+
+def test_creates_a_branch_off_the_base(git):
+    assert git.create_branch("agent/a", "main").success is True
+    assert git.current_branch() == "agent/a"
+
+
+def test_stale_existing_branch_is_refused(git, repo):
+    """
+    The regression this PR exists for: reusing the name silently put the agent
+    on a branch missing the base branch's newer commits.
+    """
+    git.create_branch("agent/a", "main")
+    commit(git, repo, "old.txt", "work from an earlier run\n")
+
+    run(repo, "checkout", "-q", "main")
+    commit(git, repo, "new.txt", "main has moved on\n")
+
+    result = git.create_branch("agent/a", "main")
+
+    assert result.success is False
+    assert "stale" in result.error
+    assert git.current_branch() == "main"  # not switched onto the stale branch
+
+
+def test_up_to_date_existing_branch_is_reused(git):
+    """Reuse is only dangerous when the branch is behind the base."""
+    git.create_branch("agent/a", "main")
+    run(git.repo_root, "checkout", "-q", "main")
+
+    result = git.create_branch("agent/a", "main")
+
+    assert result.success is True
+    assert git.current_branch() == "agent/a"
+
+
+def test_missing_base_branch_falls_back(git):
+    """Pre-existing behaviour: fall back rather than fail outright."""
+    assert git.create_branch("agent/b", "does-not-exist").success is True
+
+
+def test_branch_exists_reports_accurately(git):
+    assert git.branch_exists("agent/c") is False
+    git.create_branch("agent/c", "main")
+    assert git.branch_exists("agent/c") is True
+
+
+# ── push ──────────────────────────────────────────────────────────────────
+
+
+def test_pushing_a_new_branch_succeeds(git, repo):
+    """
+    An advanced base branch does not break a push of a new branch — worth
+    pinning, since the issue assumed otherwise.
+    """
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "a.txt", "work\n")
+    assert git.push("agent/p").success is True
+
+
+def test_push_sets_upstream(git, repo):
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "a.txt", "work\n")
+    git.push("agent/p")
+
+    tracking = run(repo, "rev-parse", "--abbrev-ref", "agent/p@{upstream}")
+    assert tracking.stdout.strip() == "origin/agent/p"
+
+
+def diverge_remote(tmp_path, remote, branch, filename, content):
+    """Land a commit on `branch` from a second clone."""
+    other = tmp_path / f"other-{filename}"
+    subprocess.run(["git", "clone", "-q", str(remote), str(other)], check=True)
+    run(other, "config", "user.email", "o@example.com")
+    run(other, "config", "user.name", "Other")
+    run(other, "checkout", "-q", branch)
+    (other / filename).write_text(content)
+    run(other, "add", "-A")
+    run(other, "commit", "-qm", f"other {filename}")
+    run(other, "push", "-q", "origin", branch)
+
+
+def test_diverged_remote_is_rebased_and_retried(git, repo, tmp_path, remote):
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "ours.txt", "ours\n")
+    git.push("agent/p")
+
+    diverge_remote(tmp_path, remote, "agent/p", "theirs.txt", "theirs\n")
+
+    commit(git, repo, "ours2.txt", "ours again\n")
+    result = git.push("agent/p")
+
+    assert result.success is True
+    assert (repo / "theirs.txt").exists()  # their commit was rebased in
+
+
+def test_conflicting_rebase_is_aborted(git, repo, tmp_path, remote):
+    """
+    An unattended agent cannot resolve conflicts. Leaving the repository
+    mid-rebase would be a worse outcome than a failed push.
+    """
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "shared.txt", "ours\n")
+    git.push("agent/p")
+
+    diverge_remote(tmp_path, remote, "agent/p", "shared.txt", "theirs\n")
+
+    (repo / "shared.txt").write_text("ours changed\n")
+    git.stage_all()
+    git.commit("ours conflicting")
+
+    result = git.push("agent/p")
+
+    assert result.success is False
+    assert "aborted" in result.error
+    assert not (repo / ".git" / "rebase-merge").exists()
+    assert not (repo / ".git" / "rebase-apply").exists()
+    assert (repo / "shared.txt").read_text() == "ours changed\n"
+
+
+def test_rebase_retry_can_be_disabled(git, repo, tmp_path, remote):
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "ours.txt", "ours\n")
+    git.push("agent/p")
+
+    diverge_remote(tmp_path, remote, "agent/p", "theirs.txt", "theirs\n")
+
+    commit(git, repo, "ours2.txt", "ours again\n")
+    result = git.push("agent/p", retry_with_rebase=False)
+
+    assert result.success is False
+    assert not (repo / "theirs.txt").exists()  # no rebase happened
+
+
+def test_failed_push_error_carries_a_remedy(git, repo, tmp_path, remote):
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "ours.txt", "ours\n")
+    git.push("agent/p")
+
+    diverge_remote(tmp_path, remote, "agent/p", "theirs.txt", "theirs\n")
+
+    commit(git, repo, "ours2.txt", "ours again\n")
+    result = git.push("agent/p", retry_with_rebase=False)
+
+    assert PUSH_REMEDIES["non-fast-forward"] in result.error
+
+
+def test_missing_remote_is_diagnosed(git, repo):
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "a.txt", "work\n")
+
+    result = git.push("agent/p", remote="nope")
+
+    assert result.success is False
+    assert PUSH_REMEDIES["no-remote"] in result.error
+
+
+def test_the_commit_survives_a_failed_push(git, repo):
+    """The wording of every remedy promises this; it should be true."""
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "a.txt", "work\n")
+    head_before = run(repo, "rev-parse", "HEAD").stdout.strip()
+
+    git.push("agent/p", remote="nope")
+
+    assert run(repo, "rev-parse", "HEAD").stdout.strip() == head_before
+
+
+# ── rebase_onto_remote ────────────────────────────────────────────────────
+
+
+def test_rebase_reports_a_missing_remote_branch(git, repo):
+    git.create_branch("agent/p", "main")
+    commit(git, repo, "a.txt", "work\n")
+
+    assert git.rebase_onto_remote("agent/never-pushed").success is False


### PR DESCRIPTION
Closes #57

## Summary

Two failure paths in `git_integration.py`: `create_branch` silently reused a stale branch, and a rejected push returned raw stderr with no diagnosis and no recovery. Both are addressed here.

Worth saying up front: the mechanism the issue describes does not reproduce, but something worse does.

## The stated cause does not happen

> if the base branch has advanced since the `AutonomousAgent` started, a git push might fail

I set up a real bare remote and tested it. Pushing a *new* branch succeeds no matter how far the base has advanced — `git push origin <new-branch>` has nothing to fast-forward against, so an advanced base is irrelevant to it. There is now a test pinning that, because it is a natural thing to assume and worth having written down.

A push is only rejected when the *remote branch itself* already exists and has diverged. That case is real and is handled below.

## The real bug: `create_branch` fails silently

```python
result = self._run(["git", "checkout", "-b", branch_name, from_branch])
if not result.success:
    result = self._run(["git", "checkout", branch_name])   # <- unconditional
return result
```

If `checkout -b` fails because the branch already exists, the fallback checks it out and reports success — regardless of what that branch contains. Reproduced against a real repository:

```
run 1: agent/x created off main, work committed
       main then advances with a new commit
run 2: create_branch("agent/x", "main")
         reported success : True
         landed on        : agent/x
         file content     : run1      <- main's newer commit is not present
```

The agent then reads an out-of-date tree, applies changes against it, commits, and opens a PR from it. This is the "branch creation might result in conflicts" the issue is pointing at, and it is worse than a failure would be, because nothing reports it.

An existing branch is now only reused when `git merge-base --is-ancestor <base> <branch>` confirms it already contains the base tip. Otherwise the call fails with an explanation and leaves you where you were:

```
Branch 'agent/x' already exists and does not contain 'main'. Checking it out
would run the agent against a stale base. Delete it, or choose another branch name.
```

A `checkout -b` that fails for any *other* reason — uncommitted changes in the way, an invalid name — is now returned as-is rather than being masked by the fallback.

## Push: recover where recovery makes sense

A diverged remote branch is the one git failure worth retrying automatically, because rebasing on top is exactly what a person would do. `push()` now does that once, then retries. Verified end to end: the other clone's commit is rebased in and the push succeeds.

**The safety property that matters is the conflict case.** A rebase that conflicts is aborted, not left half-applied:

```
success            : False
error              : Rebase onto origin/agent/fresh hit conflicts and was aborted;
                     the working tree is unchanged.
mid-rebase         : False
our content intact : ours-conflict
```

An unattended agent cannot resolve conflicts, and a repository stuck mid-rebase is a worse outcome than a failed push — the user did not ask for that state and may not notice it. `retry_with_rebase=False` skips the whole mechanism.

Everything else is classified rather than retried, because retrying would not help, and gets a specific remedy appended to the error: missing remote, auth failure, network, protected branch. Each remedy tells the user the commit is safe locally, which it is — there is a test asserting `HEAD` does not move on a failed push.

`push()` also passes `--set-upstream` now, so the branch tracks its remote.

## One bug my own test caught

I wrote a case for GitHub's protected-branch refusal and it failed. `remote: error: GH006: Protected branch update failed` contains neither "rejected" nor "fetch first", so it fell through to `unknown` — and the protected check was nested *inside* the non-fast-forward branch, where it could never be reached for that message. The classifier now checks protected first. A real rejection message still classifies as `non-fast-forward`, verified against actual git output.

## Tests

`tests/test_git_failures.py` — 25 cases. The integration tests drive real bare remotes and clones in temp directories; they skip if git is unavailable.

Classification: ten parametrised stderr samples covering non-fast-forward, protected, missing remote, three auth variants, network, unknown, and empty. Plus an assertion that every reason has a non-empty remedy — a classification with no advice attached is no better than raw stderr.

`create_branch`: creates off the base; refuses a stale existing branch and does not switch onto it; still reuses an up-to-date one; still falls back when the base branch does not exist; `branch_exists` reports accurately.

`push`: a new branch pushes even with an advanced base; upstream is set; a diverged remote is rebased and retried, with the other clone's file present afterwards; a conflicting rebase is aborted with no `rebase-merge`/`rebase-apply` left behind and our content unchanged; `retry_with_rebase=False` skips it; a failed push carries the right remedy; a missing remote is diagnosed; and the commit survives a failed push.

`rebase_onto_remote`: reports failure for a branch that was never pushed.

## Verified

- every scenario above run against real repositories, before and after
- 25 tests pass; `tests/test_utils.py` still 4 passed
- ruff on `modules/git_integration.py`: 3 findings before, 2 after — the two remaining are both pre-existing long lines
- `npx prettier --check README.md` clean
- merges clean against all eleven other branches, including a semantic check against #51, which also edits this file — `diff_unstaged`, `push`, `rebase_onto_remote` and `create_branch` all coexist and 47 tests pass on the merged tree

## Deliberately out of scope

`agent_loop.py` treats a failed push as non-fatal: the outcome stays `success` and the run reports completion with no PR. Surfacing that in the outcome would be a genuine improvement, but this issue names `git_integration.py` specifically, and `agent_loop.py` currently has open PRs against it. The improved error text does reach the run log through the existing `log_git` call. Happy to do the loop-side change separately.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.