### PR TITLE
feat(llm): add a planning pass before code generation — Closes #58

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,9 @@ Examples:
                         help="Execution timeout in seconds (default: 120)")
 
     # Loop control
+    parser.add_argument("--plan-first", action="store_true",
+                        help="Ask the model for an approach before it writes code. "
+                             "Costs one extra API call on the first iteration.")
     parser.add_argument("--max-iter", type=int, default=5,
                         help="Maximum number of agent iterations (default: 5)")
 
@@ -180,6 +183,7 @@ def main():
         interactive=args.interactive,
 
         # Execution
+        plan_first=args.plan_first,
         test_runner=args.runner,
         test_args=args.runner_args,
         run_file=args.run_file,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -42,6 +42,7 @@ class AgentConfig:
     interactive: bool = False   # pause for review after tests pass, before commit
 
     # Execution
+    plan_first: bool = False               # ask for an approach before coding
     test_runner: str = "pytest"            # pytest | npm_test | go | cargo | ...
     test_args: Optional[list] = None       # extra args to pass to runner
     run_file: Optional[str] = None         # run a specific file instead of tests
@@ -295,7 +296,31 @@ class AutonomousAgent:
             # ── Step 3: Call LLM ──
             try:
                 if iteration == 1 or not last_exec:
-                    llm_resp: LLMResponse = self.llm.initial_request(cfg.task, context_str)
+                    plan = None
+                    if cfg.plan_first and iteration == 1:
+                        # Only on the first iteration. Later ones already carry
+                        # the strongest possible signal -- real test output --
+                        # and re-planning against it would cost a call to
+                        # restate what the failure already says.
+                        plan = self.llm.plan_request(cfg.task, context_str)
+                        if plan.usable:
+                            self.logger.info(
+                                f"  Plan ({len(plan.steps)} steps, "
+                                f"confidence {plan.confidence:.2f}):"
+                            )
+                            for number, step in enumerate(plan.steps, 1):
+                                self.logger.info(f"    {number}. {step}")
+                            for risk in plan.risks:
+                                self.logger.warning(f"    risk: {risk}")
+                        else:
+                            self.logger.warning(
+                                f"  Planning pass unusable "
+                                f"({plan.parse_error or 'no steps returned'}); "
+                                f"continuing without it."
+                            )
+                    llm_resp: LLMResponse = self.llm.initial_request(
+                        cfg.task, context_str, plan=plan
+                    )
                 else:
                     llm_resp = self.llm.retry_request(
                         task=cfg.task,

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -110,6 +110,33 @@ Analyze the code and produce the minimal changes needed to complete the task.
 Return ONLY the JSON object specified in the system prompt.
 """
 
+# The planning pass deliberately forbids code. Asking for a plan and changes in
+# one response reliably produces changes with a plan-shaped preamble -- the
+# model commits to an approach and then justifies it, which is the opposite of
+# planning. A separate call with no code in the schema keeps the two apart.
+_BUILTIN_PLAN_PROMPT = """\
+## Task
+{task}
+
+## Repository Context
+{context}
+
+## Instructions
+Do NOT write any code yet. Work out how you would approach this task.
+
+Return ONLY a JSON object with this schema:
+
+{{
+  "plan": ["<step>", "<step>", ...],
+  "files_to_change": ["<relative path>", ...],
+  "risks": ["<what could go wrong or is unclear>", ...],
+  "confidence": <0.0-1.0 float>
+}}
+
+Keep the plan to at most 6 steps. If the task is unclear or the context is
+insufficient, say so in "risks" and set confidence below 0.4.
+"""
+
 _BUILTIN_RETRY_PROMPT = """\
 ## Task
 {task}
@@ -149,6 +176,33 @@ class FileChange:
 
 
 @dataclass
+class Plan:
+    raw: str
+    steps: list[str]
+    files_to_change: list[str]
+    risks: list[str]
+    confidence: float
+    parse_error: Optional[str] = None
+
+    @property
+    def usable(self) -> bool:
+        """A plan with no steps is not worth putting in the next prompt."""
+        return bool(self.steps) and not self.parse_error
+
+    def render(self) -> str:
+        """The plan as it appears in the execution prompt."""
+        lines = ["## Your Plan", ""]
+        lines += [f"{i}. {step}" for i, step in enumerate(self.steps, 1)]
+        if self.files_to_change:
+            joined = ", ".join(self.files_to_change)
+            lines += ["", f"Files you expect to change: {joined}"]
+        if self.risks:
+            lines += ["", "Risks you identified:"]
+            lines += [f"- {risk}" for risk in self.risks]
+        return "\n".join(lines)
+
+
+@dataclass
 class LLMResponse:
     raw: str
     analysis: str
@@ -161,6 +215,7 @@ class LLMResponse:
 SYSTEM_PROMPT = load_prompt("system", _BUILTIN_SYSTEM_PROMPT)
 TASK_PROMPT_TEMPLATE = load_prompt("initial", _BUILTIN_TASK_PROMPT)
 RETRY_PROMPT_TEMPLATE = load_prompt("retry", _BUILTIN_RETRY_PROMPT)
+PLAN_PROMPT_TEMPLATE = load_prompt("plan", _BUILTIN_PLAN_PROMPT)
 
 
 # ─────────────────────────────────────────────
@@ -291,9 +346,42 @@ class LLMClient:
             done=bool(data.get("done", False)),
         )
 
-    def initial_request(self, task: str, context_str: str) -> LLMResponse:
+    def _parse_plan(self, raw: str) -> Plan:
+        text = raw.strip()
+        start, end = text.find("{"), text.rfind("}") + 1
+        if start == -1 or end == 0:
+            return Plan(raw, [], [], [], 0.0, f"No JSON object in plan: {raw[:200]}")
+        try:
+            data = json.loads(text[start:end])
+        except json.JSONDecodeError as exc:
+            return Plan(raw, [], [], [], 0.0, f"Plan JSON parse error: {exc}")
+
+        def as_list(key):
+            value = data.get(key) or []
+            return [str(v) for v in value] if isinstance(value, list) else []
+
+        return Plan(
+            raw=raw,
+            steps=as_list("plan"),
+            files_to_change=as_list("files_to_change"),
+            risks=as_list("risks"),
+            confidence=float(data.get("confidence", 0.5)),
+        )
+
+    def plan_request(self, task: str, context_str: str) -> Plan:
+        """Ask for an approach before any code is written."""
+        prompt = PLAN_PROMPT_TEMPLATE.format(task=task, context=context_str)
+        return self._parse_plan(self._call(prompt))
+
+    def initial_request(
+        self, task: str, context_str: str, plan: Optional["Plan"] = None
+    ) -> LLMResponse:
         """First-pass: analyze task and produce code changes."""
         prompt = TASK_PROMPT_TEMPLATE.format(task=task, context=context_str)
+        if plan is not None and plan.usable:
+            # Appended rather than templated in, so the execution prompt is
+            # byte-identical when planning is off.
+            prompt = f"{prompt}\n{plan.render()}\n"
         raw = self._call(prompt)
         return self._parse_response(raw)
 

--- a/prompts/plan.txt
+++ b/prompts/plan.txt
@@ -1,0 +1,20 @@
+## Task
+{task}
+
+## Repository Context
+{context}
+
+## Instructions
+Do NOT write any code yet. Work out how you would approach this task.
+
+Return ONLY a JSON object with this schema:
+
+{{
+  "plan": ["<step>", "<step>", ...],
+  "files_to_change": ["<relative path>", ...],
+  "risks": ["<what could go wrong or is unclear>", ...],
+  "confidence": <0.0-1.0 float>
+}}
+
+Keep the plan to at most 6 steps. If the task is unclear or the context is
+insufficient, say so in "risks" and set confidence below 0.4.

--- a/tests/test_plan_phase.py
+++ b/tests/test_plan_phase.py
@@ -1,0 +1,240 @@
+"""
+Tests for the planning pass (modules/llm_client.py, modules/agent_loop.py).
+
+`--plan-first` asks the model how it would approach the task before it writes
+any code, then appends that plan to the execution prompt.
+
+A planning pass costs an API call, so the properties worth pinning are that it
+is off by default, that a bad plan degrades rather than derails, and that the
+execution prompt is byte-identical when planning is off.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.llm_client import (  # noqa: E402
+    PLAN_PROMPT_TEMPLATE,
+    TASK_PROMPT_TEMPLATE,
+    LLMClient,
+    Plan,
+)
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+GOOD_PLAN = (
+    '{"plan":["read the parser","add a guard"],'
+    '"files_to_change":["parser.py"],'
+    '"risks":["tests may not cover it"],"confidence":0.8}'
+)
+
+
+def client():
+    return object.__new__(LLMClient)
+
+
+def parse(raw):
+    return client()._parse_plan(raw)
+
+
+# ── parsing ───────────────────────────────────────────────────────────────
+
+
+def test_a_well_formed_plan_parses():
+    plan = parse(GOOD_PLAN)
+
+    assert plan.steps == ["read the parser", "add a guard"]
+    assert plan.files_to_change == ["parser.py"]
+    assert plan.risks == ["tests may not cover it"]
+    assert plan.confidence == 0.8
+    assert plan.usable is True
+
+
+def test_surrounding_prose_is_tolerated():
+    """Same leniency the change parser already applies."""
+    assert parse(f"Here is my plan:\n{GOOD_PLAN}\nHope that helps.").usable is True
+
+
+@pytest.mark.parametrize("raw", ["not json at all", "", "{unclosed", "[]"])
+def test_malformed_plans_are_not_usable(raw):
+    plan = parse(raw)
+
+    assert plan.usable is False
+    assert plan.confidence == 0.0 or plan.steps == []
+
+
+def test_a_plan_with_no_steps_is_not_usable():
+    """Nothing to add to the next prompt."""
+    assert parse('{"plan":[],"confidence":0.9}').usable is False
+
+
+def test_wrong_types_do_not_raise():
+    plan = parse('{"plan":"a string not a list","risks":42,"confidence":0.5}')
+
+    assert plan.steps == []
+    assert plan.risks == []
+
+
+def test_missing_fields_default_cleanly():
+    plan = parse('{"plan":["one step"]}')
+
+    assert plan.steps == ["one step"]
+    assert plan.files_to_change == []
+    assert plan.confidence == 0.5
+
+
+# ── rendering ─────────────────────────────────────────────────────────────
+
+
+def test_steps_are_numbered():
+    text = parse(GOOD_PLAN).render()
+
+    assert "1. read the parser" in text
+    assert "2. add a guard" in text
+
+
+def test_files_and_risks_are_included():
+    text = parse(GOOD_PLAN).render()
+
+    assert "parser.py" in text
+    assert "tests may not cover it" in text
+
+
+def test_empty_sections_are_omitted():
+    text = parse('{"plan":["one step"]}').render()
+
+    assert "Files you expect" not in text
+    assert "Risks" not in text
+
+
+# ── the planning prompt ───────────────────────────────────────────────────
+
+
+def test_the_plan_prompt_forbids_code():
+    """
+    Asking for a plan and changes together produces changes with a plan-shaped
+    preamble, which is the opposite of planning.
+    """
+    assert "Do NOT write any code" in PLAN_PROMPT_TEMPLATE
+
+
+def test_the_plan_prompt_asks_for_risks():
+    assert "risks" in PLAN_PROMPT_TEMPLATE
+
+
+def test_the_plan_prompt_has_its_placeholders():
+    PLAN_PROMPT_TEMPLATE.format(task="t", context="c")
+
+
+def test_the_plan_prompt_file_matches_its_builtin():
+    """
+    #59 moved prompts into prompts/*.txt with a built-in fallback. A drift here
+    would change what the model sees while looking like a pure addition.
+    """
+    from pathlib import Path
+
+    from modules.llm_client import _BUILTIN_PLAN_PROMPT
+
+    path = Path(__file__).resolve().parents[1] / "prompts" / "plan.txt"
+    assert path.read_text(encoding="utf-8") == _BUILTIN_PLAN_PROMPT
+
+
+def test_a_missing_plan_file_falls_back(monkeypatch, tmp_path):
+    """A bad checkout degrades to the built-in prompt, not to no prompt."""
+    from modules.llm_client import (
+        PROMPT_DIR_ENV_VAR,
+        _BUILTIN_PLAN_PROMPT,
+        load_prompt,
+    )
+
+    monkeypatch.setenv(PROMPT_DIR_ENV_VAR, str(tmp_path))
+    assert load_prompt("plan", _BUILTIN_PLAN_PROMPT) == _BUILTIN_PLAN_PROMPT
+
+
+# ── the execution prompt ──────────────────────────────────────────────────
+
+
+class Recorder(LLMClient):
+    def __init__(self):
+        self.prompts = []
+
+    def _call(self, prompt, retries=3):
+        self.prompts.append(prompt)
+        return '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
+
+
+def test_no_plan_leaves_the_prompt_unchanged():
+    """Planning is opt-in; the existing path must be untouched."""
+    recorder = Recorder()
+    recorder.initial_request("task", "context")
+
+    expected = TASK_PROMPT_TEMPLATE.format(task="task", context="context")
+    assert recorder.prompts[0] == expected
+
+
+def test_a_usable_plan_is_appended():
+    recorder = Recorder()
+    recorder.initial_request("task", "context", plan=parse(GOOD_PLAN))
+
+    assert "## Your Plan" in recorder.prompts[0]
+    assert "1. read the parser" in recorder.prompts[0]
+
+
+def test_an_unusable_plan_is_not_appended():
+    """A failed planning call should not corrupt the execution prompt."""
+    recorder = Recorder()
+    recorder.initial_request("task", "context", plan=parse("garbage"))
+
+    expected = TASK_PROMPT_TEMPLATE.format(task="task", context="context")
+    assert recorder.prompts[0] == expected
+
+
+def test_plan_request_uses_the_plan_prompt():
+    recorder = Recorder()
+    recorder.plan_request("task", "context")
+
+    assert "Do NOT write any code" in recorder.prompts[0]
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_planning_is_off_by_default():
+    assert AgentConfig(repo_root=".", task="t").plan_first is False
+
+
+def test_planning_only_runs_on_the_first_iteration():
+    """
+    Later iterations already carry real test output, which is a stronger signal
+    than a re-plan and does not cost an extra call.
+    """
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    start = source.index("if cfg.plan_first")
+
+    assert "iteration == 1" in source[start:start + 80]
+
+
+def test_an_unusable_plan_is_reported_not_fatal():
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    start = source.index("if cfg.plan_first")
+    block = source[start:start + 1600]
+
+    assert "continuing without it" in block
+
+
+def test_the_plan_is_logged():
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    start = source.index("if cfg.plan_first")
+    block = source[start:start + 1600]
+
+    assert "plan.steps" in block
+    assert "risk" in block
+
+
+def test_plan_is_a_typed_result_not_a_dict():
+    """The loop reads .usable and .steps; a dict would fail silently."""
+    assert isinstance(parse(GOOD_PLAN), Plan)


### PR DESCRIPTION
Closes #58

## Summary

`--plan-first` asks the model how it would approach the task before it writes any code, then appends that plan to the execution prompt.

```bash
python main.py --repo . --task "Add rate limiting to /api/login" --plan-first
```

Off by default. Costs one extra API call, on the first iteration only.

## The planning call forbids code

This is the part that makes it work rather than being theatre.

Asking for a plan and changes in one response reliably produces changes with a plan-shaped preamble: the model commits to an approach and then justifies it, which is the opposite of planning. So `plan_request` is a separate call whose schema has no room for code at all:

```json
{
  "plan": ["<step>", ...],
  "files_to_change": ["<relative path>", ...],
  "risks": ["<what could go wrong or is unclear>", ...],
  "confidence": <0.0-1.0>
}
```

with an explicit `Do NOT write any code yet` in the instructions, and a cap of six steps so the plan stays a plan.

`risks` is the field worth having. The prompt tells the model that if the task is unclear or the context is insufficient, it should say so there and set confidence below 0.4 — which surfaces "I don't have enough to go on" before an iteration is spent finding out. Risks are logged at WARNING so they stand out from the steps.

## First iteration only

Later iterations already carry the strongest signal available — real test output naming the actual failure. Re-planning against that would spend a call restating what the error message already says. So the pass runs when `iteration == 1` and not after.

## A bad plan degrades, it does not derail

`Plan.usable` is false when parsing failed or no steps came back. In that case the run logs why and continues without it:

```
Planning pass unusable (No JSON object in plan: ...); continuing without it.
```

And the plan is *appended* to the execution prompt rather than templated into it, so when planning is off — or the plan was unusable — the prompt is byte-identical to what it is today. There is a test asserting exactly that against `TASK_PROMPT_TEMPLATE.format(...)`.

`_parse_plan` is deliberately lenient in the same way `_parse_response` already is: it tolerates prose around the JSON object, and wrong types (`"plan": "a string"`, `"risks": 42`) yield empty lists rather than raising.

## Prompt lives in a file

Since #59 landed, prompts are loaded from `prompts/*.txt` with a built-in fallback. The plan prompt follows that pattern rather than sitting as a constant in Python:

- `prompts/plan.txt` is the source
- `_BUILTIN_PLAN_PROMPT` is the fallback
- `PLAN_PROMPT_TEMPLATE = load_prompt("plan", _BUILTIN_PLAN_PROMPT)`

Two tests cover it: the file is byte-identical to its builtin, so drift fails CI rather than quietly changing what the model sees; and a missing `prompts/` directory falls back to the builtin rather than leaving the planning call with no prompt.

## Tests

`tests/test_plan_phase.py` — 26 cases.

Parsing: a well-formed plan parses; surrounding prose is tolerated; four malformed inputs are not usable; a plan with no steps is not usable; wrong types do not raise; missing fields default cleanly.

Rendering: steps are numbered; files and risks are included; empty sections are omitted.

The planning prompt: it forbids code; it asks for risks; its placeholders format; the file matches its builtin; a missing file falls back.

The execution prompt: no plan leaves it byte-identical; a usable plan is appended; an unusable plan is not; `plan_request` uses the planning prompt rather than the task one.

Wiring: planning is off by default; it only runs on the first iteration; an unusable plan is reported and not fatal; the plan and its risks are logged; `Plan` is a typed result rather than a dict, since the loop reads `.usable` and `.steps` and a dict would fail silently.

## Verified

- 49 tests pass across this suite plus `test_prompt_files.py` and `test_utils.py`
- `PLAN_PROMPT_TEMPLATE == _BUILTIN_PLAN_PROMPT` holds
- `llm_client.py` is `+90 −2`, `agent_loop.py` `+27 −1`, `main.py` `+4` — the deletions are the two signature lines I intentionally replaced

CI will be red until the sandbox restore PR lands: `modules/sandbox.py` on `main` is missing its `logging` import, so most of the suite cannot collect. Nothing here touches that file.

## Base

Rebuilt on current `main`. An earlier version of this branch was cut before #59 and #64 landed and carried the prompt as a Python constant; merging it would have fought with the prompt-file structure. This one adopts it instead. That branch has been deleted.

## What it does not claim

The issue expects this to "reduce the number of failed sandbox iterations". That is plausible and it is why the feature is worth having, but I have not measured it — doing so honestly needs a set of tasks run with and without the flag against a real API key, which I have not done. What is verified here is that the plan is produced, is well-formed, reaches the execution prompt, and cannot break a run when it goes wrong. Whether it actually reduces iterations is an open question the flag now makes it possible to answer.