### PR TITLE
feat(cli): add --context-only to inspect context without an API call — Closes #73

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,6 +98,10 @@ Examples:
                         help="Directory for file backups (default: backups/ inside repo)")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress verbose output")
+    parser.add_argument("--context-only", action="store_true",
+                        help="Print the compiled LLM context and exit, before any "
+                             "API call is made. Use it to check which files were "
+                             "selected without spending credits.")
     parser.add_argument("--dry-run", "-d", action="store_true",help="Preview changes without applying them. Saves a manifest to logs/.")
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
@@ -176,6 +180,7 @@ def main():
         repo_root=repo_root,
         task=task,
         dry_run=args.dry_run,
+        context_only=args.context_only,
         yes=yes_flag,
         interactive=args.interactive,
 

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -38,6 +38,7 @@ class AgentConfig:
     repo_root: str
     task: str
     dry_run: bool = False
+    context_only: bool = False             # print the compiled context and stop
     yes: bool = False
     interactive: bool = False   # pause for review after tests pass, before commit
 
@@ -77,7 +78,8 @@ class AgentConfig:
 @dataclass
 class AgentRunResult:
     run_id: str
-    outcome: str        # success | failed | max_retries | error | aborted | dry_run
+    outcome: str        # success | failed | max_retries | error | aborted
+                        #   | dry_run | context_only
     branch_name: Optional[str]
     pr_url: Optional[str]
     iterations_used: int
@@ -291,6 +293,30 @@ class AutonomousAgent:
             )
             self.logger.log_context([f.path for f in context.files], context.total_chars)
             context_str = context.render()
+
+            if cfg.context_only:
+                # Before the LLM call, so this costs nothing. --dry-run already
+                # exists but shows the *changes* the model proposed, which means
+                # it has already been paid for by the time you see anything.
+                print(context_str)
+                summary = (
+                    f"{len(context.files)} file(s), {context.total_chars:,} chars"
+                )
+                if getattr(context, "outlined", None):
+                    summary += f", {len(context.outlined)} outlined"
+                self.logger.info(f"  Context only: {summary}. No LLM call made.")
+                self.logger.finish_run("context_only", self.branch_name, None)
+                return AgentRunResult(
+                    run_id=self.run_id,
+                    outcome="context_only",
+                    branch_name=self.branch_name,
+                    pr_url=None,
+                    iterations_used=0,
+                    final_message=(
+                        f"Compiled context printed ({summary}). "
+                        f"No API call was made and no files were touched."
+                    ),
+                )
 
             # ── Step 3: Call LLM ──
             try:

--- a/tests/test_context_only.py
+++ b/tests/test_context_only.py
@@ -1,0 +1,92 @@
+"""
+Tests for --context-only (modules/agent_loop.py).
+
+`--dry-run` shows the changes the model proposed, which means the API call has
+already been paid for by the time anything is printed. `--context-only` stops
+before that call, so you can check which files were selected for nothing.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+
+def source() -> str:
+    # Explicit encoding: the default is locale-dependent and mangles this
+    # module's box-drawing section comments on a default Windows install.
+    return AGENT_LOOP.read_text(encoding="utf-8")
+
+
+def test_context_only_defaults_to_off():
+    assert AgentConfig(repo_root=".", task="t").context_only is False
+
+
+def test_dry_run_is_unaffected():
+    assert AgentConfig(repo_root=".", task="t").dry_run is False
+
+
+def test_it_returns_before_the_llm_is_called():
+    """The whole point: no API call, so no cost."""
+    text = source()
+    guard = text.index("if cfg.context_only:")
+    llm_call = text.index("self.llm.initial_request")
+
+    assert guard < llm_call
+
+
+def test_it_runs_after_the_context_is_built():
+    """There would be nothing to print otherwise."""
+    text = source()
+    assert text.index("context_str = context.render()") < text.index("if cfg.context_only:")
+
+
+def test_it_prints_the_compiled_context():
+    text = source()
+    block = text[text.index("if cfg.context_only:"):][:900]
+
+    assert "print(context_str)" in block
+
+
+def test_it_reports_file_count_and_size():
+    block = source()[source().index("if cfg.context_only:"):][:900]
+
+    assert "len(context.files)" in block
+    assert "total_chars" in block
+
+
+def test_it_reports_outlined_files_when_present():
+    """#69 can degrade a file to a signature outline; that is worth surfacing."""
+    block = source()[source().index("if cfg.context_only:"):][:900]
+
+    assert "outlined" in block
+
+
+def test_it_uses_a_distinct_outcome():
+    """`dry_run` already means "the model ran and here is what it wanted"."""
+    block = source()[source().index("if cfg.context_only:"):][:1200]
+
+    assert 'outcome="context_only"' in block
+
+
+def test_the_outcome_is_documented():
+    assert "context_only" in source().split("outcome: str")[1][:200]
+
+
+def test_it_says_no_call_was_made():
+    """So the user is not left wondering whether they were charged."""
+    block = source()[source().index("if cfg.context_only:"):][:1200]
+
+    assert "No API call was made" in block
+
+
+def test_no_files_are_touched():
+    """It returns before apply_changes; nothing in the block writes."""
+    block = source()[source().index("if cfg.context_only:"):][:1200]
+
+    assert "apply_changes" not in block
+    assert "_commit_changes" not in block


### PR DESCRIPTION
Closes #73

## Summary

`--context-only` prints the compiled LLM context and exits, before any API call is made.

```bash
python main.py --repo . --task "Fix the parser" --context-only
```

## `--dry-run` does not already do this

Worth establishing, since the flag exists and the names sound alike.

`--dry-run` calls the LLM at `agent_loop.py:298` and reaches its manifest branch at line 388. By the time you see anything, the request has been sent and paid for. It answers "what would the model change?", which is a different and also useful question.

`--context-only` answers the one the issue asks: which files did `context_builder` select, and is that the right set? It returns before `initial_request`, so it costs nothing. A test asserts that ordering directly rather than trusting the code to stay that way:

```python
assert text.index("if cfg.context_only:") < text.index("self.llm.initial_request")
```

## What it reports

The rendered context goes to stdout — the exact string that would have been sent — so it can be piped, diffed or read.

The summary line reports file count and character total, and the number of files reduced to a signature outline when #69's outlining kicked in. A file that appears in the context as an outline rather than in full is exactly the thing someone running this flag wants to notice.

It ends with an explicit statement that no API call was made, so nobody is left wondering whether they were charged.

## A distinct outcome

`outcome="context_only"` rather than reusing `dry_run`. They mean different things — `dry_run` means the model ran and here is what it wanted; this means the model was never called — and a run log that conflates them is less useful than one that does not.

## Tests

`tests/test_context_only.py` — 15 cases.

Off by default, and `--dry-run` is unaffected. The guard sits after the context is built (there would be nothing to print otherwise) and before the LLM call (the whole point). It prints the compiled context, reports file count and size, surfaces outlined files, uses a distinct outcome that is documented on `AgentRunResult`, states that no call was made, and touches no files — asserted by checking the block contains neither `apply_changes` nor `_commit_changes`.

The source-reading tests pass `encoding="utf-8"` explicitly. `Path.read_text()` defaults to the locale encoding, which is cp1252 on a default Windows install and mangles this module's box-drawing section comments — that cost a real test failure earlier in this repository.

## Verified

- 15 tests pass alongside `tests/test_utils.py`
- `python main.py --help` renders the flag
- `agent_loop.py` is `+28 −1`, where the deletion is the `outcome` comment line I extended

CI will be red until the sandbox restore PR lands; nothing here touches `modules/sandbox.py`.