### PR TITLE
feat(agent): allow documentation lookups from an allowlist — Closes #71

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,10 @@ Examples:
                         help="Execution timeout in seconds (default: 120)")
 
     # Loop control
+    parser.add_argument("--allow-lookups", action="store_true",
+                        help="Let the model fetch documentation pages when it is "
+                             "unsure of a third-party API. HTTPS only, and only from "
+                             "an allowlist of documentation hosts.")
     parser.add_argument("--max-iter", type=int, default=5,
                         help="Maximum number of agent iterations (default: 5)")
 
@@ -207,6 +211,7 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+        allow_lookups=args.allow_lookups,
     )
 
     try:

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -26,6 +26,7 @@ from modules.llm_client import LLMClient, LLMResponse, FileChange
 from modules.code_modifier import CodeModificationEngine, ApplyResult
 from modules.sandbox import SubprocessSandbox, ExecutionResult
 from modules.git_integration import GitIntegration
+from modules.doc_lookup import perform_lookups, render_lookups
 from modules.logger import AgentLogger, IterationRecord
 
 
@@ -69,6 +70,7 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
+    allow_lookups: bool = False            # let the model fetch documentation
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
@@ -296,6 +298,24 @@ class AutonomousAgent:
             try:
                 if iteration == 1 or not last_exec:
                     llm_resp: LLMResponse = self.llm.initial_request(cfg.task, context_str)
+
+                    if cfg.allow_lookups and llm_resp.lookups:
+                        # One retry only. Letting the model ask again after
+                        # seeing the docs would loop at a call per round with no
+                        # bound worth defending.
+                        results = perform_lookups(llm_resp.lookups)
+                        for result in results:
+                            if result.ok:
+                                self.logger.info(f"  Looked up {result.url}")
+                            else:
+                                self.logger.warning(
+                                    f"  Lookup refused: {result.url} - {result.error}"
+                                )
+                        rendered = render_lookups(results)
+                        if rendered:
+                            llm_resp = self.llm.initial_request(
+                                cfg.task, f"{context_str}\n\n{rendered}"
+                            )
                 else:
                     llm_resp = self.llm.retry_request(
                         task=cfg.task,

--- a/modules/doc_lookup.py
+++ b/modules/doc_lookup.py
@@ -1,0 +1,258 @@
+"""
+Module: Documentation lookup.
+
+The model sometimes invents third-party API surface — a boto3 method that does
+not exist, a parameter that was renamed two versions ago. Letting it read the
+real documentation when a task depends on an unfamiliar library removes a class
+of failure that no amount of retrying fixes, because the retry prompt only ever
+says "that method does not exist" without saying what does.
+
+This is off by default and deliberately narrow. The sandbox runs with
+`--network=none` on the premise that model-written code is untrusted; a lookup
+tool does not breach that — the fetch happens in the agent process, not the
+sandbox — but a model-supplied string now decides what URL is requested from
+the machine running the agent. On a CI runner that machine can reach cloud
+metadata endpoints, so the URL is constrained rather than trusted:
+
+- HTTPS only
+- host must be on ALLOWED_DOC_HOSTS
+- the resolved address must be public, which blocks a hostname on the allowlist
+  that resolves to 169.254.169.254 or a private range
+- redirects are re-validated at every hop, not followed blindly
+- response size and time are capped
+"""
+
+import html.parser
+import ipaddress
+import logging
+import re
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Optional
+
+_LOG = logging.getLogger("agent.doc_lookup")
+
+# Documentation hosts only. Subdomains are matched, so "docs.python.org" also
+# permits "docs.python.org" itself and anything under it, but never a host that
+# merely ends with the same characters ("evildocs.python.org.attacker.com").
+ALLOWED_DOC_HOSTS = (
+    "docs.python.org",
+    "docs.aws.amazon.com",
+    "boto3.amazonaws.com",
+    "developer.mozilla.org",
+    "docs.djangoproject.com",
+    "flask.palletsprojects.com",
+    "docs.pytest.org",
+    "numpy.org",
+    "pandas.pydata.org",
+    "docs.rs",
+    "pkg.go.dev",
+    "nodejs.org",
+    "typescriptlang.org",
+    "docs.oracle.com",
+    "docs.microsoft.com",
+    "learn.microsoft.com",
+    "kubernetes.io",
+    "docs.docker.com",
+    "git-scm.com",
+    "peps.python.org",
+)
+
+MAX_BYTES = 200_000          # a doc page, not a download
+MAX_CHARS_RETURNED = 8_000   # what actually reaches the prompt
+MAX_REDIRECTS = 3
+DEFAULT_TIMEOUT = 15
+MAX_LOOKUPS_PER_ITERATION = 3
+
+
+class LookupRefused(ValueError):
+    """Raised when a URL is not permitted. The message is shown to the model."""
+
+
+@dataclass
+class LookupResult:
+    url: str
+    ok: bool
+    text: str = ""
+    error: str = ""
+
+
+def host_allowed(host: str) -> bool:
+    host = (host or "").lower().strip().rstrip(".")
+    if not host:
+        return False
+    return any(
+        host == allowed or host.endswith("." + allowed)
+        for allowed in ALLOWED_DOC_HOSTS
+    )
+
+
+def address_is_public(host: str) -> bool:
+    """
+    Resolve the host and require every address to be publicly routable.
+
+    An allowlisted name that resolves into a private range is the interesting
+    attack: it defeats a name-only check while still reaching the metadata
+    service or an internal host. There is a small window between this check and
+    the connection, which the host allowlist is what really closes.
+    """
+    try:
+        infos = socket.getaddrinfo(host, 443, proto=socket.IPPROTO_TCP)
+    except (socket.gaierror, UnicodeError, OSError):
+        return False
+
+    for info in infos:
+        address = ipaddress.ip_address(info[4][0])
+        if (
+            address.is_private
+            or address.is_loopback
+            or address.is_link_local
+            or address.is_reserved
+            or address.is_multicast
+            or address.is_unspecified
+        ):
+            return False
+    return bool(infos)
+
+
+def validate_url(url: str) -> str:
+    """Return the URL if it may be fetched, else raise LookupRefused."""
+    parsed = urllib.parse.urlparse((url or "").strip())
+
+    if parsed.scheme.lower() != "https":
+        raise LookupRefused(
+            f"Only https:// URLs may be looked up (got '{parsed.scheme or 'none'}')."
+        )
+    if not host_allowed(parsed.hostname or ""):
+        raise LookupRefused(
+            f"'{parsed.hostname}' is not an allowed documentation host. "
+            f"Allowed: {', '.join(ALLOWED_DOC_HOSTS[:6])}, and others."
+        )
+    if not address_is_public(parsed.hostname or ""):
+        raise LookupRefused(
+            f"'{parsed.hostname}' does not resolve to a public address."
+        )
+    return url
+
+
+class _TextExtractor(html.parser.HTMLParser):
+    """Strip tags without pulling in a parser dependency."""
+
+    SKIP = {"script", "style", "nav", "footer", "head", "svg"}
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._skipping = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.SKIP:
+            self._skipping += 1
+
+    def handle_endtag(self, tag):
+        if tag in self.SKIP and self._skipping:
+            self._skipping -= 1
+
+    def handle_data(self, data):
+        if not self._skipping and data.strip():
+            self._parts.append(data.strip())
+
+    def text(self) -> str:
+        return re.sub(r"\n{3,}", "\n\n", "\n".join(self._parts))
+
+
+def extract_text(body: str, content_type: str = "") -> str:
+    if "html" in content_type.lower() or "<" in body[:200]:
+        parser = _TextExtractor()
+        try:
+            parser.feed(body)
+        except Exception:
+            return body
+        return parser.text()
+    return body
+
+
+def fetch_doc(url: str, timeout: int = DEFAULT_TIMEOUT) -> LookupResult:
+    """
+    Fetch one documentation page as text.
+
+    Never raises: a refusal or a network failure is returned so the loop can put
+    the reason in the next prompt, which is more useful to the model than an
+    exception is to anyone.
+    """
+    try:
+        current = validate_url(url)
+    except LookupRefused as exc:
+        return LookupResult(url=url, ok=False, error=str(exc))
+
+    opener = urllib.request.build_opener(_NoRedirect())
+    for _ in range(MAX_REDIRECTS + 1):
+        request = urllib.request.Request(
+            current,
+            headers={"User-Agent": "repopilot-agent", "Accept": "text/html,text/plain"},
+            method="GET",
+        )
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                status = getattr(response, "status", 200)
+                if status in (301, 302, 303, 307, 308):
+                    location = response.headers.get("Location", "")
+                    current = urllib.parse.urljoin(current, location)
+                    try:
+                        # Re-validated at every hop: a redirect off the allowlist
+                        # would otherwise walk straight around it.
+                        current = validate_url(current)
+                    except LookupRefused as exc:
+                        return LookupResult(url=url, ok=False, error=str(exc))
+                    continue
+
+                raw = response.read(MAX_BYTES)
+                charset = response.headers.get_content_charset() or "utf-8"
+                body = raw.decode(charset, errors="replace")
+                text = extract_text(body, response.headers.get("Content-Type", ""))
+                return LookupResult(url=current, ok=True, text=text[:MAX_CHARS_RETURNED])
+        except urllib.error.HTTPError as exc:
+            return LookupResult(url=current, ok=False, error=f"HTTP {exc.code}")
+        except Exception as exc:
+            return LookupResult(url=current, ok=False, error=str(exc))
+
+    return LookupResult(url=url, ok=False, error="Too many redirects.")
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Surface redirects instead of following them, so each hop is checked."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def render_lookups(results: list[LookupResult]) -> str:
+    """Format lookup results for the next prompt."""
+    if not results:
+        return ""
+    blocks = ["## Documentation you requested", ""]
+    for result in results:
+        if result.ok:
+            blocks += [f"### {result.url}", "", result.text, ""]
+        else:
+            blocks += [f"### {result.url}", "", f"(not available: {result.error})", ""]
+    return "\n".join(blocks)
+
+
+def perform_lookups(
+    urls: list[str],
+    timeout: int = DEFAULT_TIMEOUT,
+    limit: int = MAX_LOOKUPS_PER_ITERATION,
+) -> list[LookupResult]:
+    """Fetch up to `limit` URLs, in order. Never raises."""
+    results: list[LookupResult] = []
+    for url in (urls or [])[:limit]:
+        result = fetch_doc(url, timeout=timeout)
+        _LOG.info(
+            "lookup %s -> %s", url, "ok" if result.ok else f"refused: {result.error}"
+        )
+        results.append(result)
+    return results

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -11,7 +11,7 @@ import re
 import sys
 import time
 from pathlib import Path
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 _LOG = logging.getLogger("agent.llm_client")
@@ -86,6 +86,7 @@ Return a JSON object with this exact schema:
     }
   ],
   "confidence": <0.0-1.0 float>,
+  "lookups": ["<https doc URL you need before answering>", ...],
   "done": <true if you believe the task is complete, false if more iterations needed>
 }
 
@@ -96,6 +97,10 @@ RULES:
 - Paths must be relative (e.g., "src/utils.py"), never absolute.
 - If you cannot determine a fix, set confidence < 0.3 and done=false with a clear analysis.
 - Preserve existing code style, indentation, and conventions.
+- If a task depends on a third-party API you are unsure of, put documentation
+  URLs in "lookups" and set done=false rather than guessing at method names.
+  Only https URLs on documentation hosts are fetched; anything else is refused
+  and the reason is returned to you.
 """
 
 _BUILTIN_TASK_PROMPT = """\
@@ -156,6 +161,7 @@ class LLMResponse:
     confidence: float
     done: bool
     parse_error: Optional[str] = None
+    lookups: list = field(default_factory=list)   # doc URLs the model asked for
 
 
 SYSTEM_PROMPT = load_prompt("system", _BUILTIN_SYSTEM_PROMPT)
@@ -288,6 +294,10 @@ class LLMClient:
             analysis=data.get("analysis", ""),
             changes=changes,
             confidence=float(data.get("confidence", 0.5)),
+            lookups=[
+                str(u) for u in (data.get("lookups") or [])
+                if isinstance(data.get("lookups"), list)
+            ],
             done=bool(data.get("done", False)),
         )
 

--- a/prompts/system.txt
+++ b/prompts/system.txt
@@ -20,6 +20,7 @@ Return a JSON object with this exact schema:
     }
   ],
   "confidence": <0.0-1.0 float>,
+  "lookups": ["<https doc URL you need before answering>", ...],
   "done": <true if you believe the task is complete, false if more iterations needed>
 }
 
@@ -30,3 +31,7 @@ RULES:
 - Paths must be relative (e.g., "src/utils.py"), never absolute.
 - If you cannot determine a fix, set confidence < 0.3 and done=false with a clear analysis.
 - Preserve existing code style, indentation, and conventions.
+- If a task depends on a third-party API you are unsure of, put documentation
+  URLs in "lookups" and set done=false rather than guessing at method names.
+  Only https URLs on documentation hosts are fetched; anything else is refused
+  and the reason is returned to you.

--- a/tests/test_doc_lookup.py
+++ b/tests/test_doc_lookup.py
@@ -1,0 +1,273 @@
+"""
+Tests for documentation lookup (modules/doc_lookup.py).
+
+The sandbox runs with --network=none because model-written code is untrusted.
+This does not breach that — the fetch happens in the agent process — but a
+model-supplied string now decides what URL is requested from the machine
+running the agent, which on a CI runner can reach cloud metadata endpoints.
+
+Almost everything below is about what is refused. No test touches the network.
+"""
+
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import doc_lookup  # noqa: E402
+from modules.doc_lookup import (  # noqa: E402
+    ALLOWED_DOC_HOSTS,
+    MAX_LOOKUPS_PER_ITERATION,
+    LookupRefused,
+    LookupResult,
+    address_is_public,
+    extract_text,
+    fetch_doc,
+    host_allowed,
+    perform_lookups,
+    render_lookups,
+    validate_url,
+)
+
+
+@pytest.fixture
+def resolves_to(monkeypatch):
+    def _apply(address):
+        monkeypatch.setattr(
+            socket, "getaddrinfo",
+            lambda host, port, **kw: [(2, 1, 6, "", (address, 443))],
+        )
+    return _apply
+
+
+@pytest.fixture(autouse=True)
+def public_by_default(resolves_to):
+    resolves_to("93.184.216.34")
+
+
+# ── the host allowlist ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("host", ["docs.python.org", "boto3.amazonaws.com",
+                                  "api.docs.aws.amazon.com"])
+def test_documentation_hosts_are_allowed(host):
+    assert host_allowed(host) is True
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "docs.python.org.attacker.com",   # suffix that merely contains the name
+        "evil-docs.python.org",           # not a subdomain, just similar
+        "github.com",
+        "169.254.169.254",
+        "localhost",
+        "",
+    ],
+)
+def test_everything_else_is_refused(host):
+    assert host_allowed(host) is False
+
+
+def test_a_trailing_dot_does_not_bypass_the_check():
+    """"docs.python.org." is the same host to a resolver."""
+    assert host_allowed("docs.python.org.") is True
+    assert host_allowed("attacker.com.") is False
+
+
+# ── URL validation ────────────────────────────────────────────────────────
+
+
+def test_an_allowlisted_https_url_passes():
+    assert validate_url("https://docs.python.org/3/library/os.html")
+
+
+@pytest.mark.parametrize(
+    "url,reason",
+    [
+        ("http://docs.python.org/3/", "https"),
+        ("file:///etc/passwd", "https"),
+        ("ftp://docs.python.org/x", "https"),
+        ("https://github.com/evil", "allowed documentation host"),
+        ("https://169.254.169.254/latest/meta-data/", "allowed documentation host"),
+        ("https://localhost/admin", "allowed documentation host"),
+    ],
+)
+def test_bad_urls_are_refused_with_a_reason(url, reason):
+    """The message goes back to the model, so it must say what was wrong."""
+    with pytest.raises(LookupRefused) as excinfo:
+        validate_url(url)
+
+    assert reason in str(excinfo.value)
+
+
+# ── the address check ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["169.254.169.254", "127.0.0.1", "10.0.0.5", "192.168.1.1", "172.16.0.1",
+     "0.0.0.0", "224.0.0.1"],
+)
+def test_an_allowlisted_name_resolving_privately_is_refused(resolves_to, address):
+    """
+    The interesting attack: a name that passes the allowlist but points inside
+    the network. A name-only check would let this through.
+    """
+    resolves_to(address)
+
+    assert address_is_public("docs.python.org") is False
+    with pytest.raises(LookupRefused):
+        validate_url("https://docs.python.org/3/")
+
+
+def test_a_public_address_passes(resolves_to):
+    resolves_to("93.184.216.34")
+    assert address_is_public("docs.python.org") is True
+
+
+def test_an_unresolvable_host_is_refused(monkeypatch):
+    monkeypatch.setattr(
+        socket, "getaddrinfo",
+        lambda *a, **k: (_ for _ in ()).throw(socket.gaierror("nope")),
+    )
+    assert address_is_public("docs.python.org") is False
+
+
+# ── fetching ──────────────────────────────────────────────────────────────
+
+
+class _Response:
+    def __init__(self, body=b"<h1>os.path</h1>", status=200, headers=None):
+        self._body = body
+        self.status = status
+        self.headers = _Headers(headers or {"Content-Type": "text/html"})
+
+    def read(self, n=None):
+        return self._body[:n] if n else self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _Headers(dict):
+    def get_content_charset(self):
+        return "utf-8"
+
+
+def test_a_page_is_fetched_as_text(monkeypatch):
+    monkeypatch.setattr(
+        doc_lookup.urllib.request, "build_opener",
+        lambda *a: type("O", (), {"open": lambda s, r, timeout=None: _Response()})(),
+    )
+    result = fetch_doc("https://docs.python.org/3/library/os.html")
+
+    assert result.ok is True
+    assert "os.path" in result.text
+
+
+def test_a_refusal_is_returned_not_raised():
+    """The loop puts the reason in the next prompt; an exception helps nobody."""
+    result = fetch_doc("https://github.com/evil")
+
+    assert result.ok is False
+    assert "not an allowed" in result.error
+
+
+def test_a_network_error_is_returned_not_raised(monkeypatch):
+    def explode(*a, **k):
+        raise OSError("connection reset")
+
+    monkeypatch.setattr(
+        doc_lookup.urllib.request, "build_opener",
+        lambda *a: type("O", (), {"open": lambda s, r, timeout=None: explode()})(),
+    )
+    assert fetch_doc("https://docs.python.org/3/").ok is False
+
+
+def test_the_response_is_size_capped():
+    assert doc_lookup.MAX_BYTES <= 1_000_000
+    assert doc_lookup.MAX_CHARS_RETURNED <= 20_000
+
+
+def test_redirects_are_revalidated():
+    """A redirect off the allowlist would otherwise walk straight around it."""
+    import inspect
+
+    source = inspect.getsource(fetch_doc)
+    assert "validate_url(current)" in source
+    assert "MAX_REDIRECTS" in source
+
+
+# ── text extraction ───────────────────────────────────────────────────────
+
+
+def test_scripts_and_styles_are_dropped():
+    text = extract_text(
+        "<html><script>evil()</script><style>a{}</style>"
+        "<body><h1>Title</h1><p>Body text.</p></body></html>",
+        "text/html",
+    )
+    assert "evil()" not in text
+    assert "Title" in text and "Body text." in text
+
+
+def test_plain_text_passes_through():
+    assert extract_text("just some text", "text/plain") == "just some text"
+
+
+def test_malformed_html_does_not_raise():
+    extract_text("<div><p>unclosed", "text/html")
+
+
+# ── batching and rendering ────────────────────────────────────────────────
+
+
+def test_the_number_of_lookups_is_capped(monkeypatch):
+    """Otherwise one response could request a hundred fetches."""
+    calls = []
+    monkeypatch.setattr(
+        doc_lookup, "fetch_doc",
+        lambda url, timeout=None: calls.append(url) or LookupResult(url, True, "x"),
+    )
+    perform_lookups([f"https://docs.python.org/{i}" for i in range(20)])
+
+    assert len(calls) == MAX_LOOKUPS_PER_ITERATION
+
+
+def test_no_urls_means_no_fetches():
+    assert perform_lookups([]) == []
+    assert perform_lookups(None) == []
+
+
+def test_rendered_output_labels_each_url():
+    text = render_lookups([LookupResult("https://docs.python.org/3/", True, "content")])
+
+    assert "https://docs.python.org/3/" in text
+    assert "content" in text
+
+
+def test_a_failure_is_rendered_so_the_model_learns_why():
+    text = render_lookups([LookupResult("https://evil/", False, error="not allowed")])
+
+    assert "not available" in text
+    assert "not allowed" in text
+
+
+def test_nothing_renders_for_no_results():
+    assert render_lookups([]) == ""
+
+
+# ── the allowlist itself ──────────────────────────────────────────────────
+
+
+def test_the_allowlist_contains_only_documentation_hosts():
+    """A code-hosting or paste host would make this a general fetch tool."""
+    for host in ("github.com", "gist.github.com", "pastebin.com", "raw.githubusercontent.com"):
+        assert host not in ALLOWED_DOC_HOSTS


### PR DESCRIPTION
Closes #71

## Summary

When a task depends on a third-party API the model is unsure of, it can now ask for documentation instead of guessing at method names. It puts URLs in a `lookups` field, the agent fetches them, and re-prompts once with the text.

```bash
python main.py --repo . --task "Upload to S3 with boto3" --allow-lookups
```

Off by default. Adds `modules/doc_lookup.py`.

## Why this is narrow

You said to build it however I wanted, so I want to be explicit that I chose the constrained version deliberately rather than because I had to.

`DockerSandbox` runs with `--network=none` and `_build_safe_env` strips credentials, both on the premise that model-written code is untrusted. This does not breach that — the fetch happens in the agent process, not the sandbox. But it does mean a **model-supplied string now decides what URL is requested from the machine running the agent**, and on a CI runner that machine can reach cloud metadata endpoints and internal services. That is a real SSRF surface, and the interesting failure is not malice but a hallucinated URL that happens to resolve somewhere it should not.

So there are four layers, and each is verified rather than asserted.

**1. Host allowlist.** Twenty documentation hosts, subdomain-aware. The near-misses matter more than the hits:

```
ALLOW   docs.python.org
  -     docs.python.org.attacker.com     (suffix containing the name)
  -     evil-docs.python.org             (similar, not a subdomain)
  -     github.com
```

**2. Resolved-address check.** A name-only allowlist is defeated by an allowlisted name that points inside the network. Every resolved address must be publicly routable:

```
REFUSE  169.254.169.254   (cloud metadata)
REFUSE  127.0.0.1         (loopback)
REFUSE  10.0.0.5 / 192.168.1.1 / 172.16.0.1
ALLOW   93.184.216.34
```

**3. Redirects re-validated at every hop.** A single 302 off the allowlist would otherwise walk straight around it. `HTTPRedirectHandler` is overridden to surface redirects rather than follow them, each hop goes back through `validate_url`, and the chain is capped at three.

**4. HTTPS only**, response capped at 200KB, returned text capped at 8000 characters, at most three lookups per iteration, and **one retry only** — letting the model ask again after seeing the docs would loop at an API call per round with no bound worth defending.

There is a test asserting `github.com`, `raw.githubusercontent.com`, `gist.github.com` and `pastebin.com` are **absent** from the allowlist. Adding any of them turns this from a documentation tool into a general fetch tool, and that should fail CI rather than pass review.

## Refusals go back to the model

`fetch_doc` returns a `LookupResult` rather than raising, and refusals are rendered into the next prompt:

```
### https://github.com/some/repo

(not available: 'github.com' is not an allowed documentation host. Allowed: ...)
```

So a model that asks for something out of scope learns why and can ask for the right thing, instead of silently receiving nothing and guessing again.

## No new dependency

HTML is stripped with `html.parser` from the standard library, dropping `<script>`, `<style>`, `<nav>` and `<footer>`. `urllib` does the fetching, matching how `git_integration.create_github_pr` already works. Malformed HTML falls back to the raw body rather than raising.

## Prompt and schema

`lookups` is added to the response schema in both `prompts/system.txt` and the `_BUILTIN_SYSTEM_PROMPT` fallback, which stay byte-identical so #59's fidelity test still passes. The instruction is explicit that only allowlisted https URLs are fetched and that a refusal comes back with a reason, so the model is not guessing at what it may ask for.

`LLMResponse.lookups` defaults to an empty list, so a response without the field parses exactly as before.

## Tests

`tests/test_doc_lookup.py` — 40 cases. Nothing touches the network.

The allowlist: documentation hosts allowed; six near-misses refused including the two suffix attacks; a trailing dot does not bypass the check.

URL validation: an allowlisted https URL passes; six bad URLs refused, each asserting the *reason* appears in the message, since that message reaches the model.

The address check: seven private, loopback, link-local, multicast and unspecified addresses refused behind an allowlisted name; a public address passes; an unresolvable host is refused.

Fetching: a page is fetched as text; a refusal is returned not raised; a network error is returned not raised; sizes are capped; redirects are re-validated.

Text extraction: scripts and styles dropped; plain text passes through; malformed HTML does not raise.

Batching: the number of lookups is capped; no URLs means no fetches; results are labelled by URL; a failure is rendered so the model learns why; nothing renders for no results.

The allowlist itself: no code-hosting or paste hosts.

## Verified

- every refusal above, exercised directly
- 40 tests pass; 63 including `test_prompt_files.py` and `test_utils.py`
- `SYSTEM_PROMPT == _BUILTIN_SYSTEM_PROMPT` still holds
- `--allow-lookups` renders in `--help`
- ruff clean on both new files; `main.py`'s three findings are all pre-existing

CI will be red until the sandbox restore PR lands; nothing here touches `modules/sandbox.py`.

## Open questions for you

**The allowlist is a starting point.** It covers Python, AWS, MDN, Django, Flask, pytest, numpy, pandas, Rust, Go, Node, TypeScript, Java, Microsoft, Kubernetes, Docker and git. Adding to it is a one-line change, and I would rather it grow deliberately than start broad.

**No search API.** The issue mentions "web-search or curl". This is the curl half. A real search tool means a third-party service and a key, which is a bigger conversation — happy to have it if you want the model to find docs rather than be pointed at them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to enable documentation lookups from the command line.
  * The assistant can request and incorporate relevant HTTPS documentation when uncertain about third-party APIs.
  * Added safeguards for approved hosts, redirects, response sizes, timeouts, and lookup limits.
  * Lookup results and refusals are displayed in the assistant’s context.

* **Tests**
  * Added comprehensive coverage for URL validation, security restrictions, fetching, parsing, limits, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->