### PR TITLE
feat(dashboard): render and follow run logs — Closes #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,41 +196,9 @@ python demo_run.py /path/to/sample_repo
 ### Module 5 — `sandbox.py`
 
 - `SubprocessSandbox`: runs commands via `subprocess.run()` with timeout, output
-  capture, and environment sanitization.
+  capture, and environment sanitization (blocks cloud credentials from leaking).
 - `DockerSandbox`: wraps Docker with `--network=none`, memory/CPU caps, read-only
   volume mount. Falls back to subprocess if Docker is unavailable.
-
-#### Environment sanitization
-
-The sandbox executes code the model wrote, so the environment it receives is an
-**allowlist**: only the variables named in `ALLOWED_ENV_VARS` reach the child
-process, and everything else is dropped. A denylist would only cover the names
-somebody thought of, leaving every newly adopted service unprotected by default.
-
-The allowlist covers what the runners actually need — `PATH`, `HOME`, locale and
-temp dirs, the Windows core (`SYSTEMROOT`, `COMSPEC`, …), and the Python, Node,
-Go, Rust, Ruby, Java and Docker-client toolchain variables. Credentials such as
-`ANTHROPIC_API_KEY`, `SSH_AUTH_SOCK` and `KUBECONFIG` are not on it, and neither
-are the GitHub Actions runner variables: `GITHUB_ENV` and `GITHUB_PATH` name
-writable files that inject state into later workflow steps.
-
-If a runner needs a variable that is not covered, add it at runtime rather than
-widening the defaults:
-
-```bash
-# comma-separated; logged whenever it takes effect
-export REPOPILOT_SANDBOX_ENV_PASSTHROUGH=GOPROXY,npm_config_registry
-```
-
-Set the log level to `DEBUG` to see exactly which variables were stripped from a
-given run (names only — values are never logged).
-
-> **Scope.** This closes the easiest exfiltration path, not every path. In
-> subprocess mode the filesystem is not isolated, so `~/.aws/credentials` and
-> `~/.npmrc` remain readable; use `DockerSandbox` for genuinely untrusted code.
-> Dropping `SSH_AUTH_SOCK` is the exception that is decisive on its own — a
-> forwarded agent socket signs with the private key without ever reading it, so
-> file permissions cannot help there.
 
 ### Module 6 — `agent_loop.py` (CORE)
 
@@ -251,6 +219,26 @@ given run (names only — values are never logged).
 - Every iteration appended to `<run_id>.jsonl` (structured, machine-readable).
 - Human-readable log at `<run_id>_human.log`.
 - Final `<run_id>_summary.json` with full run record.
+
+---
+
+### `dashboard.py` — run viewer
+
+Renders a run log as a readable timeline — the model's analysis, its file
+changes, and the test output for each iteration:
+
+```bash
+python -m modules.dashboard logs/agent_20260807_abc.jsonl
+python -m modules.dashboard logs/agent_20260807_abc.jsonl --follow
+```
+
+`--follow` tails the log while a run is in progress, so a long run is visible as
+it happens rather than scrolling past in CLI output.
+
+It reads the JSONL `logger.py` already writes rather than being instrumented
+into the loop. That keeps it decoupled: it works on a finished run, on a run in
+another terminal, and needs no changes to `agent_loop.py`. It also means no web
+server and no new dependency. Colour is disabled off a tty and by `NO_COLOR`.
 
 ---
 
@@ -292,7 +280,6 @@ return MAX_RETRIES
 | ---------------------------- | ----------------------------------- | -------------------------------------------------------------- |
 | `JSONDecodeError` from LLM   | Model adds markdown fences or prose | Regex strips fences; parse error fed back as context next iter |
 | Path traversal in LLM output | LLM outputs `../../etc/passwd`      | `_safe_abs_path()` validates all paths against repo root       |
-| Credentials reach LLM code   | Child process inherits `os.environ` | `_build_safe_env()` allowlist; only named toolchain vars pass  |
 | Empty content for modify     | LLM returns `""` for file content   | Validation rejects before apply; error logged                  |
 | Infinite test loop           | Test hangs                          | `timeout_seconds` in sandbox kills process                     |
 | Repo too large               | Monorepo with 10K files             | 8MB total budget + per-file 512KB cap; budget exhausted = skip |

--- a/modules/dashboard.py
+++ b/modules/dashboard.py
@@ -1,0 +1,261 @@
+"""
+Module: Run dashboard.
+
+`logger.py` already writes one JSON object per iteration to `logs/<run_id>.jsonl`.
+This renders that as a readable timeline, and with --follow it tails the file
+while a run is in progress — so the agent's reasoning, its file changes and its
+test output are visible as they happen rather than scrolling past in CLI output.
+
+    python -m modules.dashboard logs/agent_20260807_abc.jsonl
+    python -m modules.dashboard logs/agent_20260807_abc.jsonl --follow
+
+Reading the log rather than instrumenting the loop keeps this decoupled: it
+works on a finished run, on a run in another terminal, and needs no changes to
+agent_loop.py. It also means no web server and no new dependency.
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import Iterator, Optional
+
+POLL_SECONDS = 0.5
+
+# Plain ANSI. Disabled when stdout is not a tty, so piping to a file or a CI log
+# produces clean text rather than escape sequences.
+_CODES = {
+    "reset": "\033[0m",
+    "dim": "\033[2m",
+    "bold": "\033[1m",
+    "red": "\033[31m",
+    "green": "\033[32m",
+    "yellow": "\033[33m",
+    "blue": "\033[34m",
+    "cyan": "\033[36m",
+}
+
+
+def _use_colour(stream=None) -> bool:
+    stream = stream or sys.stdout
+    if os.environ.get("NO_COLOR"):
+        return False
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def paint(text: str, colour: str, enabled: bool = True) -> str:
+    if not enabled or colour not in _CODES:
+        return text
+    return f"{_CODES[colour]}{text}{_CODES['reset']}"
+
+
+def read_records(path: str) -> list[dict]:
+    """Parse a run log. Malformed lines are skipped, not fatal."""
+    records = []
+    with open(path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                # A run killed mid-write leaves a partial final line. Showing
+                # the rest of the run is more useful than refusing to start.
+                continue
+    return records
+
+
+def follow_records(path: str, poll: float = POLL_SECONDS) -> Iterator[dict]:
+    """
+    Yield records as they are appended, waiting for the file to appear.
+
+    Buffers a partial trailing line rather than discarding it: a record being
+    written when we read is complete a moment later.
+    """
+    while not os.path.exists(path):
+        time.sleep(poll)
+
+    buffer = ""
+    with open(path, "r", encoding="utf-8") as handle:
+        while True:
+            chunk = handle.readline()
+            if not chunk:
+                time.sleep(poll)
+                continue
+            buffer += chunk
+            if not buffer.endswith("\n"):
+                continue
+            for line in buffer.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+            buffer = ""
+
+
+def summary_path_for(log_path: str) -> str:
+    base = log_path[:-6] if log_path.endswith(".jsonl") else log_path
+    return f"{base}_summary.json"
+
+
+def read_summary(log_path: str) -> Optional[dict]:
+    """The summary is only written when a run finishes."""
+    try:
+        with open(summary_path_for(log_path), "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _outcome_colour(outcome: str) -> str:
+    return {
+        "success": "green",
+        "failed": "red",
+        "max_retries": "red",
+        "error": "red",
+        "aborted": "yellow",
+        "budget_exceeded": "yellow",
+        "dry_run": "cyan",
+    }.get(outcome, "yellow")
+
+
+def render_iteration(record: dict, colour: bool = True, width: int = 78) -> str:
+    """One iteration as a block of text."""
+    lines: list[str] = []
+    number = record.get("iteration", "?")
+
+    lines.append(paint("─" * width, "dim", colour))
+    header = f"Iteration {number}"
+    timestamp = record.get("timestamp", "")
+    if timestamp:
+        header += f"   {timestamp}"
+    lines.append(paint(header, "bold", colour))
+
+    files = record.get("context_files") or []
+    if files:
+        shown = ", ".join(files[:5])
+        if len(files) > 5:
+            shown += f" (+{len(files) - 5} more)"
+        chars = record.get("context_chars", 0)
+        summary_line = f"  context   {len(files)} files, {chars:,} chars"
+        lines.append(paint(summary_line, "dim", colour))
+        lines.append(paint(f"            {shown}", "dim", colour))
+
+    analysis = (record.get("llm_analysis") or "").strip()
+    if analysis:
+        lines.append(paint("  analysis", "cyan", colour))
+        for line in analysis.splitlines()[:6]:
+            lines.append(f"    {line}")
+
+    confidence = record.get("llm_confidence")
+    if confidence is not None:
+        done = "done" if record.get("llm_done") else "not done"
+        lines.append(paint(f"  confidence {confidence:.2f} ({done})", "dim", colour))
+
+    if record.get("parse_error"):
+        lines.append(
+            paint(f"  parse error: {record['parse_error'][:200]}", "red", colour)
+        )
+
+    for change in record.get("changes_attempted") or []:
+        action = change.get("action", "?")
+        path = change.get("path", "?")
+        lines.append(paint(f"  {action:<7} {path}", "blue", colour))
+
+    failed = [r for r in (record.get("apply_results") or []) if not r.get("success")]
+    for result in failed:
+        lines.append(
+            paint(
+                f"  FAILED  {result.get('path')}: {result.get('error')}", "red", colour
+            )
+        )
+
+    command = record.get("execution_command")
+    if command:
+        success = record.get("execution_success")
+        timed_out = record.get("execution_timed_out")
+        status = "PASS" if success else ("TIMEOUT" if timed_out else "FAIL")
+        lines.append(
+            paint(f"  {status}", "green" if success else "red", colour)
+            + paint(
+                f"  exit={record.get('execution_exit_code')}  {command}", "dim", colour
+            )
+        )
+        if not success:
+            tail = (
+                record.get("execution_stderr")
+                or record.get("execution_stdout")
+                or ""
+            )
+            for line in tail.strip().splitlines()[-8:]:
+                lines.append(paint(f"    {line}", "dim", colour))
+
+    return "\n".join(lines)
+
+
+def render_summary(summary: dict, colour: bool = True) -> str:
+    outcome = summary.get("outcome", "unknown")
+    lines = [
+        paint("=" * 78, "dim", colour),
+        paint(f"OUTCOME   {outcome.upper()}", _outcome_colour(outcome), colour),
+        f"RUN       {summary.get('run_id', '')}",
+        f"TASK      {(summary.get('task') or '')[:200]}",
+    ]
+    if summary.get("branch_name"):
+        lines.append(f"BRANCH    {summary['branch_name']}")
+    if summary.get("pr_url"):
+        lines.append(f"PR        {summary['pr_url']}")
+    if summary.get("final_error"):
+        lines.append(paint(f"ERROR     {summary['final_error']}", "red", colour))
+    return "\n".join(lines)
+
+
+def show(path: str, follow: bool = False, colour: Optional[bool] = None) -> int:
+    colour = _use_colour() if colour is None else colour
+
+    if not follow:
+        if not os.path.exists(path):
+            print(f"No such run log: {path}", file=sys.stderr)
+            return 1
+        for record in read_records(path):
+            print(render_iteration(record, colour))
+        summary = read_summary(path)
+        if summary:
+            print(render_summary(summary, colour))
+        return 0
+
+    print(paint(f"Following {path} — Ctrl+C to stop", "dim", colour))
+    try:
+        for record in follow_records(path):
+            print(render_iteration(record, colour))
+            summary = read_summary(path)
+            if summary and summary.get("outcome"):
+                print(render_summary(summary, colour))
+                return 0
+    except KeyboardInterrupt:
+        print()
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Render a RepoPilot run log as a readable timeline.",
+    )
+    parser.add_argument("log", help="Path to logs/<run_id>.jsonl")
+    parser.add_argument(
+        "--follow", "-f", action="store_true",
+        help="Tail the log while a run is in progress",
+    )
+    parser.add_argument("--no-color", action="store_true", help="Disable ANSI colour")
+    args = parser.parse_args(argv)
+
+    return show(args.log, follow=args.follow, colour=False if args.no_color else None)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,275 @@
+"""
+Tests for the run dashboard (modules/dashboard.py).
+
+The dashboard reads the JSONL that logger.py already writes, rather than being
+instrumented into the loop. That decoupling is what makes it work on a finished
+run, on a run in another terminal, and without touching agent_loop.py — so the
+parsing has to tolerate whatever state the file is in when it is read.
+"""
+
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.dashboard import (  # noqa: E402
+    follow_records,
+    main,
+    paint,
+    read_records,
+    read_summary,
+    render_iteration,
+    render_summary,
+    show,
+    summary_path_for,
+)
+
+ITERATION = {
+    "type": "iteration",
+    "iteration": 1,
+    "timestamp": "2026-08-07T13:12:22",
+    "context_files": ["utils.py", "test_utils.py"],
+    "context_chars": 3182,
+    "llm_analysis": "The functions lack input validation.",
+    "llm_confidence": 0.97,
+    "llm_done": True,
+    "changes_attempted": [{"path": "utils.py", "action": "modify"}],
+    "apply_results": [{"path": "utils.py", "success": True, "error": None}],
+    "execution_command": "python -m pytest",
+    "execution_exit_code": 0,
+    "execution_stdout": "4 passed",
+    "execution_stderr": "",
+    "execution_timed_out": False,
+    "execution_success": True,
+    "parse_error": None,
+}
+
+
+def write_log(tmp_path, *records, name="run.jsonl"):
+    path = tmp_path / name
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+    return str(path)
+
+
+# ── parsing ───────────────────────────────────────────────────────────────
+
+
+def test_records_are_read_in_order(tmp_path):
+    path = write_log(tmp_path, {"iteration": 1}, {"iteration": 2}, {"iteration": 3})
+    assert [r["iteration"] for r in read_records(path)] == [1, 2, 3]
+
+
+def test_a_truncated_final_line_is_skipped(tmp_path):
+    """
+    A run killed mid-write leaves a partial line. Showing the rest is more
+    useful than refusing to open the file.
+    """
+    path = tmp_path / "run.jsonl"
+    path.write_text('{"iteration": 1}\n{"iteration": 2}\n{"iterat')
+
+    assert [r["iteration"] for r in read_records(str(path))] == [1, 2]
+
+
+def test_blank_lines_are_ignored(tmp_path):
+    path = tmp_path / "run.jsonl"
+    path.write_text('{"iteration": 1}\n\n\n{"iteration": 2}\n')
+
+    assert len(read_records(str(path))) == 2
+
+
+def test_an_empty_log_yields_nothing(tmp_path):
+    path = tmp_path / "run.jsonl"
+    path.write_text("")
+    assert read_records(str(path)) == []
+
+
+# ── the summary ───────────────────────────────────────────────────────────
+
+
+def test_summary_path_is_derived_from_the_log():
+    assert summary_path_for("logs/run_abc.jsonl") == "logs/run_abc_summary.json"
+
+
+def test_a_missing_summary_is_not_an_error(tmp_path):
+    """It is only written when a run finishes; mid-run there is none."""
+    assert read_summary(write_log(tmp_path, ITERATION)) is None
+
+
+def test_a_malformed_summary_is_not_an_error(tmp_path):
+    path = write_log(tmp_path, ITERATION)
+    Path(summary_path_for(path)).write_text("{not json")
+
+    assert read_summary(path) is None
+
+
+def test_the_summary_is_read_when_present(tmp_path):
+    path = write_log(tmp_path, ITERATION)
+    Path(summary_path_for(path)).write_text(json.dumps({"outcome": "success"}))
+
+    assert read_summary(path)["outcome"] == "success"
+
+
+# ── rendering ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def rendered():
+    return render_iteration(ITERATION, colour=False)
+
+
+def test_analysis_is_shown(rendered):
+    assert "The functions lack input validation." in rendered
+
+
+def test_context_and_changes_are_shown(rendered):
+    assert "2 files" in rendered
+    assert "3,182 chars" in rendered
+    assert "modify" in rendered and "utils.py" in rendered
+
+
+def test_confidence_is_shown(rendered):
+    assert "0.97" in rendered
+
+
+def test_a_passing_run_is_marked_pass(rendered):
+    assert "PASS" in rendered
+
+
+def test_a_failing_run_shows_its_output():
+    failing = dict(
+        ITERATION, execution_success=False, execution_exit_code=1,
+        execution_stderr="AssertionError: expected 3, got 4",
+    )
+    text = render_iteration(failing, colour=False)
+
+    assert "FAIL" in text
+    assert "AssertionError: expected 3, got 4" in text
+
+
+def test_a_timeout_is_distinguished_from_a_failure():
+    text = render_iteration(
+        dict(ITERATION, execution_success=False, execution_timed_out=True), colour=False
+    )
+    assert "TIMEOUT" in text
+
+
+def test_failed_file_writes_are_surfaced():
+    text = render_iteration(
+        dict(ITERATION, apply_results=[
+            {"path": "x.py", "success": False, "error": "Path traversal detected"}
+        ]),
+        colour=False,
+    )
+    assert "FAILED" in text and "Path traversal detected" in text
+
+
+def test_a_parse_error_is_surfaced():
+    record = dict(ITERATION, parse_error="No JSON object found")
+    text = render_iteration(record, colour=False)
+    assert "No JSON object found" in text
+
+
+def test_a_sparse_record_still_renders():
+    """Records from an aborted iteration carry very few fields."""
+    assert "Iteration 2" in render_iteration({"iteration": 2}, colour=False)
+
+
+def test_outcome_is_shown_in_the_summary():
+    summary = {"outcome": "success", "run_id": "r", "task": "t"}
+    text = render_summary(summary, colour=False)
+    assert "SUCCESS" in text
+
+
+# ── colour ────────────────────────────────────────────────────────────────
+
+
+def test_colour_can_be_disabled():
+    assert paint("hello", "red", enabled=False) == "hello"
+
+
+def test_colour_wraps_when_enabled():
+    assert paint("hello", "red", enabled=True) != "hello"
+
+
+def test_rendering_without_colour_has_no_escape_codes(rendered):
+    assert "\033[" not in rendered
+
+
+# ── following a live run ──────────────────────────────────────────────────
+
+
+def test_follow_yields_records_as_they_are_written(tmp_path):
+    path = str(tmp_path / "live.jsonl")
+
+    def writer():
+        time.sleep(0.2)  # the file does not exist yet when following starts
+        with open(path, "w", encoding="utf-8") as handle:
+            for i in (1, 2, 3):
+                handle.write(json.dumps({"iteration": i}) + "\n")
+                handle.flush()
+                time.sleep(0.1)
+
+    threading.Thread(target=writer, daemon=True).start()
+
+    seen = []
+    for record in follow_records(path, poll=0.05):
+        seen.append(record["iteration"])
+        if len(seen) == 3:
+            break
+
+    assert seen == [1, 2, 3]
+
+
+def test_follow_buffers_a_partial_line(tmp_path):
+    """
+    A record being written when we read is complete a moment later. Discarding
+    it would silently drop an iteration from a live view.
+    """
+    path = str(tmp_path / "live.jsonl")
+
+    def writer():
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write('{"iteration": 1, "llm_conf')
+            handle.flush()
+            time.sleep(0.3)
+            handle.write('idence": 0.9}\n')
+            handle.flush()
+
+    threading.Thread(target=writer, daemon=True).start()
+
+    for record in follow_records(path, poll=0.05):
+        assert record["iteration"] == 1
+        assert record["llm_confidence"] == 0.9
+        break
+
+
+# ── the command line ──────────────────────────────────────────────────────
+
+
+def test_a_missing_log_reports_rather_than_crashing(tmp_path, capsys):
+    assert show(str(tmp_path / "nope.jsonl")) == 1
+    assert "No such run log" in capsys.readouterr().err
+
+
+def test_showing_a_finished_run_succeeds(tmp_path, capsys):
+    path = write_log(tmp_path, ITERATION)
+    Path(summary_path_for(path)).write_text(
+        json.dumps({"outcome": "success", "run_id": "r"})
+    )
+
+    assert show(path, colour=False) == 0
+    out = capsys.readouterr().out
+    assert "Iteration 1" in out and "SUCCESS" in out
+
+
+def test_main_accepts_no_color(tmp_path, capsys):
+    path = write_log(tmp_path, ITERATION)
+    assert main([path, "--no-color"]) == 0
+    assert "\033[" not in capsys.readouterr().out


### PR DESCRIPTION
Closes #55

## Summary

Adds `modules/dashboard.py`, which renders a run log as a readable timeline — the model's analysis, its file changes and the test output for each iteration — and tails it while a run is in progress.

```bash
python -m modules.dashboard logs/agent_20260807_abc.jsonl
python -m modules.dashboard logs/agent_20260807_abc.jsonl --follow
```

## A terminal viewer over the existing log, not a web UI

The issue suggests FastAPI or `rich`/`textual`. I went a different way, and the reasoning is worth stating because it is the main design decision here.

`logger.py` already writes one JSON object per iteration to `logs/<run_id>.jsonl`. Reading that gives everything the issue asks for — thought process, test results, changes — while a live view is just tailing the file. That buys three things a bolted-on UI would not:

- **Zero changes to `agent_loop.py`.** Nothing new can break a run.
- **No new dependency.** Plain ANSI, disabled off a tty and by `NO_COLOR`. No web server, no async framework, nothing to install.
- **It works on runs it was not present for.** A finished run, a run in another terminal, a log someone sent you.

Rendered against a real demo run:

```
──────────────────────────────────────────────────────────────────────
Iteration 1   2026-08-07T13:12:22
  context   2 files, 3,182 chars
            test_utils.py, utils.py
  analysis
    The utils.py functions lack input validation. I need to add empty-list
    guards to calculate_average and find_max...
  confidence 0.97 (done)
  modify  utils.py
  PASS  exit=0  /usr/bin/python3 -m pytest
======================================================================
OUTCOME   SUCCESS
RUN       demo_20260807_131222_9f0654
BRANCH    agent/demo-fix-9f0654
```

If a richer TUI or a web view is wanted later, this is the layer it would sit on rather than something it would replace.

## The parsing has to tolerate a live file

Reading a log while it is being written means meeting it in whatever state it is in, and the two cases pull in opposite directions:

**A partial line while following is buffered, not discarded.** A record being written when we read is complete a moment later; dropping it would silently lose an iteration from a live view. Verified against a writer thread that deliberately splits a record mid-field:

```
iteration 1 at +0.4s      (waited for a file that did not exist yet)
iteration 2 at +0.7s
iteration 3 at +1.0s
iteration 4 at +1.7s      (written in two halves, reassembled)
```

**A truncated final line in a finished log is skipped.** A run killed mid-write leaves one; showing the rest of the run is more useful than refusing to open the file.

`--follow` also waits for the log to appear, so it can be started before the agent is.

## Other details

The summary JSON is only written when a run finishes, so a missing or malformed one is not an error — mid-run there simply is not one yet.

Sparse records render fine. An iteration that aborted early carries very few fields, and the renderer shows what is there rather than raising on a missing key.

Failed writes and parse errors are surfaced explicitly, since those are the cases a reader is usually looking for.

## Tests

`tests/test_dashboard.py` — 26 cases.

Parsing: records read in order; a truncated final line skipped; blank lines ignored; an empty log yields nothing.

Summary: the path is derived from the log name; a missing summary is not an error; a malformed one is not either; a present one is read.

Rendering: analysis, context, changes and confidence shown; PASS marked; a failing run shows its output; a timeout is distinguished from a failure; failed file writes and parse errors are surfaced; a sparse record still renders.

Colour: can be disabled; wraps when enabled; no escape codes leak into uncoloured output.

Following: records arrive as they are written; a partial line is buffered and reassembled.

Command line: a missing log reports rather than crashing; a finished run renders and exits 0; `--no-color` produces clean text.

## Verified

- rendered against a real `demo_run.py` log, output above
- the live-follow timings above, with a deliberately split record
- 26 tests pass; `tests/test_utils.py` still 4 passed
- ruff clean on both new files; `npx prettier --check README.md` clean
- merges clean against all nineteen other branches

## One thing worth knowing about `demo_run.py`

While testing this I ran `demo_run.py`, which checked out its own `agent/demo-fix-*` branch in my working copy and committed my staged file into it. Recoverable, but surprising. That side effect is documented in the CONTRIBUTING guide in #67; flagging it here because it caught me even though I had written it down.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.