### PR TITLE
feat(cli): accept a GitHub issue URL as --task — Closes #75

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,25 @@ python demo_run.py /path/to/sample_repo
 
 ---
 
+## Task Sources
+
+`--task` normally carries a description. It can instead carry a GitHub issue
+URL, in which case the title, body and comments are fetched and composed into
+the task the agent works from:
+
+```bash
+python main.py --repo . --task https://github.com/sreerevanth/repopilot/issues/75
+```
+
+Public repositories work unauthenticated; `GITHUB_TOKEN` raises the rate limit
+and is required for private ones. Long bodies and threads are trimmed so the
+issue text does not crowd source files out of the context budget.
+
+If the URL cannot be resolved the run stops with an explanation. Passing it
+through as a literal task would send the agent off to implement a URL.
+
+---
+
 ## Module Reference
 
 ### Module 1 — `repo_ingestion.py`

--- a/main.py
+++ b/main.py
@@ -18,6 +18,11 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from modules.agent_loop import AutonomousAgent, AgentConfig
 from modules.code_modifier import CodeModificationEngine
+from modules.task_source import (
+    TaskResolutionError,
+    looks_like_issue_url,
+    resolve_task,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -41,7 +46,7 @@ Examples:
     )
 
     parser.add_argument("--repo", required=True, help="Path to the git repository")
-    parser.add_argument("--task", required=False, help="High-level task description (can also be provided via AGENT_TASK env var)")
+    parser.add_argument("--task", required=False, help="High-level task description, or a GitHub issue URL to pull one from (can also be provided via AGENT_TASK env var)")
 
     # Execution
     parser.add_argument("--runner", default="pytest",
@@ -128,6 +133,12 @@ def main():
     yes_flag = args.yes or os.environ.get("CI") == "true"
 
     task = args.task or os.environ.get("AGENT_TASK")
+    if task and looks_like_issue_url(task):
+        try:
+            task = resolve_task(task)
+        except TaskResolutionError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
     if not task:
         print("ERROR: Task description is required. Provide --task or set the AGENT_TASK environment variable.", file=sys.stderr)
         sys.exit(1)

--- a/modules/task_source.py
+++ b/modules/task_source.py
@@ -1,0 +1,185 @@
+"""
+Module: Task sources.
+
+`--task` normally carries a description. It can instead carry a GitHub issue
+URL, in which case the title, body and comments are fetched and composed into
+the task the agent actually works from.
+
+Unlike notifications, a failure here is fatal by design. If the URL cannot be
+resolved, passing it through as a literal task would send the agent off to
+"implement https://github.com/o/r/issues/1", which is worse than stopping.
+"""
+
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Optional
+
+_LOG = logging.getLogger("agent.task_source")
+
+GITHUB_ISSUE_URL = re.compile(
+    r"^https?://(?:www\.)?github\.com/"
+    r"(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/issues/(?P<number>\d+)"
+    r"(?:[/?#].*)?$",
+    re.IGNORECASE,
+)
+
+API_ROOT = "https://api.github.com"
+DEFAULT_TIMEOUT = 20
+
+# The issue body and its comments go into the prompt, where they compete with
+# source files for the context budget. Long threads get trimmed rather than
+# crowding the code out.
+MAX_BODY_CHARS = 6000
+MAX_COMMENT_CHARS = 1500
+MAX_COMMENTS = 10
+
+
+class TaskResolutionError(RuntimeError):
+    """Raised when a task URL is recognised but cannot be turned into a task."""
+
+
+def parse_issue_url(value: str) -> Optional[dict]:
+    """Return {owner, repo, number} for a GitHub issue URL, else None."""
+    match = GITHUB_ISSUE_URL.match((value or "").strip())
+    if not match:
+        return None
+    parts = match.groupdict()
+    parts["number"] = int(parts["number"])
+    return parts
+
+
+def looks_like_issue_url(value: str) -> bool:
+    return parse_issue_url(value) is not None
+
+
+def _get_json(url: str, token: Optional[str], timeout: int):
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "repopilot-agent",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    request = urllib.request.Request(url, headers=headers, method="GET")
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + f"\n[... truncated, {len(text) - limit} more chars]"
+
+
+def fetch_issue(
+    owner: str,
+    repo: str,
+    number: int,
+    token: Optional[str] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+    include_comments: bool = True,
+) -> dict:
+    """
+    Fetch one issue and its comments.
+
+    Works unauthenticated against public repositories; GITHUB_TOKEN raises the
+    rate limit and is required for private ones.
+    """
+    token = token or os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    base = f"{API_ROOT}/repos/{owner}/{repo}/issues/{number}"
+
+    try:
+        issue = _get_json(base, token, timeout)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            raise TaskResolutionError(
+                f"Issue {owner}/{repo}#{number} was not found. It may be private "
+                f"or deleted; set GITHUB_TOKEN if the repository is private."
+            ) from exc
+        if exc.code in (401, 403):
+            raise TaskResolutionError(
+                f"GitHub refused the request for {owner}/{repo}#{number} "
+                f"(HTTP {exc.code}). This is usually a rate limit or a missing "
+                f"GITHUB_TOKEN."
+            ) from exc
+        raise TaskResolutionError(
+            f"GitHub returned HTTP {exc.code} for {owner}/{repo}#{number}."
+        ) from exc
+    except Exception as exc:
+        raise TaskResolutionError(
+            f"Could not reach GitHub for {owner}/{repo}#{number}: {exc}"
+        ) from exc
+
+    comments: list[dict] = []
+    if include_comments and issue.get("comments"):
+        try:
+            fetched = _get_json(f"{base}/comments", token, timeout)
+            comments = fetched if isinstance(fetched, list) else []
+        except Exception as exc:
+            # The title and body alone are a usable task; losing the discussion
+            # is a degradation, not a reason to abort.
+            _LOG.warning("could not fetch comments for #%s: %s", number, exc)
+
+    return {"issue": issue, "comments": comments}
+
+
+def compose_task(issue: dict, comments: Optional[list] = None) -> str:
+    """Render an issue and its comments as a task description."""
+    number = issue.get("number", "?")
+    title = (issue.get("title") or "").strip()
+    body = _truncate(issue.get("body") or "", MAX_BODY_CHARS)
+
+    if not title and not body:
+        # "GitHub issue #1:" is a non-empty string but not a task. Returning it
+        # would send the agent off with nothing to work from.
+        return ""
+
+    lines = [f"GitHub issue #{number}: {title}"]
+    if body:
+        lines += ["", body]
+
+    for comment in (comments or [])[:MAX_COMMENTS]:
+        author = (comment.get("user") or {}).get("login", "someone")
+        text = _truncate(comment.get("body") or "", MAX_COMMENT_CHARS)
+        if text:
+            lines += ["", f"--- comment by {author} ---", text]
+
+    return "\n".join(lines).strip()
+
+
+def resolve_task(
+    value: str,
+    token: Optional[str] = None,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str:
+    """
+    Return the task to work from.
+
+    A plain description passes through untouched. A GitHub issue URL is fetched
+    and composed. Anything that looks like an issue URL but cannot be fetched
+    raises, rather than being handed to the model as a literal URL.
+    """
+    parts = parse_issue_url(value)
+    if not parts:
+        return value
+
+    _LOG.info(
+        "Resolving task from %s/%s#%s",
+        parts["owner"], parts["repo"], parts["number"],
+    )
+    fetched = fetch_issue(
+        parts["owner"], parts["repo"], parts["number"], token=token, timeout=timeout
+    )
+    task = compose_task(fetched["issue"], fetched["comments"])
+
+    if not task:
+        raise TaskResolutionError(
+            f"Issue {parts['owner']}/{parts['repo']}#{parts['number']} has no "
+            f"title or body to use as a task."
+        )
+    return task

--- a/tests/test_task_source.py
+++ b/tests/test_task_source.py
@@ -1,0 +1,278 @@
+"""
+Tests for resolving a task from a GitHub issue URL (modules/task_source.py).
+
+A failure here is fatal by design. Passing an unresolved URL through as the
+literal task would send the agent off to "implement
+https://github.com/o/r/issues/1", which is worse than stopping.
+
+No test contacts the network; urlopen is replaced throughout.
+"""
+
+import io
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import task_source  # noqa: E402
+from modules.task_source import (  # noqa: E402
+    MAX_BODY_CHARS,
+    MAX_COMMENTS,
+    TaskResolutionError,
+    compose_task,
+    fetch_issue,
+    looks_like_issue_url,
+    parse_issue_url,
+    resolve_task,
+)
+
+ISSUE = {
+    "number": 75,
+    "title": "Extract context from GitHub issues",
+    "body": "Users should be able to pass a URL instead of a task string.",
+    "comments": 2,
+}
+COMMENTS = [
+    {"user": {"login": "maintainer"}, "body": "Agreed, fetch title and body."},
+    {"user": {"login": "someone"}, "body": "And the comments."},
+]
+
+
+class _Response(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def responder(mapping, raises=None):
+    """Return a urlopen stub serving `mapping` of url-substring -> payload."""
+
+    def _open(request, timeout=None):
+        if raises is not None:
+            raise raises
+        url = request.full_url if hasattr(request, "full_url") else str(request)
+        for fragment, payload in mapping.items():
+            if fragment in url:
+                return _Response(json.dumps(payload).encode("utf-8"))
+        raise urllib.error.HTTPError(url, 404, "Not Found", {}, None)
+
+    return _open
+
+
+@pytest.fixture(autouse=True)
+def no_ambient_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+
+# ── recognising a URL ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,owner,repo,number",
+    [
+        (
+            "https://github.com/sreerevanth/repopilot/issues/75",
+            "sreerevanth", "repopilot", 75,
+        ),
+        ("http://github.com/o/r/issues/1", "o", "r", 1),
+        ("https://www.github.com/o/r/issues/42#issuecomment-1", "o", "r", 42),
+        ("https://github.com/o/r/issues/9?foo=bar", "o", "r", 9),
+        ("  https://github.com/o/r/issues/3  ", "o", "r", 3),
+    ],
+)
+def test_issue_urls_are_parsed(url, owner, repo, number):
+    parts = parse_issue_url(url)
+    assert (parts["owner"], parts["repo"], parts["number"]) == (owner, repo, number)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Fix the parser TypeError",
+        "https://github.com/o/r/pull/75",          # a PR, not an issue
+        "https://gitlab.com/o/r/issues/1",         # not GitHub
+        "https://github.com/o/r/issues/abc",       # not a number
+        "https://github.com/o/r/issues",           # no number
+        "",
+        None,
+    ],
+)
+def test_non_issue_values_are_not_matched(value):
+    assert parse_issue_url(value) is None
+    assert looks_like_issue_url(value) is False
+
+
+def test_a_plain_description_passes_through_untouched():
+    assert resolve_task("Fix the parser TypeError") == "Fix the parser TypeError"
+
+
+# ── composing the task ────────────────────────────────────────────────────
+
+
+def test_task_leads_with_number_and_title():
+    assert compose_task(ISSUE).splitlines()[0] == (
+        "GitHub issue #75: Extract context from GitHub issues"
+    )
+
+
+def test_body_is_included():
+    assert ISSUE["body"] in compose_task(ISSUE)
+
+
+def test_comments_are_attributed():
+    text = compose_task(ISSUE, COMMENTS)
+    assert "--- comment by maintainer ---" in text
+    assert "And the comments." in text
+
+
+def test_empty_comments_are_skipped():
+    text = compose_task(ISSUE, [{"user": {"login": "x"}, "body": "   "}])
+    assert "comment by x" not in text
+
+
+def test_a_missing_body_still_yields_a_task():
+    assert "only a title" in compose_task({"number": 1, "title": "only a title"})
+
+
+def test_long_bodies_are_truncated():
+    """The issue text competes with source files for the context budget."""
+    text = compose_task({"number": 1, "title": "t", "body": "x" * (MAX_BODY_CHARS * 3)})
+    assert "truncated" in text
+    assert len(text) < MAX_BODY_CHARS * 2
+
+
+def test_comment_count_is_capped():
+    many = [
+        {"user": {"login": f"u{i}"}, "body": f"c{i}"}
+        for i in range(MAX_COMMENTS + 10)
+    ]
+    text = compose_task(ISSUE, many)
+    assert f"u{MAX_COMMENTS + 5}" not in text
+
+
+# ── fetching ──────────────────────────────────────────────────────────────
+
+
+def test_issue_and_comments_are_fetched(monkeypatch):
+    monkeypatch.setattr(
+        task_source.urllib.request, "urlopen",
+        responder({"/comments": COMMENTS, "/issues/75": ISSUE}),
+    )
+    result = fetch_issue("o", "r", 75)
+
+    assert result["issue"]["title"] == ISSUE["title"]
+    assert len(result["comments"]) == 2
+
+
+def test_comment_failure_degrades_rather_than_aborting(monkeypatch):
+    """Title and body alone are a usable task."""
+
+    def _open(request, timeout=None):
+        if "/comments" in request.full_url:
+            raise TimeoutError("slow")
+        return _Response(json.dumps(ISSUE).encode("utf-8"))
+
+    monkeypatch.setattr(task_source.urllib.request, "urlopen", _open)
+    result = fetch_issue("o", "r", 75)
+
+    assert result["issue"]["title"] == ISSUE["title"]
+    assert result["comments"] == []
+
+
+@pytest.mark.parametrize(
+    "code,expected",
+    [
+        (404, "not found"),
+        (403, "rate limit"),
+        (401, "rate limit"),
+        (500, "HTTP 500"),
+    ],
+)
+def test_http_errors_explain_themselves(monkeypatch, code, expected):
+    error = urllib.error.HTTPError("u", code, "err", {}, None)
+    monkeypatch.setattr(
+        task_source.urllib.request, "urlopen", responder({}, raises=error)
+    )
+
+    with pytest.raises(TaskResolutionError) as excinfo:
+        fetch_issue("o", "r", 1)
+
+    assert expected.lower() in str(excinfo.value).lower()
+
+
+def test_network_failure_raises_a_clear_error(monkeypatch):
+    monkeypatch.setattr(
+        task_source.urllib.request, "urlopen",
+        responder({}, raises=OSError("no route to host")),
+    )
+    with pytest.raises(TaskResolutionError):
+        fetch_issue("o", "r", 1)
+
+
+def test_a_token_is_sent_when_available(monkeypatch):
+    seen = {}
+
+    def _open(request, timeout=None):
+        seen["auth"] = request.headers.get("Authorization")
+        return _Response(json.dumps(ISSUE).encode("utf-8"))
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+    monkeypatch.setattr(task_source.urllib.request, "urlopen", _open)
+    fetch_issue("o", "r", 1, include_comments=False)
+
+    assert seen["auth"] == "Bearer ghp_secret"
+
+
+def test_no_auth_header_without_a_token(monkeypatch):
+    """Public repositories work unauthenticated."""
+    seen = {}
+
+    def _open(request, timeout=None):
+        seen["auth"] = request.headers.get("Authorization")
+        return _Response(json.dumps(ISSUE).encode("utf-8"))
+
+    monkeypatch.setattr(task_source.urllib.request, "urlopen", _open)
+    fetch_issue("o", "r", 1, include_comments=False)
+
+    assert seen["auth"] is None
+
+
+# ── end to end ────────────────────────────────────────────────────────────
+
+
+def test_resolve_task_returns_the_composed_issue(monkeypatch):
+    monkeypatch.setattr(
+        task_source.urllib.request, "urlopen",
+        responder({"/comments": COMMENTS, "/issues/75": ISSUE}),
+    )
+    task = resolve_task("https://github.com/o/r/issues/75")
+
+    assert task.startswith("GitHub issue #75:")
+    assert "maintainer" in task
+
+
+def test_an_unresolvable_url_raises_rather_than_passing_through(monkeypatch):
+    """Handing the model a bare URL as its task would be worse than stopping."""
+    error = urllib.error.HTTPError("u", 404, "nf", {}, None)
+    monkeypatch.setattr(
+        task_source.urllib.request, "urlopen", responder({}, raises=error)
+    )
+
+    with pytest.raises(TaskResolutionError):
+        resolve_task("https://github.com/o/r/issues/75")
+
+
+def test_an_empty_issue_raises(monkeypatch):
+    monkeypatch.setattr(
+        task_source.urllib.request, "urlopen",
+        responder({"/issues/": {"number": 1, "title": "", "body": ""}}),
+    )
+    with pytest.raises(TaskResolutionError):
+        resolve_task("https://github.com/o/r/issues/1")


### PR DESCRIPTION
Closes #75

## Summary

`--task` can now carry a GitHub issue URL instead of a description. The title, body and comments are fetched and composed into the task the agent works from.

```bash
python main.py --repo . --task https://github.com/sreerevanth/repopilot/issues/75
```

A plain description passes through untouched, so existing usage is unchanged. The work lands in a new module, `modules/task_source.py`; `main.py` gets an import and a five-line resolution step.

## Failure here is fatal, deliberately

This is the opposite call from the webhook work in #74. There, a failure is swallowed because the run is already finished. Here, an unresolvable URL means there is no task — and passing the URL through as a literal task would send the agent off to "implement https://github.com/o/r/issues/1", burning iterations and API spend on nonsense.

So `resolve_task` raises `TaskResolutionError` and `main.py` exits 1 with the reason. Each HTTP status gets a specific explanation rather than a stack trace:

| status | message |
| ------ | ------- |
| 404 | not found; may be private or deleted, set `GITHUB_TOKEN` |
| 401 / 403 | refused, usually a rate limit or missing token |
| other | the status code |
| network | the underlying error |

**Comments are the exception.** If the issue fetches but the comments call fails, the title and body alone are a usable task, so that degrades with a warning rather than aborting.

## URL matching

Matched: `https://` and `http://`, with or without `www.`, with a `#issuecomment-…` fragment or a query string, and with surrounding whitespace.

Not matched, and this matters: `/pull/75` (a PR, not an issue), GitLab URLs, `issues/abc`, `issues` with no number, empty, and `None`. Anything unmatched is treated as a plain description and never triggers a fetch.

## A gap the tests found

An issue with no title *and* no body produced `"GitHub issue #1:"`. That is a non-empty string, so the "empty task" guard in `resolve_task` never fired and the agent would have run against nothing. `compose_task` now returns `""` for that case and the guard works. A title with no body, or a body with no title, are both still valid.

## Context budget

The issue text goes into the prompt, where it competes with source files. Bodies are trimmed at 6000 characters, comments at 1500 each, and at most 10 comments are included — with an explicit `[... truncated, N more chars]` marker rather than a silent cut.

## Auth

Works unauthenticated against public repositories. `GITHUB_TOKEN` (or `GH_TOKEN`) is sent as a bearer token when present, which raises the rate limit and is required for private repositories. Tests assert both: the header is sent when a token exists and absent when it does not.

Uses `urllib`, matching how `git_integration.create_github_pr` already does HTTP. No new dependency.

## Tests

`tests/test_task_source.py` — 32 cases. Nothing contacts the network; `urlopen` is replaced throughout, and an autouse fixture clears `GITHUB_TOKEN`/`GH_TOKEN` so an ambient token cannot change behaviour.

Recognition: five URL shapes parse to the right owner/repo/number; seven non-issue values are rejected; a plain description passes through `resolve_task` untouched.

Composition: the first line is number and title; body included; comments attributed by author; empty comments skipped; a missing body still yields a task; long bodies truncated; comment count capped.

Fetching: issue and comments retrieved; a comment failure degrades to an empty list rather than aborting; four HTTP statuses produce their own explanations; a network failure raises `TaskResolutionError`; the auth header is sent with a token and omitted without one.

End to end: `resolve_task` returns the composed issue; an unresolvable URL raises rather than passing through; an empty issue raises.

## Verified

- URL recognition and composed output, printed and inspected
- 32 tests pass; `tests/test_utils.py` still 4 passed; `--help` renders the updated `--task` text
- ruff clean on both new files; `main.py` at its baseline count of 9, i.e. none added
- `npx prettier --check README.md` clean
- merges clean against all sixteen other branches

I moved the import below `code_modifier` rather than beside `agent_loop`, because #74 inserts its own import at that exact anchor. That alone was the difference between a conflict and a clean merge.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.