### PR TITLE
feat(notify): post run outcome to a webhook on completion — Closes #74

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ python demo_run.py /path/to/sample_repo
 - GitHub PR creation via REST API (no extra dependencies — uses `urllib`).
 - `rollback` is handled by `code_modifier.py`; git ops are only for success path.
 
+### Module 9 — `notify.py`
+
+- Posts the run outcome to a webhook when `WEBHOOK_URL` is set. A six-iteration
+  run takes ten minutes or more, so people walk away from the terminal.
+- Detects Slack and Discord from the URL and uses each one's payload key; any
+  other endpoint receives the structured fields as JSON.
+- Cannot fail a run. A broken URL, unreachable host or rejected request is
+  reported through the log and the return value, never raised — the agent's
+  work is already finished by the time this fires.
+- Only `http`/`https` URLs are sent. Uses `urllib`, so no new dependency.
+
+```bash
+export WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
+python main.py --repo . --task "Fix the failing parser test"
+```
+
 ### Module 8 — `logger.py`
 
 - Every iteration appended to `<run_id>.jsonl` (structured, machine-readable).

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from modules.agent_loop import AutonomousAgent, AgentConfig
+from modules.notify import notify_run_complete
 from modules.code_modifier import CodeModificationEngine
 
 
@@ -180,6 +181,8 @@ def main():
             print(f"PR URL    : {result.pr_url}")
         print(f"MESSAGE   : {result.final_message}")
         print(f"{'='*60}")
+
+        notify_run_complete(result, task)
 
         write_github_output({
             "outcome": result.outcome,

--- a/modules/notify.py
+++ b/modules/notify.py
@@ -1,0 +1,167 @@
+"""
+Module: Run-completion notifications.
+
+A six-iteration run takes ten minutes or more, so people walk away from the
+terminal. Setting WEBHOOK_URL posts the outcome to Slack, Discord, or any
+endpoint that accepts a JSON POST.
+
+Nothing here may fail a run. A notification is a courtesy; a broken webhook URL
+or an unreachable host must not turn a successful agent run into a failed one,
+so every entry point returns a bool and swallows its own errors.
+"""
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Optional
+
+_LOG = logging.getLogger("agent.notify")
+
+WEBHOOK_ENV_VAR = "WEBHOOK_URL"
+DEFAULT_TIMEOUT = 10
+
+# Only these carry the run over a network. file:// and friends are rejected --
+# the URL comes from the environment, and a scheme mistake should be a clear
+# no-op rather than something surprising.
+ALLOWED_SCHEMES = ("http", "https")
+
+STATUS_MARKERS = {
+    "success": "PASSED",
+    "failed": "FAILED",
+    "max_retries": "FAILED",
+    "error": "ERROR",
+    "aborted": "ABORTED",
+    "budget_exceeded": "STOPPED",
+    "dry_run": "DRY RUN",
+}
+
+
+def detect_format(url: str) -> str:
+    """Slack and Discord each want their own key; anything else gets the lot."""
+    host = urllib.parse.urlparse(url).netloc.lower()
+    if "hooks.slack.com" in host or "slack.com" in host:
+        return "slack"
+    if "discord.com" in host or "discordapp.com" in host:
+        return "discord"
+    return "generic"
+
+
+def format_message(
+    outcome: str,
+    task: str,
+    run_id: str = "",
+    branch_name: Optional[str] = None,
+    pr_url: Optional[str] = None,
+    final_message: str = "",
+    iterations_used: int = 0,
+) -> str:
+    """A single human-readable line-set for chat clients."""
+    marker = STATUS_MARKERS.get(outcome, outcome.upper())
+    lines = [f"RepoPilot {marker}: {task}"]
+    if iterations_used:
+        lines.append(f"Iterations: {iterations_used}")
+    if branch_name:
+        lines.append(f"Branch: {branch_name}")
+    if pr_url:
+        lines.append(f"PR: {pr_url}")
+    if final_message:
+        lines.append(final_message)
+    if run_id:
+        lines.append(f"Run: {run_id}")
+    return "\n".join(lines)
+
+
+def build_payload(url: str, **fields) -> dict:
+    """
+    Shape the payload for whichever service the URL points at.
+
+    A generic endpoint gets the structured fields rather than a rendered
+    string, since something parsing this wants data, not prose.
+    """
+    style = detect_format(url)
+    text = format_message(**fields)
+
+    if style == "slack":
+        return {"text": text}
+    if style == "discord":
+        return {"content": text}
+
+    payload = dict(fields)
+    payload["text"] = text
+    return payload
+
+
+def send_webhook(
+    url: Optional[str] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    **fields,
+) -> bool:
+    """
+    POST the run outcome. Returns True only if the request was accepted.
+
+    Never raises: a notification failure is reported through the log and the
+    return value, never by interrupting the caller.
+    """
+    url = url or os.environ.get(WEBHOOK_ENV_VAR)
+    if not url:
+        return False
+
+    scheme = urllib.parse.urlparse(url).scheme.lower()
+    if scheme not in ALLOWED_SCHEMES:
+        _LOG.warning(
+            "%s has scheme '%s'; only %s are sent. Skipping notification.",
+            WEBHOOK_ENV_VAR, scheme or "(none)", "/".join(ALLOWED_SCHEMES),
+        )
+        return False
+
+    try:
+        body = json.dumps(build_payload(url, **fields)).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        _LOG.warning("could not serialise notification payload: %s", exc)
+        return False
+
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "repopilot-agent",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            status = getattr(response, "status", None) or response.getcode()
+            if 200 <= status < 300:
+                _LOG.debug("notification delivered (%s)", status)
+                return True
+            _LOG.warning("webhook returned HTTP %s", status)
+            return False
+    except urllib.error.HTTPError as exc:
+        _LOG.warning("webhook rejected the notification: HTTP %s", exc.code)
+    except Exception as exc:
+        # Deliberately broad: DNS, TLS, timeouts, proxies. The run already
+        # finished, and none of it is worth surfacing as a failure.
+        _LOG.warning("could not deliver notification: %s", exc)
+    return False
+
+
+def notify_run_complete(result, task: str, timeout: int = DEFAULT_TIMEOUT) -> bool:
+    """Send an AgentRunResult, if WEBHOOK_URL is set. Never raises."""
+    try:
+        return send_webhook(
+            outcome=result.outcome,
+            task=task,
+            run_id=result.run_id,
+            branch_name=result.branch_name,
+            pr_url=result.pr_url,
+            final_message=result.final_message,
+            iterations_used=result.iterations_used,
+        )
+    except Exception as exc:  # pragma: no cover - belt and braces
+        _LOG.warning("notification failed: %s", exc)
+        return False

--- a/tests/test_notify.py
+++ b/tests/test_notify.py
@@ -1,0 +1,289 @@
+"""
+Tests for run-completion notifications (modules/notify.py).
+
+The governing property is that nothing here can fail a run. A broken webhook
+URL, an unreachable host or a rejected request must be reported through the
+return value and the log, never by raising into the caller — the agent work is
+already done by the time this fires, and losing it to a notification bug would
+be absurd.
+
+No test contacts the network; urlopen is replaced throughout.
+"""
+
+import json
+import socket
+import sys
+import urllib.error
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import notify  # noqa: E402
+from modules.notify import (  # noqa: E402
+    ALLOWED_SCHEMES,
+    WEBHOOK_ENV_VAR,
+    detect_format,
+    format_message,
+    notify_run_complete,
+    send_webhook,
+)
+
+SLACK = "https://hooks.slack.com/services/T000/B000/xxxx"
+DISCORD = "https://discord.com/api/webhooks/123/abcdef"
+GENERIC = "https://ops.internal.example/hooks/agent"
+
+FIELDS = dict(
+    outcome="success",
+    task="Fix the parser TypeError",
+    run_id="agent_20260807_abc",
+    branch_name="agent/fix-abc",
+    pr_url="https://github.com/o/r/pull/9",
+    final_message="Task completed successfully. Tests pass.",
+    iterations_used=3,
+)
+
+
+class _Response:
+    """Minimal stand-in for the object urlopen returns (a context manager)."""
+
+    def __init__(self, status):
+        self.status = status
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class Capture:
+    """Records the request instead of sending it."""
+
+    def __init__(self, status=200, raises=None):
+        self.status = status
+        self.raises = raises
+        self.request = None
+        self.timeout = None
+
+    def __call__(self, request, timeout=None):
+        if self.raises is not None:
+            raise self.raises
+        self.request = request
+        self.timeout = timeout
+        return _Response(self.status)
+
+    @property
+    def payload(self):
+        return json.loads(self.request.data.decode("utf-8"))
+
+
+@pytest.fixture
+def capture(monkeypatch):
+    cap = Capture()
+    monkeypatch.setattr(notify.urllib.request, "urlopen", cap)
+    return cap
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_webhook(monkeypatch):
+    """A real WEBHOOK_URL in the environment must not leak into tests."""
+    monkeypatch.delenv(WEBHOOK_ENV_VAR, raising=False)
+
+
+# ── routing ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        (SLACK, "slack"),
+        ("https://slack.com/api/hooks/x", "slack"),
+        (DISCORD, "discord"),
+        ("https://discordapp.com/api/webhooks/1/x", "discord"),
+        (GENERIC, "generic"),
+        ("http://localhost:9000/hook", "generic"),
+    ],
+)
+def test_service_is_detected_from_the_url(url, expected):
+    assert detect_format(url) == expected
+
+
+def test_slack_gets_a_text_key(capture):
+    send_webhook(url=SLACK, **FIELDS)
+    assert set(capture.payload) == {"text"}
+
+
+def test_discord_gets_a_content_key(capture):
+    send_webhook(url=DISCORD, **FIELDS)
+    assert set(capture.payload) == {"content"}
+
+
+def test_generic_endpoints_get_structured_fields(capture):
+    """Something parsing this wants data, not prose."""
+    send_webhook(url=GENERIC, **FIELDS)
+    payload = capture.payload
+
+    assert payload["outcome"] == "success"
+    assert payload["run_id"] == FIELDS["run_id"]
+    assert payload["pr_url"] == FIELDS["pr_url"]
+    assert payload["iterations_used"] == 3
+    assert "text" in payload  # rendered form as well
+
+
+# ── the message ───────────────────────────────────────────────────────────
+
+
+def test_message_leads_with_status_and_task():
+    text = format_message(**FIELDS)
+    assert text.splitlines()[0] == "RepoPilot PASSED: Fix the parser TypeError"
+
+
+@pytest.mark.parametrize(
+    "outcome,marker",
+    [
+        ("success", "PASSED"),
+        ("failed", "FAILED"),
+        ("max_retries", "FAILED"),
+        ("error", "ERROR"),
+        ("aborted", "ABORTED"),
+        ("budget_exceeded", "STOPPED"),
+    ],
+)
+def test_each_outcome_has_a_readable_marker(outcome, marker):
+    assert marker in format_message(outcome=outcome, task="t")
+
+
+def test_unknown_outcome_still_renders():
+    assert "SOMETHING_NEW" in format_message(outcome="something_new", task="t")
+
+
+def test_optional_fields_are_omitted_when_absent():
+    text = format_message(outcome="failed", task="t")
+    assert "Branch:" not in text
+    assert "PR:" not in text
+    assert "Iterations:" not in text
+
+
+def test_pr_url_is_included_when_present():
+    assert FIELDS["pr_url"] in format_message(**FIELDS)
+
+
+# ── request mechanics ─────────────────────────────────────────────────────
+
+
+def test_it_posts_json(capture):
+    send_webhook(url=GENERIC, **FIELDS)
+    assert capture.request.method == "POST"
+    assert capture.request.headers["Content-type"] == "application/json"
+
+
+def test_a_timeout_is_always_applied(capture):
+    """An unreachable host must not hang the process after the work is done."""
+    send_webhook(url=GENERIC, timeout=7, **FIELDS)
+    assert capture.timeout == 7
+
+
+def test_a_2xx_is_success(capture):
+    assert send_webhook(url=GENERIC, **FIELDS) is True
+
+
+@pytest.mark.parametrize("status", [301, 400, 500])
+def test_a_non_2xx_is_not_success(monkeypatch, status):
+    monkeypatch.setattr(notify.urllib.request, "urlopen", Capture(status=status))
+    assert send_webhook(url=GENERIC, **FIELDS) is False
+
+
+# ── it must never fail a run ──────────────────────────────────────────────
+
+
+def test_no_url_is_a_silent_no_op(capture):
+    assert send_webhook(**FIELDS) is False
+    assert capture.request is None
+
+
+def test_env_var_is_used_when_no_url_is_passed(capture, monkeypatch):
+    monkeypatch.setenv(WEBHOOK_ENV_VAR, GENERIC)
+    assert send_webhook(**FIELDS) is True
+
+
+@pytest.mark.parametrize(
+    "url", ["file:///etc/passwd", "ftp://h/x", "hooks.slack.com/x"]
+)
+def test_non_http_schemes_are_refused(capture, url):
+    """The URL comes from the environment; a scheme mistake should be a no-op."""
+    assert send_webhook(url=url, **FIELDS) is False
+    assert capture.request is None
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        urllib.error.HTTPError("u", 404, "not found", {}, None),
+        socket.gaierror("name resolution failed"),
+        TimeoutError("timed out"),
+        OSError("certificate verify failed"),
+        RuntimeError("something unforeseen"),
+    ],
+)
+def test_transport_failures_return_false_rather_than_raising(monkeypatch, error):
+    monkeypatch.setattr(notify.urllib.request, "urlopen", Capture(raises=error))
+    assert send_webhook(url=GENERIC, **FIELDS) is False
+
+
+def test_unserialisable_fields_do_not_raise(capture):
+    class Weird:
+        pass
+
+    assert send_webhook(url=GENERIC, outcome="success", task=Weird()) is False
+
+
+# ── the caller-facing entry point ─────────────────────────────────────────
+
+
+def make_result(**overrides):
+    base = dict(
+        run_id="agent_20260807_abc", outcome="success",
+        branch_name="agent/fix-abc", pr_url=None,
+        iterations_used=2, final_message="done",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_notify_run_complete_sends_the_result(capture, monkeypatch):
+    monkeypatch.setenv(WEBHOOK_ENV_VAR, GENERIC)
+    assert notify_run_complete(make_result(), task="Fix it") is True
+
+    payload = capture.payload
+    assert payload["outcome"] == "success"
+    assert payload["task"] == "Fix it"
+    assert payload["iterations_used"] == 2
+
+
+def test_notify_run_complete_is_a_no_op_without_the_env_var(capture):
+    assert notify_run_complete(make_result(), task="Fix it") is False
+    assert capture.request is None
+
+
+def test_notify_run_complete_survives_a_malformed_result(capture, monkeypatch):
+    """It is called on every run; a missing attribute must not crash main."""
+    monkeypatch.setenv(WEBHOOK_ENV_VAR, GENERIC)
+    assert notify_run_complete(SimpleNamespace(), task="t") is False
+
+
+def test_failed_runs_are_notified_too(capture, monkeypatch):
+    """Walking away matters most when the run does not succeed."""
+    monkeypatch.setenv(WEBHOOK_ENV_VAR, SLACK)
+    notify_run_complete(make_result(outcome="max_retries"), task="Fix it")
+
+    assert "FAILED" in capture.payload["text"]
+
+
+def test_only_http_schemes_are_allowed():
+    assert set(ALLOWED_SCHEMES) == {"http", "https"}


### PR DESCRIPTION
Closes #74

## Summary

A six-iteration run takes ten minutes or more, so people walk away from the terminal and miss the result. Setting `WEBHOOK_URL` now posts the outcome to Slack, Discord, or any endpoint that accepts a JSON POST.

```bash
export WEBHOOK_URL=https://hooks.slack.com/services/T000/B000/xxxx
python main.py --repo . --task "Fix the failing parser test"
```

Unset, it is a silent no-op — existing behaviour is unchanged.

This lands as a new module, `modules/notify.py`. `main.py` gets three lines: an import and one call beside the existing `write_github_output`, which is the same shape of thing — env-var driven, side-effecting, and not allowed to interfere with the run.

## It cannot fail a run

This is the property everything else is arranged around. The agent's work is already finished by the time a notification fires, so losing a successful run to a webhook bug would be absurd. Every entry point returns a bool and swallows its own errors:

```
no WEBHOOK_URL set     -> False    file:// scheme        -> False
no scheme at all       -> False    HTTP 404 from server  -> False
DNS failure            -> False    connection timeout    -> False
TLS error              -> False    something unforeseen  -> False
unserialisable field   -> False
```

Not one of them raises. `notify_run_complete` additionally survives a malformed result object, because it is called unconditionally on every run and a missing attribute must not crash `main`.

The `except Exception` around the request is deliberately broad and commented as such: DNS, TLS, proxies and timeouts all surface differently, and none of them is worth turning into a failure after the work is done. A timeout is always applied so an unreachable host cannot hang the process.

## Payload shape follows the service

Slack and Discord each want their own key, so the URL host decides:

| endpoint | payload |
| -------- | ------- |
| `hooks.slack.com` | `{"text": ...}` |
| `discord.com` / `discordapp.com` | `{"content": ...}` |
| anything else | the structured fields plus a rendered `text` |

A generic endpoint gets `outcome`, `task`, `run_id`, `branch_name`, `pr_url`, `iterations_used` and `final_message` as JSON rather than only a string, since something parsing this wants data, not prose.

What actually lands in Slack:

```
RepoPilot PASSED: Fix the parser TypeError
Iterations: 3
Branch: agent/fix-abc
PR: https://github.com/o/r/pull/9
Task completed successfully. Tests pass.
Run: agent_20260807_abc
```

Failed runs are notified too, with `FAILED`/`ERROR`/`ABORTED`/`STOPPED` markers. Walking away from the terminal matters most when the run does not succeed.

## Two deliberate constraints

**Only `http` and `https` are sent.** The URL comes from the environment, and a scheme mistake — `file://`, a copy-paste that lost the `https:` — should be a clear no-op with a warning, not something surprising.

**No new dependency.** It uses `urllib`, matching how `git_integration.create_github_pr` already does HTTP in this project.

## Tests

`tests/test_notify.py` — 41 cases. Nothing contacts the network; `urlopen` is replaced throughout, and an autouse fixture clears `WEBHOOK_URL` so a real one in the environment cannot leak into a test run.

Routing: six URL shapes map to the right service; Slack gets exactly `{"text"}`, Discord exactly `{"content"}`, and a generic endpoint gets the structured fields.

Message: the first line carries status and task; six outcomes map to readable markers; an unrecognised outcome still renders; absent optional fields are omitted rather than printed empty.

Mechanics: it POSTs with `Content-Type: application/json`; the timeout is passed through; 2xx is success and 301/400/500 are not.

Failure handling: no URL is a silent no-op that issues no request; the env var is used when no URL is passed; three non-http schemes are refused without a request; five transport failures return `False` rather than raising; unserialisable fields do not raise.

Entry point: `notify_run_complete` sends the result fields, no-ops without the env var, survives a result object missing every attribute, and notifies failed runs.

## Verified

- every failure mode above, exercised directly
- payload shapes and the rendered Slack message
- 41 tests pass; `tests/test_utils.py` still 4 passed; `--help` unchanged
- ruff clean on both new files; `main.py` at its baseline count of 9 findings, i.e. none added
- `npx prettier --check README.md` clean
- merges clean against all thirteen other branches currently open

## One bug from my own test harness

My first stub returned a `SimpleNamespace` carrying `__enter__`/`__exit__` attributes. Python resolves dunder methods on the *type*, not the instance, so `with urlopen(...)` failed against it while working fine against the real thing — three tests failed for a reason that had nothing to do with the code under test. Replaced with a real class. Worth mentioning because the stub looked plausible and the failure message pointed at the wrong place.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.