### PR TITLE
feat(agent): add --skip-tests for non-test-driven tasks — Closes #56

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,6 +55,10 @@ Examples:
                         help="Test runner to use (default: pytest)")
     parser.add_argument("--runner-args", nargs="*", default=None,
                         help="Extra arguments to pass to the test runner")
+    parser.add_argument("--skip-tests", action="store_true",
+                        help="Do not run a test suite. Changes are accepted on the "
+                             "model's confidence alone - suitable for refactors and "
+                             "comment passes, not for behaviour changes.")
     parser.add_argument("--run-file", default=None,
                         help="Run a specific file instead of the test suite")
     parser.add_argument("--run-file-runner", default="python",
@@ -182,6 +186,7 @@ def main():
         # Execution
         test_runner=args.runner,
         test_args=args.runner_args,
+        skip_tests=args.skip_tests,
         run_file=args.run_file,
         run_file_runner=args.run_file_runner,
         lint_runner=args.lint_runner,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -42,6 +42,7 @@ class AgentConfig:
     interactive: bool = False   # pause for review after tests pass, before commit
 
     # Execution
+    skip_tests: bool = False               # accept the LLM's own verdict instead
     test_runner: str = "pytest"            # pytest | npm_test | go | cargo | ...
     test_args: Optional[list] = None       # extra args to pass to runner
     run_file: Optional[str] = None         # run a specific file instead of tests
@@ -121,6 +122,26 @@ class AutonomousAgent:
         """Convert task text into a valid git branch name."""
         slug = re.sub(r"[^a-zA-Z0-9]+", "-", task.lower())[:40].strip("-")
         return f"{self.config.git_branch_prefix}/{slug}-{self.run_id[-6:]}"
+
+    def _skipped_execution(self, confidence: float) -> ExecutionResult:
+        """
+        Stand-in result for --skip-tests.
+
+        Deliberately not dressed up as a passing test run: `command` says what
+        happened and the stdout records the confidence the decision rested on,
+        so a log cannot be mistaken for evidence that a suite went green.
+        """
+        return ExecutionResult(
+            command="(skipped - --skip-tests; no test suite was run)",
+            exit_code=0,
+            stdout=(
+                f"Tests were not run. Accepted on the model's own confidence of "
+                f"{confidence:.2f}. No suite verified this change."
+            ),
+            stderr="",
+            timed_out=False,
+            duration_seconds=0.0,
+        )
 
     def _run_execution(self) -> ExecutionResult:
         """Run tests or the specified file in the sandbox."""
@@ -471,7 +492,10 @@ class AutonomousAgent:
                     self.logger.record_iteration(iter_record)
                     continue
 
-            exec_result = self._run_execution()
+            if cfg.skip_tests:
+                exec_result = self._skipped_execution(llm_resp.confidence)
+            else:
+                exec_result = self._run_execution()
             self.logger.log_execution(exec_result)
             last_exec = exec_result
 
@@ -486,7 +510,13 @@ class AutonomousAgent:
 
             # ── Step 6: Success check ──
             if exec_result.success:
-                self.logger.info(f"  Tests passed on iteration {iteration}")
+                if cfg.skip_tests:
+                    self.logger.warning(
+                        f"  Accepting iteration {iteration} without running tests "
+                        f"(--skip-tests, confidence {llm_resp.confidence:.2f})."
+                    )
+                else:
+                    self.logger.info(f"  Tests passed on iteration {iteration}")
 
                 changed_paths = [c.path for c in last_changes]
                 if not self._confirm_commit(changed_paths):

--- a/tests/test_skip_tests.py
+++ b/tests/test_skip_tests.py
@@ -1,0 +1,112 @@
+"""
+Tests for --skip-tests (modules/agent_loop.py).
+
+The agent normally decides success from a test run. --skip-tests removes that
+evidence and accepts the model's own verdict instead, which is reasonable for a
+refactor or a comment pass and unreasonable for a behaviour change.
+
+The risk worth guarding is a log that reads like tests passed when none ran.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig, AutonomousAgent  # noqa: E402
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+
+def source() -> str:
+    # Explicit encoding: the default is locale-dependent and mangles this
+    # module's box-drawing comments on a default Windows install.
+    return AGENT_LOOP.read_text(encoding="utf-8")
+
+
+def make_agent(skip_tests=False):
+    agent = object.__new__(AutonomousAgent)
+    agent.config = AgentConfig(repo_root=".", task="t", skip_tests=skip_tests)
+    agent.logger = SimpleNamespace(
+        info=lambda *a, **k: None, warning=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    return agent
+
+
+# ── config surface ────────────────────────────────────────────────────────
+
+
+def test_skip_tests_defaults_to_off():
+    assert AgentConfig(repo_root=".", task="t").skip_tests is False
+
+
+# ── the stand-in result ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def result():
+    return make_agent(skip_tests=True)._skipped_execution(0.92)
+
+
+def test_the_result_counts_as_success(result):
+    """Otherwise the loop would retry until max_iterations with nothing to fix."""
+    assert result.success is True
+    assert result.exit_code == 0
+
+
+def test_it_does_not_claim_tests_ran(result):
+    assert "skipped" in result.command
+    assert "no test suite was run" in result.command
+    assert "Tests were not run" in result.stdout
+
+
+def test_it_records_the_confidence_the_decision_rested_on(result):
+    assert "0.92" in result.stdout
+
+
+def test_it_says_nothing_verified_the_change(result):
+    """A reader of the log should not have to infer this."""
+    assert "No suite verified this change" in result.stdout
+
+
+def test_it_is_not_a_timeout(result):
+    assert result.timed_out is False
+
+
+@pytest.mark.parametrize("confidence", [0.0, 0.5, 1.0])
+def test_confidence_is_rendered_for_any_value(confidence):
+    stdout = make_agent(skip_tests=True)._skipped_execution(confidence).stdout
+    assert f"{confidence:.2f}" in stdout
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_sandbox_is_bypassed_when_skipping():
+    """The point of the flag: no sandbox call at all."""
+    text = source()
+    start = text.index("if cfg.skip_tests:")
+    block = text[start:start + 200]
+
+    assert "_skipped_execution" in block
+    assert block.index("_skipped_execution") < block.index("_run_execution")
+
+
+def test_normal_runs_still_execute():
+    text = source()
+    start = text.index("if cfg.skip_tests:")
+    assert "self._run_execution()" in text[start:start + 200]
+
+
+def test_success_is_logged_differently_when_skipping():
+    """"Tests passed" would be a false statement under --skip-tests."""
+    text = source()
+    start = text.index("Accepting iteration")
+    block = text[max(0, start - 200):start + 200]
+
+    assert "--skip-tests" in block
+    assert "Tests passed" in text  # still used on the normal path


### PR DESCRIPTION
Closes #56

## Summary

The loop decides success from a test run, so a refactor or a comment pass in a repository with nothing to assert can never succeed. `--skip-tests` bypasses the sandbox and accepts changes on the model's confidence instead.

```bash
python main.py --repo . --task "Add docstrings to the parser module" --skip-tests
```

Off by default.

## The risk is a log that lies

Fabricating a passing `ExecutionResult` is the obvious implementation and the dangerous one: a run log would then read exactly like one where a suite went green, and nobody reading it later could tell.

So the stand-in result says what happened, in the fields a reader actually sees:

```
command : (skipped - --skip-tests; no test suite was run)
stdout  : Tests were not run. Accepted on the model's own confidence of 0.92.
          No suite verified this change.
```

It reports `exit_code=0` and `success=True` because the loop needs that to stop — otherwise it would retry until `max_iterations` with nothing to fix — but nothing in it claims tests ran.

The success log line differs too. `"Tests passed on iteration 3"` would be a false statement under this flag, so the skip path logs at WARNING instead, naming the flag and the confidence the decision rested on.

## What it does not do

It does not lower the confidence threshold. `min_confidence_to_apply` still gates whether changes are applied at all, so a low-confidence response is still skipped — `--skip-tests` removes the *verification* step, not the model's own self-assessment.

The issue mentions "or a basic lint check" as an alternative signal. That is #65, which has since landed, and the two compose: with both flags set, `--lint` runs and is the only remaining signal. Folding lint into this flag would have made `--skip-tests` mean two different things depending on configuration.

## Tests

`tests/test_skip_tests.py` — 12 cases.

Config: the flag defaults to off.

The stand-in result: it counts as success; it does not claim tests ran (asserted on both `command` and `stdout`); it records the confidence; it states that nothing verified the change; it is not a timeout; the confidence renders for 0.0, 0.5 and 1.0.

Wiring: the sandbox is bypassed when skipping; normal runs still call `_run_execution`; the success log differs on the skip path while `"Tests passed"` remains on the normal one.

The source-reading tests pass `encoding="utf-8"` explicitly — the default is locale-dependent and mangles this module's box-drawing comments on a default Windows install.

## Verified

- 12 tests pass alongside `tests/test_utils.py`
- `python main.py --help` renders the flag
- `agent_loop.py` is `+34 −2`, where the deletions are the two lines I intentionally replaced

CI will be red until the sandbox restore PR lands; nothing here touches `modules/sandbox.py`.

## Base

Rebuilt on current `main`. The `Step 5: Execute` block has moved since this was first written — #65's lint gate now sits above it — so the skip branch is placed after the linter rather than in its old position. That ordering is deliberate: under `--skip-tests`, the linter is the only signal left, so it should certainly still run.