### PR TITLE
feat(cli): add --update to fast-forward the checkout — Closes #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,32 @@ through as a literal task would send the agent off to implement a URL.
 
 ---
 
+## Updating RepoPilot
+
+```bash
+python main.py --update
+```
+
+Fast-forwards RepoPilot's own checkout to the latest upstream commit. Fetching
+and then running new code is remote code execution by definition, so this is
+deliberately conservative:
+
+- it updates a **git checkout** rather than unpacking a downloaded archive, so
+  every change is attributable to a commit and reversible with `git reset`
+- it **fast-forwards only** — a diverged local branch is reported, never
+  overwritten
+- it **refuses on a dirty tree**, so nothing uncommitted is lost
+- it **shows the incoming commits and asks** before moving anything (`--yes`
+  skips the prompt)
+- it **prints the pip command rather than running it** when `requirements.txt`
+  changes
+
+`--repo` is not required with `--update`.
+
+---
+
+---
+
 ## Module Reference
 
 ### Module 1 — `repo_ingestion.py`

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from modules.agent_loop import AutonomousAgent, AgentConfig
 from modules.notify import notify_run_complete
 from modules.code_modifier import CodeModificationEngine
+from modules.updater import run_update
 from modules.task_source import (
     TaskResolutionError,
     looks_like_issue_url,
@@ -46,7 +47,8 @@ Examples:
         """
     )
 
-    parser.add_argument("--repo", required=True, help="Path to the git repository")
+    parser.add_argument("--repo", required=False,
+                        help="Path to the git repository (not needed with --update)")
     parser.add_argument("--task", required=False, help="High-level task description, or a GitHub issue URL to pull one from (can also be provided via AGENT_TASK env var)")
 
     # Execution
@@ -99,6 +101,10 @@ Examples:
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress verbose output")
     parser.add_argument("--dry-run", "-d", action="store_true",help="Preview changes without applying them. Saves a manifest to logs/.")
+    parser.add_argument("--update", action="store_true",
+                        help="Fast-forward RepoPilot's own checkout to the latest "
+                             "upstream commit. Refuses on a dirty tree or a diverged "
+                             "branch, and never installs packages for you.")
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
     # API key
@@ -149,6 +155,13 @@ def main():
                         setattr(args, k, v)
         except Exception as e:
             print(f"Warning: Failed to load config file {config_file}: {e}", file=sys.stderr)
+
+    if args.update:
+        sys.exit(run_update(assume_yes=args.yes))
+
+    if not args.repo:
+        print("ERROR: --repo is required (except with --update).", file=sys.stderr)
+        sys.exit(2)
 
     repo_root = os.path.abspath(args.repo)
     if args.rollback:

--- a/modules/updater.py
+++ b/modules/updater.py
@@ -42,6 +42,14 @@ class UpdateResult:
     requirements_changed: bool = False
 
 
+def _same_path(a: str, b: str) -> bool:
+    """Compare two paths, tolerating symlinks and Windows case differences."""
+    return (
+        os.path.normcase(os.path.realpath(a))
+        == os.path.normcase(os.path.realpath(b))
+    )
+
+
 def _git(*args: str, cwd: str = INSTALL_ROOT) -> subprocess.CompletedProcess:
     return subprocess.run(
         ["git", *args],
@@ -55,10 +63,26 @@ def _git(*args: str, cwd: str = INSTALL_ROOT) -> subprocess.CompletedProcess:
 
 
 def is_git_checkout(root: str = INSTALL_ROOT) -> bool:
+    """
+    True only if `root` is itself the top of a git checkout.
+
+    `git rev-parse --is-inside-work-tree` walks *up* the directory tree, so it
+    answers "true" for any directory nested inside a repository. Relying on it
+    would let --update fast-forward an ancestor repo -- someone's home directory,
+    or a parent project -- instead of RepoPilot. Comparing the discovered
+    toplevel against `root` is what makes the refusal mean anything.
+    """
     try:
-        return _git("rev-parse", "--is-inside-work-tree", cwd=root).returncode == 0
+        result = _git("rev-parse", "--show-toplevel", cwd=root)
     except (OSError, subprocess.SubprocessError):
         return False
+    if result.returncode != 0:
+        return False
+
+    toplevel = result.stdout.strip()
+    if not toplevel:
+        return False
+    return _same_path(toplevel, root)
 
 
 def has_local_changes(root: str = INSTALL_ROOT) -> bool:
@@ -131,6 +155,9 @@ def apply_update(
     root: str = INSTALL_ROOT,
 ) -> UpdateResult:
     """Fast-forward to the fetched commit. Refuses anything else."""
+    if not is_git_checkout(root):
+        return UpdateResult(False, f"{root} is not the top of a git checkout.")
+
     if has_local_changes(root):
         return UpdateResult(
             False,

--- a/modules/updater.py
+++ b/modules/updater.py
@@ -1,0 +1,208 @@
+"""
+Module: Self-update.
+
+Updates RepoPilot's own checkout to the latest upstream commit.
+
+The design is deliberately conservative, because "fetch the latest code and run
+it" is remote code execution by definition:
+
+- It updates a **git checkout** rather than downloading and unpacking an
+  archive, so every change is signed by the transport, attributable to a commit,
+  and reversible with `git reset`.
+- It **fast-forwards only**. A diverged local branch is reported, never
+  overwritten.
+- It **refuses on a dirty tree**, so nothing uncommitted is lost.
+- It **shows the incoming commits and asks** before moving anything.
+- It **prints the pip command rather than running it**. Installing packages as a
+  side effect of `--update` is the kind of surprise that erodes trust in a tool.
+"""
+
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+
+_LOG = logging.getLogger("agent.updater")
+
+# The directory this file lives in, i.e. RepoPilot's own checkout -- not the
+# repository the agent is being pointed at.
+INSTALL_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+DEFAULT_REMOTE = "origin"
+DEFAULT_BRANCH = "main"
+GIT_TIMEOUT = 60
+
+
+@dataclass
+class UpdateResult:
+    ok: bool
+    message: str
+    commits: list[str] = field(default_factory=list)
+    requirements_changed: bool = False
+
+
+def _git(*args: str, cwd: str = INSTALL_ROOT) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=GIT_TIMEOUT,
+    )
+
+
+def is_git_checkout(root: str = INSTALL_ROOT) -> bool:
+    try:
+        return _git("rev-parse", "--is-inside-work-tree", cwd=root).returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def has_local_changes(root: str = INSTALL_ROOT) -> bool:
+    result = _git("status", "--porcelain", cwd=root)
+    return bool(result.stdout.strip())
+
+
+def current_branch(root: str = INSTALL_ROOT) -> str:
+    return _git("rev-parse", "--abbrev-ref", "HEAD", cwd=root).stdout.strip()
+
+
+def check_for_updates(
+    remote: str = DEFAULT_REMOTE,
+    branch: str = DEFAULT_BRANCH,
+    root: str = INSTALL_ROOT,
+) -> UpdateResult:
+    """Fetch and report what would change, without touching the working tree."""
+    if not is_git_checkout(root):
+        return UpdateResult(
+            False,
+            f"{root} is not a git checkout, so it cannot be updated this way. "
+            f"Reinstall by cloning the repository.",
+        )
+
+    fetch = _git("fetch", remote, branch, cwd=root)
+    if fetch.returncode != 0:
+        return UpdateResult(
+            False, f"Could not fetch {remote}/{branch}: {fetch.stderr.strip()}"
+        )
+
+    target = f"{remote}/{branch}"
+    log = _git("log", "--oneline", f"HEAD..{target}", cwd=root)
+    if log.returncode != 0:
+        return UpdateResult(
+            False, f"Could not compare against {target}: {log.stderr.strip()}"
+        )
+
+    commits = [line for line in log.stdout.splitlines() if line.strip()]
+    if not commits:
+        return UpdateResult(True, f"Already up to date with {target}.")
+
+    # Only a fast-forward is safe. A diverged branch means local commits that a
+    # merge or reset would discard or entangle.
+    ahead = _git("rev-list", "--count", f"{target}..HEAD", cwd=root)
+    if ahead.returncode == 0 and ahead.stdout.strip() not in ("", "0"):
+        return UpdateResult(
+            False,
+            f"Your checkout has {ahead.stdout.strip()} commit(s) not on {target}. "
+            f"Refusing to update automatically -- rebase or reset by hand.",
+            commits=commits,
+        )
+
+    changed = _git("diff", "--name-only", f"HEAD..{target}", cwd=root)
+    requirements_changed = any(
+        line.strip().startswith("requirements")
+        for line in changed.stdout.splitlines()
+    )
+
+    return UpdateResult(
+        True,
+        f"{len(commits)} new commit(s) available on {target}.",
+        commits=commits,
+        requirements_changed=requirements_changed,
+    )
+
+
+def apply_update(
+    remote: str = DEFAULT_REMOTE,
+    branch: str = DEFAULT_BRANCH,
+    root: str = INSTALL_ROOT,
+) -> UpdateResult:
+    """Fast-forward to the fetched commit. Refuses anything else."""
+    if has_local_changes(root):
+        return UpdateResult(
+            False,
+            "You have uncommitted changes in the RepoPilot checkout. "
+            "Commit or stash them first -- an update will not discard them.",
+        )
+
+    merge = _git("merge", "--ff-only", f"{remote}/{branch}", cwd=root)
+    if merge.returncode != 0:
+        return UpdateResult(
+            False,
+            f"Fast-forward failed: {merge.stderr.strip() or merge.stdout.strip()}",
+        )
+
+    head = _git("rev-parse", "--short", "HEAD", cwd=root).stdout.strip()
+    return UpdateResult(True, f"Updated to {head}.")
+
+
+def run_update(
+    remote: str = DEFAULT_REMOTE,
+    branch: str = DEFAULT_BRANCH,
+    assume_yes: bool = False,
+    root: str = INSTALL_ROOT,
+    confirm=input,
+) -> int:
+    """Drive the whole flow. Returns a process exit code."""
+    print(f"Checking {root} for updates...")
+
+    check = check_for_updates(remote, branch, root)
+    print(f"  {check.message}")
+    if not check.ok:
+        return 1
+    if not check.commits:
+        return 0
+
+    print()
+    for line in check.commits[:20]:
+        print(f"    {line}")
+    if len(check.commits) > 20:
+        print(f"    ... and {len(check.commits) - 20} more")
+    print()
+
+    if has_local_changes(root):
+        print(
+            "  Uncommitted changes in the checkout. Commit or stash them first.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not assume_yes:
+        try:
+            prompt = (
+                f"Fast-forward {current_branch(root)} to {remote}/{branch}? [y/N]: "
+            )
+            answer = confirm(prompt)
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            return 1
+        if answer.strip().lower() not in ("y", "yes"):
+            print("Aborted.")
+            return 1
+
+    result = apply_update(remote, branch, root)
+    print(f"  {result.message}")
+    if not result.ok:
+        return 1
+
+    if check.requirements_changed:
+        # Printed, not executed. Installing packages as a side effect of an
+        # update is a surprise nobody asked for.
+        print()
+        print("  Dependencies changed. Update them with:")
+        print(f"    pip install -r {os.path.join(root, 'requirements.txt')}")
+
+    return 0

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -88,6 +88,35 @@ def test_a_plain_directory_is_not(tmp_path):
     assert is_git_checkout(str(plain)) is False
 
 
+def test_a_directory_nested_in_another_repo_is_not_a_checkout(tmp_path):
+    """
+    `git rev-parse --is-inside-work-tree` walks *up*, so it answers "true" for
+    any directory inside a repository. This surfaced on a Windows machine where
+    a git repo sat above the temp directory: the "not a checkout" refusal never
+    fired, and --update would have fast-forwarded that ancestor repo instead of
+    RepoPilot.
+    """
+    outer = tmp_path / "outer"
+    outer.mkdir()
+    git(outer, "init", "-q")
+    git(outer, "config", "user.email", "o@example.com")
+    git(outer, "config", "user.name", "Other")
+    (outer / "f.txt").write_text("unrelated\n")
+    git(outer, "add", "-A")
+    git(outer, "commit", "-qm", "unrelated repo")
+
+    nested = outer / "sub" / "not-a-repo"
+    nested.mkdir(parents=True)
+
+    assert is_git_checkout(str(nested)) is False
+    assert check_for_updates(root=str(nested)).ok is False
+    assert apply_update(root=str(nested)).ok is False
+
+
+def test_the_repo_root_itself_is_a_checkout(install):
+    assert is_git_checkout(str(install)) is True
+
+
 def test_a_non_checkout_is_refused(tmp_path):
     """Downloading a tarball over it is not an acceptable fallback."""
     plain = tmp_path / "not-a-repo"

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,267 @@
+"""
+Tests for self-update (modules/updater.py).
+
+"Fetch the latest code and run it" is remote code execution by definition, so
+most of what follows is about the refusals rather than the happy path. These
+drive real git repositories; they skip if git is unavailable.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.updater import (  # noqa: E402
+    apply_update,
+    check_for_updates,
+    current_branch,
+    has_local_changes,
+    is_git_checkout,
+    run_update,
+)
+
+pytestmark = pytest.mark.skipif(shutil.which("git") is None, reason="git not available")
+
+
+def git(cwd, *args):
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def upstream(tmp_path):
+    """A bare remote with one commit on main."""
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    git(seed, "init", "-q")
+    git(seed, "config", "user.email", "t@example.com")
+    git(seed, "config", "user.name", "Test")
+    git(seed, "checkout", "-qb", "main")
+    (seed / "version.txt").write_text("1\n")
+    (seed / "requirements.txt").write_text("anthropic\n")
+    git(seed, "add", "-A")
+    git(seed, "commit", "-qm", "initial")
+
+    bare = tmp_path / "remote.git"
+    subprocess.run(["git", "clone", "-q", "--bare", str(seed), str(bare)], check=True)
+    return bare
+
+
+@pytest.fixture
+def install(tmp_path, upstream):
+    """A clone standing in for RepoPilot's own checkout."""
+    path = tmp_path / "install"
+    subprocess.run(["git", "clone", "-q", str(upstream), str(path)], check=True)
+    git(path, "config", "user.email", "t@example.com")
+    git(path, "config", "user.name", "Test")
+    return path
+
+
+def push_upstream(tmp_path, upstream, filename, content, message="upstream change"):
+    """Land a commit on the remote from a separate clone."""
+    other = tmp_path / f"other-{filename}"
+    if not other.exists():
+        subprocess.run(["git", "clone", "-q", str(upstream), str(other)], check=True)
+        git(other, "config", "user.email", "o@example.com")
+        git(other, "config", "user.name", "Other")
+    (other / filename).write_text(content)
+    git(other, "add", "-A")
+    git(other, "commit", "-qm", message)
+    git(other, "push", "-q", "origin", "main")
+
+
+# ── detection ─────────────────────────────────────────────────────────────
+
+
+def test_a_checkout_is_recognised(install):
+    assert is_git_checkout(str(install)) is True
+
+
+def test_a_plain_directory_is_not(tmp_path):
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    assert is_git_checkout(str(plain)) is False
+
+
+def test_a_non_checkout_is_refused(tmp_path):
+    """Downloading a tarball over it is not an acceptable fallback."""
+    plain = tmp_path / "not-a-repo"
+    plain.mkdir()
+    result = check_for_updates(root=str(plain))
+
+    assert result.ok is False
+    assert "not a git checkout" in result.message
+
+
+def test_local_changes_are_detected(install):
+    assert has_local_changes(str(install)) is False
+    (install / "version.txt").write_text("edited\n")
+    assert has_local_changes(str(install)) is True
+
+
+def test_current_branch_is_reported(install):
+    assert current_branch(str(install)) == "main"
+
+
+# ── checking ──────────────────────────────────────────────────────────────
+
+
+def test_up_to_date_is_reported(install):
+    result = check_for_updates(root=str(install))
+
+    assert result.ok is True
+    assert result.commits == []
+    assert "up to date" in result.message
+
+
+def test_new_commits_are_listed(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n", "bump version")
+    result = check_for_updates(root=str(install))
+
+    assert result.ok is True
+    assert len(result.commits) == 1
+    assert "bump version" in result.commits[0]
+
+
+def test_checking_does_not_touch_the_working_tree(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+    check_for_updates(root=str(install))
+
+    assert (install / "version.txt").read_text() == "1\n"
+
+
+def test_a_requirements_change_is_flagged(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "requirements.txt", "anthropic\npathspec\n")
+    assert check_for_updates(root=str(install)).requirements_changed is True
+
+
+def test_an_unrelated_change_is_not_flagged(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+    assert check_for_updates(root=str(install)).requirements_changed is False
+
+
+def test_an_unreachable_remote_is_reported(install):
+    result = check_for_updates(remote="nope", root=str(install))
+
+    assert result.ok is False
+    assert "Could not fetch" in result.message
+
+
+# ── refusals ──────────────────────────────────────────────────────────────
+
+
+def test_a_diverged_checkout_is_refused(tmp_path, upstream, install):
+    """
+    Local commits mean a merge or reset would entangle or discard work. Only a
+    fast-forward is safe without asking a human.
+    """
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+    (install / "local.txt").write_text("my own work\n")
+    git(install, "add", "-A")
+    git(install, "commit", "-qm", "local work")
+
+    result = check_for_updates(root=str(install))
+
+    assert result.ok is False
+    assert "not on" in result.message
+
+
+def test_a_dirty_tree_is_refused(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+    check_for_updates(root=str(install))
+    (install / "scratch.txt").write_text("uncommitted\n")
+
+    result = apply_update(root=str(install))
+
+    assert result.ok is False
+    assert "uncommitted" in result.message
+    assert (install / "scratch.txt").exists()  # not discarded
+
+
+def test_apply_is_fast_forward_only(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+    git(install, "fetch", "-q", "origin", "main")
+    (install / "local.txt").write_text("mine\n")
+    git(install, "add", "-A")
+    git(install, "commit", "-qm", "local")
+
+    result = apply_update(root=str(install))
+
+    assert result.ok is False
+    assert "Fast-forward failed" in result.message
+
+
+# ── applying ──────────────────────────────────────────────────────────────
+
+
+def test_a_clean_fast_forward_succeeds(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+    check_for_updates(root=str(install))
+
+    result = apply_update(root=str(install))
+
+    assert result.ok is True
+    assert (install / "version.txt").read_text() == "2\n"
+
+
+# ── the flow ──────────────────────────────────────────────────────────────
+
+
+def test_confirmation_is_required(tmp_path, upstream, install, capsys):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+
+    code = run_update(root=str(install), confirm=lambda prompt: "n")
+
+    assert code == 1
+    assert (install / "version.txt").read_text() == "1\n"  # unchanged
+
+
+def test_yes_skips_the_prompt(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+
+    def explode(prompt):
+        raise AssertionError("should not prompt when assume_yes is set")
+
+    assert run_update(root=str(install), assume_yes=True, confirm=explode) == 0
+    assert (install / "version.txt").read_text() == "2\n"
+
+
+def test_up_to_date_exits_cleanly_without_prompting(install):
+    def explode(prompt):
+        raise AssertionError("nothing to confirm")
+
+    assert run_update(root=str(install), confirm=explode) == 0
+
+
+def test_incoming_commits_are_shown_before_asking(tmp_path, upstream, install, capsys):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n", "a visible commit message")
+    run_update(root=str(install), confirm=lambda prompt: "n")
+
+    assert "a visible commit message" in capsys.readouterr().out
+
+
+def test_dependencies_are_printed_not_installed(tmp_path, upstream, install, capsys):
+    """
+    Running pip as a side effect of --update is a surprise nobody asked for.
+    """
+    push_upstream(tmp_path, upstream, "requirements.txt", "anthropic\npathspec\n")
+    run_update(root=str(install), assume_yes=True)
+
+    out = capsys.readouterr().out
+    assert "pip install -r" in out
+    assert "Dependencies changed" in out
+
+
+def test_an_interrupt_at_the_prompt_aborts(tmp_path, upstream, install):
+    push_upstream(tmp_path, upstream, "version.txt", "2\n")
+
+    def interrupt(prompt):
+        raise KeyboardInterrupt()
+
+    assert run_update(root=str(install), confirm=interrupt) == 1
+    assert (install / "version.txt").read_text() == "1\n"


### PR DESCRIPTION
Closes #70

## Summary

`python main.py --update` fast-forwards RepoPilot's own checkout to the latest upstream commit.

Fetching code and then running it is remote code execution by definition, so nearly all of this PR is about the refusals rather than the happy path.

## The design

**It updates a git checkout, not a download.** The issue says "securely fetches the latest main branch". A tarball fetched over HTTPS and unpacked over the install directory is not auditable and not reversible. `git fetch` plus `git merge --ff-only` means every change is attributable to a commit, visible in `git log`, and undone with `git reset`.

**Fast-forward only.** A diverged local branch is reported, never overwritten. Local commits mean a merge or reset would entangle or discard work.

**Refuses on a dirty tree.** Nothing uncommitted is lost.

**Shows the incoming commits and asks.** `--yes` skips the prompt for scripted use; an interrupt at the prompt aborts.

**Prints the pip command rather than running it.** When `requirements.txt` changes, `--update` tells you what to run. Installing packages as a side effect of an update is a surprise nobody asked for.

Run against a real checkout with local branches:

```
Checking /home/.../repopilot for updates...
  Your checkout has 2 commit(s) not on origin/main.
  Refusing to update automatically -- rebase or reset by hand.
```

## A security bug caught by running the tests on Windows

This is the most important thing in the PR, and it only surfaced because the suite ran on a second machine.

`is_git_checkout` originally used `git rev-parse --is-inside-work-tree`. That walks **up** the directory tree, so it answers "true" for any directory nested inside a repository. On Linux the test passed because `/tmp` has no repo above it. On a Windows machine with a git repo somewhere above `AppData\Local\Temp`, the "not a checkout" refusal never fired:

```
UpdateResult(ok=True, message='3 new commit(s) available on origin/main.',
             commits=['7eb38d3 Rename emergency-profile-...', ...])
```

Those commits are from a completely unrelated repository. The old code was offering to fast-forward someone else's project from a directory that was not a checkout at all — and on a machine where a home directory has been `git init`-ed, `--update` from the wrong place could have moved it.

`is_git_checkout` now compares `git rev-parse --show-toplevel` against the target path, via `realpath` and `normcase` for symlinks and Windows case-insensitivity. `apply_update` carries the same guard rather than trusting its caller, since it is public. There is a regression test that nests a plain directory inside an unrelated repo and asserts all three of `is_git_checkout`, `check_for_updates` and `apply_update` refuse.

## `--repo` is now conditionally required

`--repo` was `required=True`, so `--update` failed at argparse before reaching any of the above — it has nothing to do with the repository being worked on. It is now optional at parse time and enforced explicitly for every other path, so a normal run still errors if it is missing.

## Tests

`tests/test_updater.py` — 23 cases, driving real git repositories in temp directories. They skip if git is unavailable.

Detection: a checkout is recognised; a plain directory is not; a plain directory **nested inside another repo** is not — the regression above; a non-checkout is refused; local changes are detected; the current branch is reported.

Checking: up to date reported; new commits listed; checking does not touch the working tree; a `requirements.txt` change is flagged and an unrelated change is not; an unreachable remote is reported.

Refusals: a diverged checkout is refused; a dirty tree is refused and the uncommitted file still exists afterwards; `apply_update` is fast-forward only.

Applying: a clean fast-forward succeeds and the file contents change.

The flow: confirmation is required and declining leaves the tree untouched; `--yes` skips the prompt (asserted by making the prompt raise if called); an up-to-date checkout exits cleanly without prompting; incoming commit messages are shown before asking; dependencies are printed and not installed; an interrupt at the prompt aborts.

## Verified

- the divergence refusal above, against this checkout
- the nested-repo bug reproduced and then fixed, both before and after
- 23 tests pass; `tests/test_utils.py` still 4 passed
- ruff clean on both new files; `main.py` at its baseline count of 9, i.e. none added
- `npx prettier --check README.md` clean

## Interaction with #75

One conflict, in `main.py`: this PR changes the `--repo` argument line and #75 changes the `--task` line directly below it. Adjacent lines, so git cannot merge them, but the resolution is to keep both. I resolved it locally and ran the combined tree: 57 tests pass, with `--update` and the issue-URL task resolution both working.

## Not touched, noticed while working

Both pre-existing on `main`: `python -m pytest` from the repo root fails collection (three files share the basename `test_utils.py`, no `__init__.py`, no pytest config — the new test file uses a unique basename), and `npm run format:check` already fails for the two workflow files and `ARCHITECTURE.md`.