### PR TITLE
refactor(modules): log instead of printing from library code — Closes #79

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -387,8 +387,8 @@ class AutonomousAgent:
 
                 if self.config.dry_run:
                     manifest_path = save_manifest(changes_list, self.config.log_dir, self.run_id)
-                    print(f"\n[DRY RUN] No files were modified.")
-                    print(f"[DRY RUN] Manifest saved to: {manifest_path}")
+                    self.logger.info("[DRY RUN] No files were modified.")
+                    self.logger.info(f"[DRY RUN] Manifest saved to: {manifest_path}")
                     return AgentRunResult(
                         outcome="dry_run",
                         run_id=self.run_id,

--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -4,6 +4,7 @@ Safely applies file changes from LLM output.
 Creates backups, validates paths, preserves structure.
 """
 
+import logging
 import os
 import shutil
 from dataclasses import dataclass
@@ -12,6 +13,11 @@ from pathlib import Path
 from typing import Optional
 
 from modules.llm_client import FileChange
+
+# Named under "agent." so it inherits whatever handlers AgentLogger configures,
+# and so --quiet and the run log both apply. Library code writing to stdout can
+# be neither routed nor silenced.
+_LOG = logging.getLogger("agent.code_modifier")
 
 
 @dataclass
@@ -250,15 +256,15 @@ class CodeModificationEngine:
             text=True,
         )
         if check.returncode != 0:
-            print(f"[Rollback] Warning: git stash failed — {check.stderr.strip()}")
+            _LOG.warning("git stash failed: %s", check.stderr.strip())
             return False
 
         # git stash exits 0 even on a clean tree — detect that case
         if "No local changes to save" in check.stdout:
-            print("[Rollback] Nothing to stash — working tree is clean.")
+            _LOG.info("Nothing to stash; the working tree is clean.")
             return False
 
-        print("[Rollback] Git stash saved. Run with --rollback to undo.")
+        _LOG.info("Git stash saved. Run with --rollback to undo.")
         return True
 
     def git_stash_pop(self, repo_root: str) -> bool:
@@ -271,7 +277,7 @@ class CodeModificationEngine:
             text=True,
         )
         if result.returncode == 0:
-            print("[Rollback] Successfully restored previous state.")
+            _LOG.info("Restored the previous working state.")
         else:
-            print(f"[Rollback] Failed to pop stash — {result.stderr.strip()}")
+            _LOG.error("Failed to pop the stash: %s", result.stderr.strip())
         return result.returncode == 0

--- a/tests/test_module_logging.py
+++ b/tests/test_module_logging.py
@@ -1,0 +1,150 @@
+"""
+Tests for module-level logging (modules/code_modifier.py, modules/agent_loop.py).
+
+A library that calls print() writes to stdout unconditionally: it cannot be
+routed to a file, cannot be silenced by --quiet, and does not appear in the run
+log. These pin the conversion — and, just as deliberately, pin the places where
+print() is the right call and should stay.
+"""
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.code_modifier import CodeModificationEngine  # noqa: E402
+
+MODULES = Path(__file__).resolve().parents[1] / "modules"
+
+
+def source(name: str) -> str:
+    # Explicit encoding: the default is locale-dependent and mangles the
+    # box-drawing section comments on a default Windows install.
+    return (MODULES / name).read_text(encoding="utf-8")
+
+
+def git(cwd, *args):
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def engine(tmp_path):
+    git(tmp_path, "init", "-q")
+    git(tmp_path, "config", "user.email", "t@example.com")
+    git(tmp_path, "config", "user.name", "Test")
+    (tmp_path / "f.txt").write_text("v1\n")
+    git(tmp_path, "add", "-A")
+    git(tmp_path, "commit", "-qm", "initial")
+    (tmp_path / "f.txt").write_text("v2\n")
+
+    return CodeModificationEngine(
+        repo_root=str(tmp_path), backup_dir=str(tmp_path / ".backups")
+    )
+
+
+# ── the conversion ────────────────────────────────────────────────────────
+
+
+def test_code_modifier_no_longer_prints():
+    assert "print(" not in source("code_modifier.py")
+
+
+def test_agent_loops_dry_run_lines_go_to_the_logger():
+    """The two [DRY RUN] lines had a logger to hand and were not using it."""
+    text = source("agent_loop.py")
+    assert 'print(f"\\n[DRY RUN]' not in text
+    assert 'self.logger.info("[DRY RUN] No files were modified.")' in text
+
+
+def test_the_review_prompt_still_prints():
+    """
+    _confirm_commit renders the diff a user is being asked to approve, for the
+    same reason dry_run's manifest does. A log level must not be able to hide it.
+    """
+    text = source("agent_loop.py")
+    assert "TESTS PASSED - REVIEW BEFORE COMMIT" in text
+    assert 'print("=" * 60)' in text
+
+
+def test_the_logger_is_in_the_agent_namespace():
+    """
+    So it inherits the handlers AgentLogger configures on `agent.<run_id>` and
+    appears in the run log rather than only on the terminal.
+    """
+    assert 'logging.getLogger("agent.code_modifier")' in source("code_modifier.py")
+
+
+def test_stash_messages_go_to_the_logger(engine, caplog):
+    with caplog.at_level(logging.INFO, logger="agent.code_modifier"):
+        engine.git_stash_before_apply(engine.repo_root)
+
+    assert any("stash" in record.message.lower() for record in caplog.records)
+
+
+def test_nothing_reaches_stdout(engine, capsys):
+    """A library must not write to stdout uninvited."""
+    engine.git_stash_before_apply(engine.repo_root)
+    engine.git_stash_pop(engine.repo_root)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_info_is_suppressed_at_warning_level(engine, caplog):
+    """This is what --quiet buys; print() could not be silenced at all."""
+    with caplog.at_level(logging.WARNING, logger="agent.code_modifier"):
+        engine.git_stash_before_apply(engine.repo_root)
+
+    assert [r for r in caplog.records if r.levelno < logging.WARNING] == []
+
+
+def test_a_failed_pop_is_logged_as_an_error(engine, caplog):
+    """Nothing to pop: the failure should be an error, not silence."""
+    with caplog.at_level(logging.DEBUG, logger="agent.code_modifier"):
+        engine.git_stash_pop(engine.repo_root)
+
+    assert any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+def test_a_clean_tree_is_reported_at_info(engine, caplog):
+    engine.git_stash_before_apply(engine.repo_root)  # stashes the pending edit
+    with caplog.at_level(logging.DEBUG, logger="agent.code_modifier"):
+        engine.git_stash_before_apply(engine.repo_root)
+
+    assert any("clean" in r.message.lower() for r in caplog.records)
+
+
+def test_lazy_formatting_is_used():
+    """
+    %-style arguments rather than f-strings, so a suppressed message costs no
+    string interpolation.
+    """
+    text = source("code_modifier.py")
+    assert '_LOG.warning("git stash failed: %s"' in text
+    assert '_LOG.error("Failed to pop the stash: %s"' in text
+
+
+# ── what should stay a print ──────────────────────────────────────────────
+
+
+def test_dry_run_still_prints_the_manifest():
+    """
+    print_manifest renders a table the user is being asked to approve, and
+    ask_confirmation drives an interactive prompt. Routing those through the
+    logger would let a log level hide the thing the user must read.
+    """
+    assert "print(" in source("dry_run.py")
+
+
+def test_main_still_prints_cli_output():
+    """
+    The banner, the final summary and errors to stderr are the CLI's output,
+    not diagnostics. They belong on stdout unconditionally.
+    """
+    root = Path(__file__).resolve().parents[1]
+    assert "print(" in (root / "main.py").read_text(encoding="utf-8")


### PR DESCRIPTION
Closes #79

## Summary

Converts the `print()` calls in `modules/code_modifier.py` and the two `[DRY RUN]` lines in `modules/agent_loop.py` to `logging`. Deliberately leaves the other 32 alone.

## Not all of them are the same thing

The issue says "many modules currently use standard `print()` calls for verbose output". There are 39 on current `main`, and they fall into two groups:

| file | count | verdict |
| ---- | ----- | ------- |
| `code_modifier.py` | 5 | **the bug** — library code writing to stdout |
| `agent_loop.py` | 2 of 10 | inconsistent — the class has `self.logger` to hand |
| `agent_loop.py` | 8 of 10 | **stays** — the `--interactive` review prompt |
| `dry_run.py` | 9 | **stays** — the manifest being approved |
| `main.py` | 15 | **stays** — CLI banner, summary, stderr |

So 7 converted, 32 left, with tests pinning both decisions.

## Why the code_modifier ones are the bug

They are the only case where a *library* writes to stdout. That output cannot be routed to a file, does not appear in the run log, and `--quiet` has no effect on it:

```
>>> anything below this line came from inside a library module:
[Rollback] Git stash saved. Run with --rollback to undo.
>>> --quiet cannot suppress it; nothing routes it to a log sink
```

After, all three behaviours are correct:

- **no logging configured** — silent. A library should not print uninvited.
- **handler attached**, as `AgentLogger` does — `[INFO] agent.code_modifier: Restored the previous working state.`
- **WARNING level**, which is what `--quiet` buys — info suppressed, warnings still shown.

The logger is named `agent.code_modifier` so it inherits the handlers `AgentLogger` configures on the `agent.*` namespace, which means these messages now reach the run log too. `%`-style lazy formatting is used, so a suppressed message costs no interpolation.

## Why the rest keep printing

`dry_run.print_manifest` renders the table of changes a user is being asked to approve, and `agent_loop._confirm_commit` prints the diff for `--interactive`. Routing either through the logger would let a log level hide the thing the user must read before answering. `main.py`'s prints are the CLI's own output, not diagnostics.

All three are pinned by tests, so a future pass at this issue does not "finish the job" by converting them.

## Tests

`tests/test_module_logging.py` — 12 cases.

The conversion: `code_modifier.py` contains no `print(`; the `[DRY RUN]` lines go through `self.logger`; the logger sits in the `agent.` namespace; stash messages reach it; **nothing reaches stdout**; info is suppressed at WARNING level; a failed pop is an error rather than silence; a clean tree is reported at info; lazy `%`-formatting is used.

What stays: `dry_run.py` still prints; `main.py` still prints; the `--interactive` review prompt still prints.

## Verified

- the three logging behaviours above, against a real git repository
- 12 tests pass alongside `tests/test_utils.py`
- `code_modifier.py` is `+16 −5`; `_apply_unified_diff` and the `patch` action are untouched

CI will be red until the sandbox restore PR lands; nothing here touches `modules/sandbox.py`.

## Base

Rebuilt on current `main`. An earlier version of this branch was cut before #51 landed and would have converted the `--interactive` review prompt as well — which would have let `--quiet` hide a confirmation prompt. Worth mentioning because that is precisely the mistake the "what stays" tests now guard against.