### PR TITLE
feat(agent): add --skip-tests for non-test-driven tasks — Closes #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ python demo_run.py /path/to/sample_repo
 - Iterates up to `max_iterations` times.
 - On success: commits (optionally pushes + opens PR).
 - On failure: rolls back all file changes.
+- `--skip-tests` bypasses the sandbox entirely and accepts changes on the
+  model's confidence alone. Useful for refactors and comment passes where there
+  is nothing to assert; unsuitable for behaviour changes. The recorded result
+  says plainly that no suite ran, so a log cannot be mistaken for evidence that
+  tests passed.
 - Produces a `AgentRunResult` with outcome, branch, PR URL, iteration count.
 
 ### Module 7 — `git_integration.py`

--- a/main.py
+++ b/main.py
@@ -49,6 +49,10 @@ Examples:
                         help="Test runner to use (default: pytest)")
     parser.add_argument("--runner-args", nargs="*", default=None,
                         help="Extra arguments to pass to the test runner")
+    parser.add_argument("--skip-tests", action="store_true",
+                        help="Do not run a test suite. Changes are accepted on the "
+                             "model's confidence alone - suitable for refactors and "
+                             "comment passes, not for behaviour changes.")
     parser.add_argument("--run-file", default=None,
                         help="Run a specific file instead of the test suite")
     parser.add_argument("--run-file-runner", default="python",
@@ -141,6 +145,7 @@ def main():
         # Execution
         test_runner=args.runner,
         test_args=args.runner_args,
+        skip_tests=args.skip_tests,
         run_file=args.run_file,
         run_file_runner=args.run_file_runner,
         timeout_seconds=args.timeout,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -43,6 +43,7 @@ class AgentConfig:
     # Execution
     test_runner: str = "pytest"            # pytest | npm_test | go | cargo | ...
     test_args: Optional[list] = None       # extra args to pass to runner
+    skip_tests: bool = False               # accept the LLM's own verdict instead
     run_file: Optional[str] = None         # run a specific file instead of tests
     run_file_runner: str = "python"
     timeout_seconds: int = 120
@@ -113,6 +114,26 @@ class AutonomousAgent:
         """Convert task text into a valid git branch name."""
         slug = re.sub(r"[^a-zA-Z0-9]+", "-", task.lower())[:40].strip("-")
         return f"{self.config.git_branch_prefix}/{slug}-{self.run_id[-6:]}"
+
+    def _skipped_execution(self, confidence: float) -> ExecutionResult:
+        """
+        Stand-in result for --skip-tests.
+
+        Deliberately not dressed up as a passing test run: `command` says what
+        happened and the stdout records the confidence the decision rested on,
+        so a log cannot be mistaken for evidence that a suite went green.
+        """
+        return ExecutionResult(
+            command="(skipped - --skip-tests; no test suite was run)",
+            exit_code=0,
+            stdout=(
+                f"Tests were not run. Accepted on the model's own confidence of "
+                f"{confidence:.2f}. No suite verified this change."
+            ),
+            stderr="",
+            timed_out=False,
+            duration_seconds=0.0,
+        )
 
     def _run_execution(self) -> ExecutionResult:
         """Run tests or the specified file in the sandbox."""
@@ -339,7 +360,10 @@ class AutonomousAgent:
                 break
 
             # ── Step 5: Execute ──
-            exec_result = self._run_execution()
+            if cfg.skip_tests:
+                exec_result = self._skipped_execution(llm_resp.confidence)
+            else:
+                exec_result = self._run_execution()
             self.logger.log_execution(exec_result)
             last_exec = exec_result
 
@@ -354,7 +378,13 @@ class AutonomousAgent:
 
             # ── Step 6: Success check ──
             if exec_result.success:
-                self.logger.info(f"  Tests passed on iteration {iteration}")
+                if cfg.skip_tests:
+                    self.logger.warning(
+                        f"  Accepting iteration {iteration} without running tests "
+                        f"(--skip-tests, confidence {llm_resp.confidence:.2f})."
+                    )
+                else:
+                    self.logger.info(f"  Tests passed on iteration {iteration}")
                 self._commit_changes(iteration, [c.path for c in last_changes])
                 outcome = "success"
                 break

--- a/tests/test_skip_tests.py
+++ b/tests/test_skip_tests.py
@@ -1,0 +1,112 @@
+"""
+Tests for --skip-tests (modules/agent_loop.py).
+
+The agent normally decides success from a test run. --skip-tests removes that
+evidence and accepts the model's own verdict instead, which is reasonable for a
+refactor or a comment pass and unreasonable for a behaviour change.
+
+The risk worth guarding is a log that reads like tests passed when none ran.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig, AutonomousAgent  # noqa: E402
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+
+def source() -> str:
+    # Explicit encoding: the default is locale-dependent and mangles this
+    # module's box-drawing comments on a default Windows install.
+    return AGENT_LOOP.read_text(encoding="utf-8")
+
+
+def make_agent(skip_tests=False):
+    agent = object.__new__(AutonomousAgent)
+    agent.config = AgentConfig(repo_root=".", task="t", skip_tests=skip_tests)
+    agent.logger = SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    return agent
+
+
+# ── config surface ────────────────────────────────────────────────────────
+
+
+def test_skip_tests_defaults_to_off():
+    assert AgentConfig(repo_root=".", task="t").skip_tests is False
+
+
+# ── the stand-in result ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def result():
+    return make_agent(skip_tests=True)._skipped_execution(0.92)
+
+
+def test_the_result_counts_as_success(result):
+    """Otherwise the loop would retry until max_iterations with nothing to fix."""
+    assert result.success is True
+    assert result.exit_code == 0
+
+
+def test_it_does_not_claim_tests_ran(result):
+    assert "skipped" in result.command
+    assert "no test suite was run" in result.command
+    assert "Tests were not run" in result.stdout
+
+
+def test_it_records_the_confidence_the_decision_rested_on(result):
+    assert "0.92" in result.stdout
+
+
+def test_it_says_nothing_verified_the_change(result):
+    """A reader of the log should not have to infer this."""
+    assert "No suite verified this change" in result.stdout
+
+
+def test_it_is_not_a_timeout(result):
+    assert result.timed_out is False
+
+
+@pytest.mark.parametrize("confidence", [0.0, 0.5, 1.0])
+def test_confidence_is_rendered_for_any_value(confidence):
+    stdout = make_agent(skip_tests=True)._skipped_execution(confidence).stdout
+    assert f"{confidence:.2f}" in stdout
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_sandbox_is_bypassed_when_skipping():
+    """The point of the flag: no sandbox call at all."""
+    text = source()
+    start = text.index("if cfg.skip_tests:")
+    block = text[start:start + 200]
+
+    assert "_skipped_execution" in block
+    assert block.index("_skipped_execution") < block.index("_run_execution")
+
+
+def test_normal_runs_still_execute():
+    text = source()
+    start = text.index("if cfg.skip_tests:")
+    assert "self._run_execution()" in text[start:start + 200]
+
+
+def test_success_is_logged_differently_when_skipping():
+    """"Tests passed" would be a false statement under --skip-tests."""
+    text = source()
+    start = text.index("Accepting iteration")
+    block = text[max(0, start - 200):start + 200]
+
+    assert "--skip-tests" in block
+    assert "Tests passed" in text  # still used on the normal path


### PR DESCRIPTION
Closes #56

## Summary

The loop decides success from a test run, so a refactor or a comment pass in a repository with nothing to assert can never succeed. `--skip-tests` bypasses the sandbox and accepts changes on the model's confidence instead.

```bash
python main.py --repo . --task "Add docstrings to the parser module" --skip-tests
```

Off by default.

## The risk is a log that lies

Fabricating a passing `ExecutionResult` is the obvious implementation and the dangerous one: a run log would then read exactly like one where a suite went green. Someone reading it later — or a maintainer reviewing the resulting PR — would have no way to tell.

So the stand-in result says what happened, in the fields a reader actually sees:

```
command : (skipped - --skip-tests; no test suite was run)
stdout  : Tests were not run. Accepted on the model's own confidence of 0.92.
          No suite verified this change.
```

It reports `exit_code=0` and `success=True` because the loop needs that to stop — otherwise it would retry until `max_iterations` with nothing to fix — but nothing in it claims tests ran.

The success log line differs too. `"Tests passed on iteration 3"` would be a false statement under this flag, so the skip path logs at WARNING instead, naming the flag and the confidence the decision rested on.

## What it does not do

It does not lower the confidence threshold. `min_confidence_to_apply` still gates whether changes are applied at all, so a low-confidence response is still skipped — `--skip-tests` only removes the *verification* step, not the model's own self-assessment.

The issue mentions "or a basic lint check" as an alternative signal. I have left that out: a lint step is a separate concern that belongs in the sandbox rather than in the skip path, and #65 covers exactly that. Wiring lint in here would make `--skip-tests` mean two different things depending on configuration.

## Tests

`tests/test_skip_tests.py` — 12 cases.

Config: the flag defaults to off.

The stand-in result: it counts as success; it does not claim tests ran (asserted on both `command` and `stdout`); it records the confidence; it states that nothing verified the change; it is not a timeout; and the confidence renders for 0.0, 0.5 and 1.0.

Wiring: the sandbox is bypassed when skipping — the branch reaches `_skipped_execution` before `_run_execution` — normal runs still call `_run_execution`, and the success log differs on the skip path while `"Tests passed"` remains on the normal one.

The source-reading tests pass `encoding="utf-8"` explicitly. `Path.read_text()` defaults to the locale encoding, which is cp1252 on a default Windows install and mangles this module's box-drawing section comments — that cost a real test failure on a Windows machine during earlier work in this repo.

## Verified

- 12 tests pass; `tests/test_utils.py` still 4 passed; `--help` renders the flag
- ruff: `modules/agent_loop.py` at its baseline of 19 findings, `main.py` at 9 — none added
- `npx prettier --check README.md` clean
- merges clean against fifteen of the sixteen other branches

## Interaction with #51

One conflict, in `agent_loop.py`. Both PRs edit the `if exec_result.success:` block — #51 inserts its `_confirm_commit` gate there, this one changes the log line above it. Genuinely unavoidable and purely additive; the resolution is to keep the skip-tests logging, then #51's confirm gate, then the commit. I resolved it locally and ran the combined tree: 38 tests pass.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.