### PR TITLE
feat(llm): track token spend and stop at --max-cost — Closes #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,13 @@ python demo_run.py /path/to/sample_repo
 - System prompt enforces a machine-parseable output schema.
 - `initial_request()` for first pass; `retry_request()` for error-fed retries.
 - Parses `FileChange[]` from JSON; gracefully handles malformed output.
+- Accumulates token usage per call and prices it from a table of published
+  per-model rates. `--max-cost 1.00` stops before the next call once that much
+  has been spent, so a runaway retry loop halts instead of billing indefinitely.
+- The limit is a stop condition rather than a pre-authorisation: a call's cost
+  is only known once it returns, so spend can exceed the limit by at most one
+  call. An unrecognised model falls back to default pricing rather than
+  reporting $0.00 — a budget that silently costs nothing is worse than none.
 
 ### Module 4 — `code_modifier.py`
 

--- a/main.py
+++ b/main.py
@@ -92,6 +92,9 @@ Examples:
                         help="Anthropic API key (default: ANTHROPIC_API_KEY env var)")
 
     # Non-interactive / CI
+    parser.add_argument("--max-cost", type=float, default=None, metavar="USD",
+                        help="Stop before the next LLM call once this much has been "
+                             "spent (e.g. --max-cost 1.00). Off by default.")
     parser.add_argument("--yes", "-y", action="store_true",
                         help="Auto-approve file changes (bypass confirmation prompt)")
 
@@ -164,6 +167,7 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+        max_cost_usd=args.max_cost,
     )
 
     try:

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -22,7 +22,12 @@ from typing import Optional
 
 from modules.repo_ingestion import ingest_repository, Repository
 from modules.context_builder import build_context
-from modules.llm_client import LLMClient, LLMResponse, FileChange
+from modules.llm_client import (
+    BudgetExceededError,
+    FileChange,
+    LLMClient,
+    LLMResponse,
+)
 from modules.code_modifier import CodeModificationEngine, ApplyResult
 from modules.sandbox import SubprocessSandbox, ExecutionResult
 from modules.git_integration import GitIntegration
@@ -66,6 +71,7 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
+    max_cost_usd: Optional[float] = None
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
@@ -74,7 +80,7 @@ class AgentConfig:
 @dataclass
 class AgentRunResult:
     run_id: str
-    outcome: str        # success | failed | max_retries | error
+    outcome: str        # success | failed | max_retries | error | budget_exceeded
     branch_name: Optional[str]
     pr_url: Optional[str]
     iterations_used: int
@@ -98,7 +104,9 @@ class AutonomousAgent:
 
         # Instantiate modules
         self.logger = AgentLogger(self.log_dir, self.run_id, verbose=True)
-        self.llm = LLMClient(api_key=cfg.anthropic_api_key)
+        self.llm = LLMClient(
+            api_key=cfg.anthropic_api_key, max_cost_usd=cfg.max_cost_usd
+        )
         self.modifier = CodeModificationEngine(cfg.repo_root, self.backup_dir)
         self.sandbox = SubprocessSandbox(cfg.repo_root, timeout_seconds=cfg.timeout_seconds)
 
@@ -204,6 +212,12 @@ class AutonomousAgent:
                         stderr=last_exec.stderr,
                         exit_code=last_exec.exit_code,
                     )
+            except BudgetExceededError as e:
+                # A deliberate stop, not a failure. Reported separately so the
+                # run log distinguishes "ran out of money" from "the API broke".
+                self.logger.warning(f"  {e}")
+                outcome = "budget_exceeded"
+                break
             except Exception as e:
                 self.logger.error(f"LLM call failed: {e}")
                 outcome = "error"
@@ -396,12 +410,19 @@ class AutonomousAgent:
                         self.logger.info(f"  PR created: {pr_url}")
 
         # ── Rollback on failure if rollback_on_failure ──
-        if outcome in ("failed", "max_retries", "error") and last_apply_results:
+        if (
+            outcome in ("failed", "max_retries", "error", "budget_exceeded")
+            and last_apply_results
+        ):
             self.logger.warning("  Rolling back file changes due to failed run...")
             restored = self.modifier.rollback(last_apply_results)
             self.logger.info(f"  Rolled back {len(restored)} file(s): {restored}")
 
         final_message = {
+            "budget_exceeded": (
+                f"Stopped at the --max-cost limit after {self.llm.usage.summary()}. "
+                f"Any applied changes were rolled back."
+            ),
             "success": "Task completed successfully. Tests pass.",
             "failed": "Task could not be completed. Check logs.",
             "max_retries": f"Exhausted {cfg.max_iterations} iterations without passing tests.",

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -20,6 +20,56 @@ except ImportError:
 MODEL = "claude-sonnet-4-20250514"
 MAX_TOKENS = 8192
 
+# USD per million tokens. Published rates, kept in one place so a price change
+# is a one-line edit rather than a hunt. An unknown model falls back to the
+# default rather than silently costing nothing -- a budget that reports $0.00
+# for an unrecognised model is worse than no budget at all.
+PRICING_PER_MTOK = {
+    "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+    "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
+    "claude-3-5-haiku-20241022": {"input": 0.80, "output": 4.00},
+}
+DEFAULT_PRICING = {"input": 3.00, "output": 15.00}
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when the accumulated spend has reached --max-cost."""
+
+
+@dataclass
+class UsageTracker:
+    """Running token and cost total for one client."""
+
+    model: str = MODEL
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    @property
+    def pricing(self) -> dict:
+        return PRICING_PER_MTOK.get(self.model, DEFAULT_PRICING)
+
+    @property
+    def cost_usd(self) -> float:
+        rates = self.pricing
+        return (
+            self.input_tokens * rates["input"]
+            + self.output_tokens * rates["output"]
+        ) / 1_000_000
+
+    def record(self, response) -> None:
+        """Add one API response. Tolerates a client that reports no usage."""
+        usage = getattr(response, "usage", None)
+        self.calls += 1
+        self.input_tokens += int(getattr(usage, "input_tokens", 0) or 0)
+        self.output_tokens += int(getattr(usage, "output_tokens", 0) or 0)
+
+    def summary(self) -> str:
+        return (
+            f"{self.calls} call(s), {self.input_tokens:,} in / "
+            f"{self.output_tokens:,} out tokens, ${self.cost_usd:.4f}"
+        )
+
 # ─────────────────────────────────────────────
 # Prompt Templates
 # ─────────────────────────────────────────────
@@ -123,7 +173,12 @@ class LLMResponse:
 # ─────────────────────────────────────────────
 
 class LLMClient:
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        max_cost_usd: Optional[float] = None,
+        model: str = MODEL,
+    ):
         if not _ANTHROPIC_AVAILABLE:
             raise RuntimeError(
                 "anthropic package not installed. Run: pip install anthropic"
@@ -132,17 +187,40 @@ class LLMClient:
         if not key:
             raise ValueError("ANTHROPIC_API_KEY not set")
         self.client = anthropic.Anthropic(api_key=key)
+        self.model = model
+        self.max_cost_usd = max_cost_usd
+        self.usage = UsageTracker(model=model)
+
+    def _check_budget(self) -> None:
+        """
+        Stop before the next call once the limit is reached.
+
+        The cost of a call is only known after it returns, so this is a stop
+        condition rather than a pre-authorisation: spend can overshoot the limit
+        by at most one call. Set the limit slightly below what you can actually
+        afford.
+        """
+        if self.max_cost_usd is None:
+            return
+        if self.usage.cost_usd >= self.max_cost_usd:
+            raise BudgetExceededError(
+                f"Cost limit reached: spent ${self.usage.cost_usd:.4f} of "
+                f"${self.max_cost_usd:.2f} after {self.usage.summary()}. "
+                f"Stopping before the next call."
+            )
 
     def _call(self, prompt: str, retries: int = 3) -> str:
         """Raw API call with retry on transient errors."""
+        self._check_budget()
         for attempt in range(retries):
             try:
                 response = self.client.messages.create(
-                    model=MODEL,
+                    model=self.model,
                     max_tokens=MAX_TOKENS,
                     system=SYSTEM_PROMPT,
                     messages=[{"role": "user", "content": prompt}],
                 )
+                self.usage.record(response)
                 return response.content[0].text
             except Exception as e:
                 if attempt == retries - 1:

--- a/tests/test_cost_budget.py
+++ b/tests/test_cost_budget.py
@@ -1,0 +1,254 @@
+"""
+Tests for the cost budget (modules/llm_client.py).
+
+An agent that retries can loop, and every iteration is a paid API call. These
+pin the accounting and the stop condition. Nothing here contacts the API — the
+Anthropic client is replaced with a stub that reports usage.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.llm_client import (  # noqa: E402
+    DEFAULT_PRICING,
+    PRICING_PER_MTOK,
+    BudgetExceededError,
+    LLMClient,
+    UsageTracker,
+)
+
+SONNET = "claude-sonnet-4-20250514"
+
+
+def _agent_loop_source() -> str:
+    """
+    Read agent_loop.py as UTF-8.
+
+    Path.read_text() defaults to the locale encoding, which is cp1252 on a
+    default Windows install -- the module's box-drawing section comments then
+    decode to mojibake and any search against them silently fails.
+    """
+    path = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    return path.read_text(encoding="utf-8")
+VALID_JSON = '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
+
+
+def stub_response(in_tokens=100_000, out_tokens=20_000, usage=True):
+    return SimpleNamespace(
+        content=[SimpleNamespace(text=VALID_JSON)],
+        usage=(
+            SimpleNamespace(input_tokens=in_tokens, output_tokens=out_tokens)
+            if usage else None
+        ),
+    )
+
+
+class StubMessages:
+    def __init__(self, response_factory=stub_response):
+        self.calls = 0
+        self._factory = response_factory
+
+    def create(self, **kwargs):
+        self.calls += 1
+        self.last_kwargs = kwargs
+        return self._factory()
+
+
+def make_client(max_cost_usd=None, model=SONNET, response_factory=stub_response):
+    """Build an LLMClient without needing an API key or the anthropic package."""
+    client = object.__new__(LLMClient)
+    client.client = SimpleNamespace(messages=StubMessages(response_factory))
+    client.model = model
+    client.max_cost_usd = max_cost_usd
+    client.usage = UsageTracker(model=model)
+    return client
+
+
+# ── accounting ────────────────────────────────────────────────────────────
+
+
+def test_cost_matches_published_rates():
+    usage = UsageTracker(model=SONNET)
+    usage.input_tokens = 1_000_000
+    usage.output_tokens = 1_000_000
+    # $3/Mtok in + $15/Mtok out
+    assert usage.cost_usd == pytest.approx(18.00)
+
+
+def test_input_and_output_are_priced_differently():
+    only_in = UsageTracker(model=SONNET)
+    only_in.input_tokens = 1_000_000
+    only_out = UsageTracker(model=SONNET)
+    only_out.output_tokens = 1_000_000
+
+    assert only_out.cost_usd > only_in.cost_usd
+
+
+@pytest.mark.parametrize("model", sorted(PRICING_PER_MTOK))
+def test_every_priced_model_has_both_rates(model):
+    assert PRICING_PER_MTOK[model]["input"] > 0
+    assert PRICING_PER_MTOK[model]["output"] > 0
+
+
+def test_unknown_model_falls_back_rather_than_costing_nothing():
+    """A budget reporting $0.00 for an unrecognised model is worse than none."""
+    usage = UsageTracker(model="claude-something-not-released-yet")
+    usage.input_tokens = 1_000_000
+
+    assert usage.pricing == DEFAULT_PRICING
+    assert usage.cost_usd > 0
+
+
+def test_zero_usage_costs_nothing():
+    assert UsageTracker(model=SONNET).cost_usd == 0.0
+
+
+def test_record_accumulates_across_calls():
+    usage = UsageTracker(model=SONNET)
+    usage.record(stub_response(1_000, 200))
+    usage.record(stub_response(3_000, 400))
+
+    assert usage.calls == 2
+    assert usage.input_tokens == 4_000
+    assert usage.output_tokens == 600
+
+
+def test_record_tolerates_a_response_with_no_usage():
+    """A stub or an older SDK should not crash the run."""
+    usage = UsageTracker(model=SONNET)
+    usage.record(stub_response(usage=False))
+
+    assert usage.calls == 1
+    assert usage.cost_usd == 0.0
+
+
+def test_summary_reports_calls_tokens_and_cost():
+    usage = UsageTracker(model=SONNET)
+    usage.record(stub_response(1_000, 200))
+    text = usage.summary()
+
+    assert "1 call" in text
+    assert "1,000" in text
+    assert "$" in text
+
+
+# ── the stop condition ────────────────────────────────────────────────────
+
+
+def test_no_limit_means_no_stopping():
+    client = make_client(max_cost_usd=None)
+    for _ in range(10):
+        client._call("prompt")
+
+    assert client.client.messages.calls == 10
+
+
+def test_calls_stop_once_the_limit_is_reached():
+    client = make_client(max_cost_usd=1.00)  # each call costs $0.60
+
+    made = 0
+    with pytest.raises(BudgetExceededError):
+        for _ in range(20):
+            client._call("prompt")
+            made += 1
+
+    assert made == 2
+    assert client.client.messages.calls == 2
+
+
+def test_usage_is_recorded_on_every_call():
+    client = make_client()
+    client._call("prompt")
+    client._call("prompt")
+
+    assert client.usage.calls == 2
+    assert client.usage.input_tokens == 200_000
+
+
+def test_overshoot_is_at_most_one_call():
+    """
+    Cost is only known after a call returns, so the limit is a stop condition
+    rather than a pre-authorisation. Documented, and pinned here.
+    """
+    client = make_client(max_cost_usd=1.00)
+    with pytest.raises(BudgetExceededError):
+        for _ in range(20):
+            client._call("prompt")
+
+    per_call = 0.60
+    assert client.usage.cost_usd <= 1.00 + per_call
+
+
+def test_the_error_says_what_was_spent():
+    client = make_client(max_cost_usd=0.50)
+    with pytest.raises(BudgetExceededError) as excinfo:
+        for _ in range(5):
+            client._call("prompt")
+
+    message = str(excinfo.value)
+    assert "0.50" in message
+    assert "call(s)" in message
+
+
+def test_a_zero_limit_blocks_the_first_call():
+    client = make_client(max_cost_usd=0.0)
+    with pytest.raises(BudgetExceededError):
+        client._call("prompt")
+
+    assert client.client.messages.calls == 0
+
+
+def test_budget_error_is_catchable_as_runtime_error():
+    """agent_loop distinguishes it from a generic failure; both are catchable."""
+    assert issubclass(BudgetExceededError, RuntimeError)
+
+
+# ── plumbing ──────────────────────────────────────────────────────────────
+
+
+def test_the_configured_model_is_the_one_called():
+    client = make_client(model="claude-3-5-haiku-20241022")
+    client._call("prompt")
+
+    assert client.client.messages.last_kwargs["model"] == "claude-3-5-haiku-20241022"
+
+
+def test_pricing_follows_the_configured_model():
+    client = make_client(model="claude-opus-4-20250514")
+    client._call("prompt")
+    sonnet = make_client(model=SONNET)
+    sonnet._call("prompt")
+
+    assert client.usage.cost_usd > sonnet.usage.cost_usd
+
+
+def test_loop_treats_the_budget_as_a_stop_not_an_error():
+    """
+    agent_loop must catch BudgetExceededError before the generic handler, or a
+    deliberate stop is reported as "the API broke".
+    """
+    source = _agent_loop_source()
+
+    # Scoped to the LLM call block: there is an unrelated `outcome = "error"`
+    # earlier in run() for context building. Anchored on code rather than on a
+    # section comment, since comments are decorative and get reworded.
+    start = source.index("self.llm.initial_request")
+    block = source[start:start + 1800]
+
+    assert "except BudgetExceededError" in block
+    assert block.index("except BudgetExceededError") < block.index("except Exception")
+
+
+def test_budget_stop_rolls_back_applied_changes():
+    """The reported message promises this, so it needs to be true."""
+    source = _agent_loop_source()
+
+    rollback_line = source.index("Rolling back file changes due to failed run")
+    condition = source[source.rindex("if (", 0, rollback_line):rollback_line]
+
+    assert "budget_exceeded" in condition


### PR DESCRIPTION
Closes #62

## Summary

An agent that retries on failure makes a paid API call per iteration, and nothing bounded that. This adds a token accumulator in `llm_client.py` and a `--max-cost` CLI limit that stops the run before the next call once the threshold is reached.

```bash
python main.py --repo . --task "..." --max-cost 1.00
```

Off by default, so existing behaviour is unchanged.

## Accounting

`UsageTracker` records input and output tokens per call and prices them from a table of published per-model rates, kept in one place so a price change is a one-line edit. Verified against the published figures rather than asserted:

```
Sonnet 4, 1M in + 1M out = $18.00   (3 + 15)
Opus 4,   1M in + 1M out = $90.00   (15 + 75)
```

Input and output are priced separately, which matters — output is 5x input on Sonnet, and an agent's responses are the expensive half.

**An unrecognised model falls back to default pricing rather than costing nothing.** A budget that silently reports `$0.00` because the model string changed is worse than having no budget at all: it would look like it was working right up until the bill arrived.

`record()` tolerates a response with no `usage` attribute, so a stub client or an older SDK degrades to zero-cost accounting instead of crashing the run.

## The limit is a stop condition, not a pre-authorisation

A call's cost is only known once it returns, so spend can exceed the limit by at most one call. That is a real limitation and it is documented in the docstring, in the README, and pinned by `test_overshoot_is_at_most_one_call`. Set the limit slightly below what you can actually afford.

Demonstrated with a $1.00 limit and $0.60 per call:

```
call 1: cumulative $0.6000
call 2: cumulative $1.2000
STOPPED after 2 calls
API invocations made: 2
```

A limit of `0.0` blocks the first call outright.

## Running out of money is not an error

`agent_loop` catches `BudgetExceededError` **before** the generic `except Exception`, so hitting the limit reports `outcome="budget_exceeded"` rather than "the API broke". The run log then distinguishes a deliberate stop from a genuine failure, which matters when you are looking at why a run ended.

Since the reported message says applied changes were rolled back, `budget_exceeded` is added to the rollback condition — a message that promises a rollback that did not happen would be worse than no message. There is a test asserting both: that the handler precedes the generic one, and that the outcome appears in the rollback condition.

## A Windows bug caught during review

My first version of the structural test read `agent_loop.py` with `Path.read_text()` and searched for a section comment. It passed on Linux and failed on Windows:

```
utf-8  : '# ── Step 3: Call LLM ──'
cp1252 : '# â”€â”€ Step 3: '
```

`read_text()` defaults to the *locale* encoding, which is cp1252 on a default Windows install, so the module's box-drawing comments decode to mojibake and the search silently misses. Fixed by passing `encoding="utf-8"` explicitly and by anchoring on `self.llm.initial_request` — actual code rather than a decorative comment. Verified the anchor holds under utf-8, cp1252 and latin-1.

## Tests

`tests/test_cost_budget.py` — 21 cases. Nothing contacts the API; the Anthropic client is replaced with a stub that reports usage.

Accounting: cost matches published rates; output is priced above input; every model in the table has both rates; an unknown model falls back and still costs something; zero usage costs zero; totals accumulate across calls; a response with no usage does not crash; `summary()` reports calls, tokens and cost.

Stopping: no limit means no stopping; calls stop at the limit and the stub confirms no further API invocations; usage is recorded on every call; overshoot is bounded to one call; the error message states what was spent; a zero limit blocks the first call; the exception is catchable as `RuntimeError`.

Plumbing: the configured model is the one passed to the API and the one used for pricing; `agent_loop` catches the budget error before the generic handler; `budget_exceeded` is in the rollback condition.

## Verified

- the arithmetic and stop behaviour above
- 21 tests pass; `tests/test_utils.py` still 4 passed; `--help` renders the flag
- ruff: `llm_client.py`, `agent_loop.py` and `main.py` all at their baseline finding counts, i.e. none added. The `F841` in `llm_client.py` is pre-existing on `main` — my change only shifted its line number.
- `npx prettier --check README.md` clean

## Interaction with #51

Merges clean against eleven of the twelve open branches. One conflict with #51 remains, on a single line where both PRs add a name to the `outcome` comment:

```python
    outcome: str        # success | failed | max_retries | error | aborted
                        #   | dry_run | budget_exceeded
```

I minimised it: my `final_message` entry goes at the *top* of the dict rather than after `"error"`, where #51 inserts, so the two no longer collide there. I resolved the remaining line locally and ran the combined tree — 47 tests pass.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.