### PR TITLE
refactor(llm): move prompts into prompts/*.txt — Closes #59

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ python demo_run.py /path/to/sample_repo
 ### Module 3 — `llm_client.py`
 
 - Wraps the Anthropic API with structured JSON I/O.
+- Prompts live in `prompts/*.txt` (`system`, `initial`, `retry`) so they can be
+  edited and diffed without touching Python. Point `REPOPILOT_PROMPT_DIR` at
+  another directory to try an alternative set. A missing, empty or unreadable
+  file falls back to the built-in text, so a bad checkout degrades to the
+  previous behaviour rather than leaving the agent with no prompt.
 - System prompt enforces a machine-parseable output schema.
 - `initial_request()` for first pass; `retry_request()` for error-fed retries.
 - Parses `FileChange[]` from JSON; gracefully handles malformed output.

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -5,11 +5,15 @@ iterative refinement support. Uses Anthropic Claude API.
 """
 
 import json
+import logging
 import os
 import re
 import time
+from pathlib import Path
 from dataclasses import dataclass
 from typing import Optional
+
+_LOG = logging.getLogger("agent.llm_client")
 
 try:
     import anthropic
@@ -24,7 +28,42 @@ MAX_TOKENS = 8192
 # Prompt Templates
 # ─────────────────────────────────────────────
 
-SYSTEM_PROMPT = """You are an expert software engineer embedded in an autonomous code modification pipeline.
+# ─────────────────────────────────────────────
+# Prompt loading
+# ─────────────────────────────────────────────
+#
+# Prompts live in prompts/*.txt so they can be edited, diffed and swapped
+# without touching Python. The values below are the fallback: if a file is
+# missing or unreadable the built-in text is used, so a bad checkout degrades
+# to today's behaviour instead of leaving the agent with no prompt at all.
+#
+# Point REPOPILOT_PROMPT_DIR at another directory to try an alternative set.
+
+PROMPT_DIR_ENV_VAR = "REPOPILOT_PROMPT_DIR"
+DEFAULT_PROMPT_DIR = Path(__file__).resolve().parents[1] / "prompts"
+
+
+def prompt_dir() -> Path:
+    override = os.environ.get(PROMPT_DIR_ENV_VAR)
+    return Path(override) if override else DEFAULT_PROMPT_DIR
+
+
+def load_prompt(name: str, fallback: str) -> str:
+    """Read prompts/<name>.txt, falling back to the built-in text."""
+    path = prompt_dir() / f"{name}.txt"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        _LOG.debug("using built-in '%s' prompt (%s)", name, exc)
+        return fallback
+
+    if not text.strip():
+        _LOG.warning("%s is empty; using the built-in prompt instead", path)
+        return fallback
+    return text
+
+
+_BUILTIN_SYSTEM_PROMPT = """You are an expert software engineer embedded in an autonomous code modification pipeline.
 You receive:
 1. A task description
 2. Relevant source files from the repository
@@ -58,7 +97,7 @@ RULES:
 - Preserve existing code style, indentation, and conventions.
 """
 
-TASK_PROMPT_TEMPLATE = """\
+_BUILTIN_TASK_PROMPT = """\
 ## Task
 {task}
 
@@ -70,7 +109,7 @@ Analyze the code and produce the minimal changes needed to complete the task.
 Return ONLY the JSON object specified in the system prompt.
 """
 
-RETRY_PROMPT_TEMPLATE = """\
+_BUILTIN_RETRY_PROMPT = """\
 ## Task
 {task}
 
@@ -116,6 +155,11 @@ class LLMResponse:
     confidence: float
     done: bool
     parse_error: Optional[str] = None
+
+
+SYSTEM_PROMPT = load_prompt("system", _BUILTIN_SYSTEM_PROMPT)
+TASK_PROMPT_TEMPLATE = load_prompt("initial", _BUILTIN_TASK_PROMPT)
+RETRY_PROMPT_TEMPLATE = load_prompt("retry", _BUILTIN_RETRY_PROMPT)
 
 
 # ─────────────────────────────────────────────

--- a/prompts/initial.txt
+++ b/prompts/initial.txt
@@ -1,0 +1,9 @@
+## Task
+{task}
+
+## Repository Context
+{context}
+
+## Instructions
+Analyze the code and produce the minimal changes needed to complete the task.
+Return ONLY the JSON object specified in the system prompt.

--- a/prompts/retry.txt
+++ b/prompts/retry.txt
@@ -1,0 +1,22 @@
+## Task
+{task}
+
+## Previous Changes Applied
+The following files were modified in the previous iteration:
+{previous_changes_summary}
+
+## Execution Result (FAILED)
+Exit code: {exit_code}
+
+### stdout:
+{stdout}
+
+### stderr:
+{stderr}
+
+## Current Repository Context
+{context}
+
+## Instructions
+The previous attempt failed. Analyze the error output carefully and produce corrected changes.
+Focus on the root cause of the failure. Return ONLY the JSON object.

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -1,0 +1,32 @@
+You are an expert software engineer embedded in an autonomous code modification pipeline.
+You receive:
+1. A task description
+2. Relevant source files from the repository
+3. (Optionally) error output from a previous execution attempt
+
+Your job is to produce ONLY the file changes required to complete the task.
+
+OUTPUT FORMAT (STRICT — machine-parsed):
+Return a JSON object with this exact schema:
+
+{
+  "analysis": "<brief explanation of what you understood and what changes are needed>",
+  "changes": [
+    {
+      "path": "<relative file path from repo root>",
+      "action": "modify" | "create" | "delete",
+      "content": "<full new file content (for modify/create)>",
+      "explanation": "<why this change>"
+    }
+  ],
+  "confidence": <0.0-1.0 float>,
+  "done": <true if you believe the task is complete, false if more iterations needed>
+}
+
+RULES:
+- For "modify" and "create": always provide the COMPLETE file content, not diffs or snippets.
+- For "delete": omit "content".
+- Do NOT include markdown fences, explanation text, or anything outside the JSON object.
+- Paths must be relative (e.g., "src/utils.py"), never absolute.
+- If you cannot determine a fix, set confidence < 0.3 and done=false with a clear analysis.
+- Preserve existing code style, indentation, and conventions.

--- a/tests/test_prompt_files.py
+++ b/tests/test_prompt_files.py
@@ -1,0 +1,150 @@
+"""
+Tests for file-based prompts (modules/llm_client.py, prompts/).
+
+The prompts moved out of Python so they can be edited and diffed. Two things
+must hold: the text the model receives is unchanged, and a missing or broken
+prompts directory falls back to the built-in text rather than leaving the agent
+with no prompt at all.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import llm_client  # noqa: E402
+from modules.llm_client import (  # noqa: E402
+    PROMPT_DIR_ENV_VAR,
+    _BUILTIN_RETRY_PROMPT,
+    _BUILTIN_SYSTEM_PROMPT,
+    _BUILTIN_TASK_PROMPT,
+    load_prompt,
+    prompt_dir,
+)
+
+PROMPTS = Path(__file__).resolve().parents[1] / "prompts"
+
+PAIRS = [
+    ("system", _BUILTIN_SYSTEM_PROMPT),
+    ("initial", _BUILTIN_TASK_PROMPT),
+    ("retry", _BUILTIN_RETRY_PROMPT),
+]
+
+
+# ── the files match the built-ins ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name,builtin", PAIRS)
+def test_file_is_byte_identical_to_the_builtin(name, builtin):
+    """
+    The whole point is that behaviour does not change. A drift here would alter
+    what the model sees while looking like a pure refactor.
+    """
+    assert (PROMPTS / f"{name}.txt").read_text(encoding="utf-8") == builtin
+
+
+@pytest.mark.parametrize("name,_", PAIRS)
+def test_every_prompt_file_exists(name, _):
+    assert (PROMPTS / f"{name}.txt").is_file()
+
+
+def test_output_schema_survived_the_move():
+    assert "OUTPUT FORMAT (STRICT" in llm_client.SYSTEM_PROMPT
+    assert '"action"' in llm_client.SYSTEM_PROMPT
+
+
+@pytest.mark.parametrize(
+    "template,fields",
+    [
+        ("TASK_PROMPT_TEMPLATE", ["{task}", "{context}"]),
+        (
+            "RETRY_PROMPT_TEMPLATE",
+            ["{task}", "{context}", "{stdout}", "{stderr}", "{exit_code}",
+             "{previous_changes_summary}"],
+        ),
+    ],
+)
+def test_placeholders_are_intact(template, fields):
+    """A dropped placeholder would raise KeyError only at call time."""
+    text = getattr(llm_client, template)
+    for field in fields:
+        assert field in text
+
+
+def test_templates_still_format():
+    llm_client.TASK_PROMPT_TEMPLATE.format(task="t", context="c")
+    llm_client.RETRY_PROMPT_TEMPLATE.format(
+        task="t", context="c", stdout="o", stderr="e",
+        exit_code=1, previous_changes_summary="s",
+    )
+
+
+# ── falling back ──────────────────────────────────────────────────────────
+
+
+def test_missing_file_falls_back(tmp_path):
+    assert load_prompt("system", _BUILTIN_SYSTEM_PROMPT) is not None
+    assert load_prompt("does-not-exist", "fallback text") == "fallback text"
+
+
+def test_missing_directory_falls_back(monkeypatch):
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, "/definitely/not/a/directory")
+    assert load_prompt("system", _BUILTIN_SYSTEM_PROMPT) == _BUILTIN_SYSTEM_PROMPT
+
+
+def test_empty_file_falls_back(tmp_path, monkeypatch):
+    """An empty prompt would be accepted by the API and produce nonsense."""
+    (tmp_path / "system.txt").write_text("   \n\n")
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, str(tmp_path))
+
+    assert load_prompt("system", _BUILTIN_SYSTEM_PROMPT) == _BUILTIN_SYSTEM_PROMPT
+
+
+def test_a_directory_where_a_file_should_be_falls_back(tmp_path, monkeypatch):
+    (tmp_path / "system.txt").mkdir()
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, str(tmp_path))
+
+    assert load_prompt("system", _BUILTIN_SYSTEM_PROMPT) == _BUILTIN_SYSTEM_PROMPT
+
+
+def test_module_import_survives_a_missing_prompt_dir(monkeypatch):
+    """Reimporting with no prompts must not raise."""
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, "/definitely/not/a/directory")
+    reloaded = importlib.reload(llm_client)
+
+    assert reloaded.SYSTEM_PROMPT == _BUILTIN_SYSTEM_PROMPT
+    monkeypatch.delenv(PROMPT_DIR_ENV_VAR)
+    importlib.reload(llm_client)
+
+
+# ── overriding ────────────────────────────────────────────────────────────
+
+
+def test_env_var_redirects_the_directory(tmp_path, monkeypatch):
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, str(tmp_path))
+    assert prompt_dir() == tmp_path
+
+
+def test_default_directory_is_the_repo_prompts_folder(monkeypatch):
+    monkeypatch.delenv(PROMPT_DIR_ENV_VAR, raising=False)
+    assert prompt_dir() == PROMPTS
+
+
+def test_a_custom_prompt_is_used(tmp_path, monkeypatch):
+    (tmp_path / "system.txt").write_text("you are a haiku poet\n")
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, str(tmp_path))
+
+    assert load_prompt("system", _BUILTIN_SYSTEM_PROMPT) == "you are a haiku poet\n"
+
+
+def test_files_are_read_as_utf8(tmp_path, monkeypatch):
+    """Locale-dependent reads mangle non-ASCII on a default Windows install."""
+    (tmp_path / "system.txt").write_text(
+        "respond precisely — no waffle\n", encoding="utf-8"
+    )
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, str(tmp_path))
+
+    assert "—" in load_prompt("system", _BUILTIN_SYSTEM_PROMPT)


### PR DESCRIPTION
Closes #59

## Summary

`SYSTEM_PROMPT`, `TASK_PROMPT_TEMPLATE` and `RETRY_PROMPT_TEMPLATE` move out of `modules/llm_client.py` into `prompts/system.txt`, `prompts/initial.txt` and `prompts/retry.txt`, so prompt engineering is a text edit rather than a Python change and shows up as a readable diff.

`REPOPILOT_PROMPT_DIR` points at an alternative directory for trying a different set without touching the repository.

## The text is byte-identical

This is a refactor, so the only thing that really matters is that the model receives exactly what it received before. I checked it by loading `main`'s `llm_client` module side by side with the new one and comparing the constants directly:

```
SYSTEM_PROMPT          identical: True
TASK_PROMPT_TEMPLATE   identical: True
RETRY_PROMPT_TEMPLATE  identical: True
```

And again with `REPOPILOT_PROMPT_DIR` pointed somewhere that does not exist, so the fallback path is verified to produce the same text as well. A test asserts each file against its built-in constant, so drift would fail CI rather than quietly changing what the model sees while looking like a pure refactor.

## Missing prompts must not break the agent

The built-in strings stay in the module as `_BUILTIN_*` and are used whenever a file cannot be read. A missing file, a missing directory, an empty file, or a directory where a file should be all fall back rather than raising — a bad checkout or a half-applied patch degrades to today's behaviour instead of leaving the agent with no prompt at all.

An empty file is treated as missing on purpose. The API would accept an empty system prompt and return confident nonsense, which is a much harder failure to diagnose than a warning in the log.

Module import is tested under a missing prompt directory, since a `load_prompt` at import time that raised would take the whole CLI down.

## Encoding

Prompt files are read with `encoding="utf-8"` explicitly. `Path.read_text()` defaults to the locale encoding — cp1252 on a default Windows install — which would mangle any non-ASCII a contributor puts in a prompt. There is a test for it. This came out of a real Windows failure in earlier work on this repo, so it seemed worth pinning rather than assuming.

## Tests

`tests/test_prompt_files.py` — 19 cases.

Fidelity: each of the three files is byte-identical to its built-in; all three exist; the output schema survived the move; every `{placeholder}` is intact in both templates — a dropped one would only raise `KeyError` at call time, in the middle of a run — and both templates still `.format()` cleanly.

Fallback: a missing file, a missing directory, an empty file, and a directory-shaped file all fall back; module import survives a missing prompt directory.

Overriding: the env var redirects the directory; the default is the repo's `prompts/`; a custom prompt is used when present; files are read as UTF-8.

## Verified

- the byte-identity comparison above, both normally and via the fallback
- 19 tests pass; `tests/test_utils.py` still 4 passed
- ruff: `modules/llm_client.py` at its baseline of 5 findings, i.e. none added
- `npx prettier --check README.md` clean
- merges clean against all sixteen other branches

I anchored the README addition on the first Module 3 bullet rather than the last, because #62 adds its own bullet at the last one. That alone was the difference between a conflict and a clean merge.

## Note on line endings

The `prompts/*.txt` files are compared byte-for-byte against the built-in strings, so they are sensitive to line-ending conversion. If `core.autocrlf` rewrites them on checkout the fidelity tests will fail on Windows. If that happens, the right fix is a `.gitattributes` entry pinning `prompts/*.txt` to LF rather than relaxing the test — I would rather the check stay strict, since its whole purpose is catching drift.

## Interaction with #63

No conflict today, but worth flagging: #63 edits the text of `SYSTEM_PROMPT` to document the `rename` action. Whichever of the two merges second needs its change to land in `prompts/system.txt` rather than in the Python constant. The `_BUILTIN_SYSTEM_PROMPT` fallback should be updated to match, or the fidelity test will catch the divergence — which is the intended behaviour.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.