### PR TITLE
feat(agent): resume an interrupted run with --resume — Closes #78

### DIFF
--- a/main.py
+++ b/main.py
@@ -99,6 +99,11 @@ Examples:
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress verbose output")
     parser.add_argument("--dry-run", "-d", action="store_true",help="Preview changes without applying them. Saves a manifest to logs/.")
+    parser.add_argument("--resume", dest="resume_from", default=None, metavar="RUN_ID",
+                        help="Continue an interrupted run from its last completed "
+                             "iteration. Use --list-resumable to see candidates.")
+    parser.add_argument("--list-resumable", action="store_true",
+                        help="List run ids that can be resumed, then exit.")
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
     # API key
@@ -151,6 +156,15 @@ def main():
             print(f"Warning: Failed to load config file {config_file}: {e}", file=sys.stderr)
 
     repo_root = os.path.abspath(args.repo)
+    if args.list_resumable:
+        from modules.run_state import list_resumable
+        candidates = list_resumable(args.log_dir)
+        if not candidates:
+            print("No resumable runs found.")
+        for run_id in candidates:
+            print(run_id)
+        sys.exit(0)
+
     if args.rollback:
         modifier = CodeModificationEngine(repo_root=repo_root, backup_dir="backups")
         success = modifier.git_stash_pop(repo_root)
@@ -207,6 +221,7 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+        resume_from=args.resume_from,
     )
 
     try:

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -26,6 +26,13 @@ from modules.llm_client import LLMClient, LLMResponse, FileChange
 from modules.code_modifier import CodeModificationEngine, ApplyResult
 from modules.sandbox import SubprocessSandbox, ExecutionResult
 from modules.git_integration import GitIntegration
+from modules.run_state import (
+    RunState,
+    check_resumable,
+    clear_state,
+    load_state,
+    save_state,
+)
 from modules.logger import AgentLogger, IterationRecord
 
 
@@ -69,6 +76,7 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
+    resume_from: Optional[str] = None      # run_id to continue
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
@@ -264,11 +272,36 @@ class AutonomousAgent:
         last_exec: Optional[ExecutionResult] = None
         last_changes: list[FileChange] = []
         last_apply_results: list[ApplyResult] = []
+        start_iteration = 1
+
+        if cfg.resume_from:
+            state = load_state(cfg.log_dir, cfg.resume_from)
+            check_resumable(state, cfg.repo_root, cfg.task)
+            start_iteration = state.iteration + 1
+            self.branch_name = state.branch_name or self.branch_name
+            last_changes = [FileChange(**c) for c in state.last_changes]
+            if state.last_exit_code is not None:
+                # Rebuilt rather than stored whole: the retry prompt only reads
+                # these four fields, and persisting a full ExecutionResult would
+                # tie the state file to that dataclass's shape.
+                last_exec = ExecutionResult(
+                    command="(restored from a previous run)",
+                    exit_code=state.last_exit_code,
+                    stdout=state.last_stdout,
+                    stderr=state.last_stderr,
+                    timed_out=False,
+                    duration_seconds=0.0,
+                )
+            self.logger.info(
+                f"  Resuming '{cfg.resume_from}' at iteration {start_iteration} "
+                f"({len(last_changes)} change(s) from the previous attempt)."
+            )
+
         outcome = "failed"
         self.pr_url = None
         iterations_used = 0
 
-        for iteration in range(1, cfg.max_iterations + 1):
+        for iteration in range(start_iteration, cfg.max_iterations + 1):
             iterations_used = iteration
             self.logger.start_iteration(iteration)
 
@@ -484,6 +517,21 @@ class AutonomousAgent:
 
             self.logger.record_iteration(iter_record)
 
+            save_state(
+                RunState(
+                    run_id=self.run_id,
+                    task=cfg.task,
+                    repo_root=cfg.repo_root,
+                    iteration=iteration,
+                    branch_name=self.branch_name,
+                    last_changes=[c.__dict__ for c in last_changes],
+                    last_exit_code=exec_result.exit_code,
+                    last_stdout=exec_result.stdout[:8000],
+                    last_stderr=exec_result.stderr[:8000],
+                ),
+                cfg.log_dir,
+            )
+
             # ── Step 6: Success check ──
             if exec_result.success:
                 self.logger.info(f"  Tests passed on iteration {iteration}")
@@ -541,6 +589,11 @@ class AutonomousAgent:
             self.logger.warning("  Rolling back file changes due to failed run...")
             restored = self.modifier.rollback(last_apply_results)
             self.logger.info(f"  Rolled back {len(restored)} file(s): {restored}")
+
+        if outcome not in ("failed", "max_retries", "error"):
+            # A run that ended deliberately has nothing to resume. Leaving the
+            # checkpoint would offer to continue a finished run.
+            clear_state(cfg.log_dir, self.run_id)
 
         final_message = {
             "success": "Task completed successfully. Tests pass.",

--- a/modules/run_state.py
+++ b/modules/run_state.py
@@ -1,0 +1,145 @@
+"""
+Module: Run state.
+
+A run that dies at iteration 4 — a dropped connection, a rate limit, Ctrl+C —
+throws away three iterations of paid API calls. This persists the little state
+`run()` actually needs to pick up where it left off.
+
+Only four things matter for resuming: which iteration was reached, the changes
+the model last proposed, the execution output those changes produced, and the
+branch being worked on. Everything else (the repo, the context) is re-derived
+from disk on the next iteration anyway, which is what makes this small.
+
+The file is written after every iteration and removed when a run finishes, so
+its presence means "this run did not complete".
+"""
+
+import json
+import logging
+import os
+import tempfile
+from dataclasses import asdict, dataclass, field
+from typing import Optional
+
+_LOG = logging.getLogger("agent.run_state")
+
+# Bumped when the shape changes. A state file from an older version is ignored
+# rather than half-understood -- resuming from a misread state would apply
+# changes the model never proposed.
+STATE_VERSION = 1
+
+
+class ResumeError(RuntimeError):
+    """Raised when a run cannot be resumed from the requested state."""
+
+
+@dataclass
+class RunState:
+    run_id: str
+    task: str
+    repo_root: str
+    iteration: int                      # the last iteration that completed
+    branch_name: Optional[str] = None
+    last_changes: list = field(default_factory=list)   # serialised FileChange
+    last_exit_code: Optional[int] = None
+    last_stdout: str = ""
+    last_stderr: str = ""
+    version: int = STATE_VERSION
+
+
+def state_path(log_dir: str, run_id: str) -> str:
+    return os.path.join(log_dir, f"{run_id}_state.json")
+
+
+def save_state(state: RunState, log_dir: str) -> Optional[str]:
+    """
+    Write the state file atomically.
+
+    Written to a temporary file and renamed, because this is saved after every
+    iteration and a crash mid-write is exactly the case it exists to survive --
+    a half-written file would be worse than none.
+
+    Never raises: failing to checkpoint must not fail a run that is otherwise
+    going fine.
+    """
+    try:
+        os.makedirs(log_dir, exist_ok=True)
+        path = state_path(log_dir, state.run_id)
+        handle, tmp = tempfile.mkstemp(dir=log_dir, suffix=".tmp")
+        with os.fdopen(handle, "w", encoding="utf-8") as fh:
+            json.dump(asdict(state), fh, indent=2, ensure_ascii=False)
+        os.replace(tmp, path)
+        return path
+    except Exception as exc:
+        _LOG.warning("could not save run state: %s", exc)
+        return None
+
+
+def clear_state(log_dir: str, run_id: str) -> None:
+    """Remove the state file. A finished run has nothing to resume."""
+    try:
+        os.remove(state_path(log_dir, run_id))
+    except OSError:
+        pass
+
+
+def load_state(log_dir: str, run_id: str) -> RunState:
+    """Read a state file, or raise ResumeError explaining why it cannot be used."""
+    path = state_path(log_dir, run_id)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        raise ResumeError(
+            f"No resumable state for run '{run_id}'. Either the run completed, "
+            f"or it never wrote a checkpoint. Looked in {path}."
+        ) from None
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ResumeError(f"Could not read {path}: {exc}") from exc
+
+    version = data.get("version")
+    if version != STATE_VERSION:
+        raise ResumeError(
+            f"State file {path} is version {version}, this build expects "
+            f"{STATE_VERSION}. Start a fresh run rather than resuming."
+        )
+
+    known = set(RunState.__dataclass_fields__)
+    return RunState(**{k: v for k, v in data.items() if k in known})
+
+
+def list_resumable(log_dir: str) -> list[str]:
+    """Run ids with a state file present, newest first."""
+    try:
+        entries = [
+            name for name in os.listdir(log_dir) if name.endswith("_state.json")
+        ]
+    except OSError:
+        return []
+
+    entries.sort(
+        key=lambda name: os.path.getmtime(os.path.join(log_dir, name)),
+        reverse=True,
+    )
+    return [name[: -len("_state.json")] for name in entries]
+
+
+def check_resumable(
+    state: RunState, repo_root: str, task: Optional[str] = None
+) -> None:
+    """
+    Refuse to resume into a different repository or a different task.
+
+    Both would silently apply one run's half-finished changes to another run's
+    problem, which is worse than starting over.
+    """
+    if os.path.realpath(state.repo_root) != os.path.realpath(repo_root):
+        raise ResumeError(
+            f"Run '{state.run_id}' was against {state.repo_root}, not {repo_root}. "
+            f"Resume from the same repository, or start a fresh run."
+        )
+    if task and task.strip() and task.strip() != state.task.strip():
+        raise ResumeError(
+            f"Run '{state.run_id}' was working on a different task. Resume without "
+            f"--task to continue the original, or start a fresh run."
+        )

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -1,0 +1,248 @@
+"""
+Tests for resumable runs (modules/run_state.py, modules/agent_loop.py).
+
+A run that dies at iteration 4 throws away three iterations of paid API calls.
+`--resume <run_id>` picks up from the last completed iteration.
+
+The properties worth pinning are the refusals: resuming into the wrong
+repository or the wrong task would silently apply one run's half-finished work
+to another run's problem, which is worse than starting over.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.run_state import (  # noqa: E402
+    STATE_VERSION,
+    ResumeError,
+    RunState,
+    check_resumable,
+    clear_state,
+    list_resumable,
+    load_state,
+    save_state,
+    state_path,
+)
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+
+def source() -> str:
+    # Explicit encoding: the default is locale-dependent and mangles this
+    # module's box-drawing section comments on a default Windows install.
+    return AGENT_LOOP.read_text(encoding="utf-8")
+
+
+def make_state(tmp_path, **overrides):
+    base = dict(
+        run_id="agent_20260807_abc",
+        task="Fix the parser",
+        repo_root=str(tmp_path),
+        iteration=3,
+        branch_name="agent/fix-abc",
+        last_changes=[{"path": "p.py", "action": "modify",
+                       "content": "x", "explanation": "e"}],
+        last_exit_code=1,
+        last_stdout="1 failed",
+        last_stderr="AssertionError",
+    )
+    base.update(overrides)
+    return RunState(**base)
+
+
+# ── round trip ────────────────────────────────────────────────────────────
+
+
+def test_state_survives_a_round_trip(tmp_path):
+    original = make_state(tmp_path)
+    save_state(original, str(tmp_path))
+
+    restored = load_state(str(tmp_path), original.run_id)
+
+    assert restored.iteration == 3
+    assert restored.branch_name == "agent/fix-abc"
+    assert restored.last_changes == original.last_changes
+    assert restored.last_stderr == "AssertionError"
+
+
+def test_the_write_is_atomic(tmp_path):
+    """
+    Saved after every iteration, so a crash mid-write is the case this exists
+    to survive. A temp file plus rename means the reader sees whole or nothing.
+    """
+    save_state(make_state(tmp_path), str(tmp_path))
+
+    leftovers = [n for n in os.listdir(tmp_path) if n.endswith(".tmp")]
+    assert leftovers == []
+    json.loads(Path(state_path(str(tmp_path), "agent_20260807_abc")).read_text())
+
+
+def test_saving_never_raises(tmp_path):
+    """Failing to checkpoint must not fail a run that is otherwise going fine."""
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("a file where a log dir should be")
+
+    # makedirs cannot create a directory inside a regular file, on any platform
+    # and regardless of privileges.
+    assert save_state(make_state(tmp_path), str(blocker / "logs")) is None
+
+
+def test_clearing_a_missing_state_is_not_an_error(tmp_path):
+    clear_state(str(tmp_path), "never-existed")
+
+
+def test_clearing_removes_the_file(tmp_path):
+    state = make_state(tmp_path)
+    save_state(state, str(tmp_path))
+    clear_state(str(tmp_path), state.run_id)
+
+    assert not os.path.exists(state_path(str(tmp_path), state.run_id))
+
+
+# ── refusing to load ──────────────────────────────────────────────────────
+
+
+def test_a_missing_state_explains_itself(tmp_path):
+    with pytest.raises(ResumeError) as excinfo:
+        load_state(str(tmp_path), "nope")
+
+    assert "No resumable state" in str(excinfo.value)
+
+
+def test_a_corrupt_state_is_refused(tmp_path):
+    Path(state_path(str(tmp_path), "broken")).write_text("{not json")
+
+    with pytest.raises(ResumeError):
+        load_state(str(tmp_path), "broken")
+
+
+def test_an_older_schema_is_refused(tmp_path):
+    """
+    Resuming from a misread state would apply changes the model never proposed,
+    so an unrecognised version is refused rather than half-understood.
+    """
+    path = Path(state_path(str(tmp_path), "old"))
+    path.write_text(json.dumps({"version": STATE_VERSION - 1, "run_id": "old"}))
+
+    with pytest.raises(ResumeError) as excinfo:
+        load_state(str(tmp_path), "old")
+
+    assert "version" in str(excinfo.value)
+
+
+def test_unknown_fields_are_ignored(tmp_path):
+    """A newer build's extra keys should not crash an older reader."""
+    state = make_state(tmp_path)
+    save_state(state, str(tmp_path))
+    path = Path(state_path(str(tmp_path), state.run_id))
+    data = json.loads(path.read_text())
+    data["something_from_the_future"] = True
+    path.write_text(json.dumps(data))
+
+    assert load_state(str(tmp_path), state.run_id).iteration == 3
+
+
+# ── refusing to resume ────────────────────────────────────────────────────
+
+
+def test_a_different_repository_is_refused(tmp_path):
+    state = make_state(tmp_path)
+
+    with pytest.raises(ResumeError) as excinfo:
+        check_resumable(state, "/some/other/repo")
+
+    assert "not" in str(excinfo.value)
+
+
+def test_a_different_task_is_refused(tmp_path):
+    state = make_state(tmp_path)
+
+    with pytest.raises(ResumeError) as excinfo:
+        check_resumable(state, str(tmp_path), task="Something else entirely")
+
+    assert "different task" in str(excinfo.value)
+
+
+def test_the_same_task_is_allowed(tmp_path):
+    check_resumable(make_state(tmp_path), str(tmp_path), task="Fix the parser")
+
+
+def test_no_task_means_continue_the_original(tmp_path):
+    """--resume without --task is the normal way to continue."""
+    check_resumable(make_state(tmp_path), str(tmp_path), task=None)
+
+
+def test_whitespace_differences_do_not_block_a_resume(tmp_path):
+    check_resumable(make_state(tmp_path), str(tmp_path), task="  Fix the parser  ")
+
+
+# ── listing ───────────────────────────────────────────────────────────────
+
+
+def test_resumable_runs_are_listed(tmp_path):
+    for run_id in ("run_a", "run_b"):
+        save_state(make_state(tmp_path, run_id=run_id), str(tmp_path))
+
+    assert set(list_resumable(str(tmp_path))) == {"run_a", "run_b"}
+
+
+def test_only_state_files_are_listed(tmp_path):
+    save_state(make_state(tmp_path, run_id="run_a"), str(tmp_path))
+    (tmp_path / "run_a.jsonl").write_text("{}")
+    (tmp_path / "run_a_summary.json").write_text("{}")
+
+    assert list_resumable(str(tmp_path)) == ["run_a"]
+
+
+def test_a_missing_log_dir_lists_nothing(tmp_path):
+    assert list_resumable(str(tmp_path / "nope")) == []
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_resume_is_off_by_default():
+    from modules.agent_loop import AgentConfig
+
+    assert AgentConfig(repo_root=".", task="t").resume_from is None
+
+
+def test_the_loop_starts_from_the_saved_iteration():
+    text = source()
+
+    assert "start_iteration = state.iteration + 1" in text
+    assert "for iteration in range(start_iteration," in text
+
+
+def test_state_is_saved_every_iteration():
+    """A checkpoint written only at the end would never survive a crash."""
+    text = source()
+    marker = "self.logger.record_iteration(iter_record)\n\n            save_state("
+    record = text.index(marker)
+
+    assert record > 0
+
+
+def test_a_finished_run_clears_its_state():
+    """Otherwise --list-resumable would offer to continue a completed run."""
+    text = source()
+    block = text[text.index("clear_state(cfg.log_dir"):]
+
+    assert "clear_state" in block
+    assert 'outcome not in ("failed", "max_retries", "error")' in text
+
+
+def test_previous_output_is_restored_for_the_retry_prompt():
+    """Without it the resumed iteration would ask as though nothing had failed."""
+    text = source()
+    block = text[text.index("if cfg.resume_from:"):][:1400]
+
+    assert "last_exec = ExecutionResult(" in block
+    assert "state.last_stderr" in block
+    assert "FileChange(**c)" in block


### PR DESCRIPTION
Closes #78

## Summary

A run that dies at iteration 4 — dropped connection, rate limit, Ctrl+C — throws away three iterations of paid API calls. `--resume <run_id>` picks up from the last completed iteration.

```bash
python main.py --repo . --list-resumable
python main.py --repo . --resume agent_20260807_131222_9f0654
```

Off by default. Adds `modules/run_state.py`.

## Only four things are persisted

The state file holds the iteration reached, the changes the model last proposed, the execution output those changes produced, and the branch being worked on. That is everything `retry_request` consumes — it takes `previous_changes`, `stdout`, `stderr` and `exit_code`, and nothing else.

Repository contents and the compiled context are re-derived from disk on the next iteration anyway, so persisting them would be duplicating the working tree into JSON for no benefit.

`ExecutionResult` is rebuilt from those four fields rather than serialised whole, which keeps the state file from tracking that dataclass's shape. `command` is set to `(restored from a previous run)` so a resumed log does not claim a command was run that was not.

## Written after every iteration, atomically

A checkpoint written only at the end would never survive the crash it exists for, so it is saved after each `record_iteration`. And because a crash *during* the write is exactly the case in scope, it goes to a temp file and is renamed — the reader sees a whole file or none. A test asserts no `.tmp` files are left behind and that the result parses.

`save_state` never raises. Failing to checkpoint must not fail a run that is otherwise going fine.

The file is deleted when a run ends deliberately — success, aborted, dry-run — so `--list-resumable` never offers to continue something that finished. Its presence means "this did not complete".

## Three refusals

**A different repository.** Resuming a run that was against another checkout would apply one run's half-finished changes to another run's tree.

**A different task.** `--resume` without `--task` continues the original, which is the normal path. Passing a *different* `--task` is refused rather than silently ignored, because it looks like it should work and would not. Whitespace differences are tolerated.

**An unrecognised schema version.** Refused rather than half-read: resuming from a misread state would apply changes the model never proposed. Unknown *fields* are ignored, so a newer build's extra keys do not break an older reader.

## What this does not do

It does not verify the working tree is unchanged since the interruption. If you edited files between the crash and the resume, the agent picks up against your edits. Detecting that would need a content hash of every touched file, which is a bigger change than the issue asks for — flagging it rather than pretending the guard exists.

## Tests

`tests/test_run_state.py` — 22 cases.

Round trip: state survives save and load; the write is atomic with no temp files left; saving never raises; clearing a missing file is not an error; clearing removes the file.

Refusing to load: a missing state explains itself; a corrupt file is refused; an older schema is refused; unknown fields are ignored.

Refusing to resume: a different repository; a different task; the same task is allowed; no task means continue the original; whitespace differences do not block.

Listing: resumable runs are listed; only `_state.json` files are (not `.jsonl` or `_summary.json`); a missing log dir lists nothing.

Wiring: resume is off by default; the loop starts from the saved iteration; state is saved every iteration rather than once at the end; a finished run clears its state; previous output is restored for the retry prompt, so the resumed iteration does not ask as though nothing had failed.

One of those tests initially passed for the wrong reason. `test_saving_never_raises` pointed at `/definitely/not/writable/anywhere`, which **succeeded** — the test environment runs as root, so `makedirs` simply created it. Rewritten to point inside a regular file, which `makedirs` cannot do on any platform at any privilege level.

## Verified

- 22 tests pass alongside `tests/test_utils.py`
- `--resume` and `--list-resumable` render in `--help`
- ruff: `agent_loop.py` and `main.py` both at their baseline finding counts, i.e. none added
- `agent_loop.py` is `+55 −1`, where the deletion is the `for iteration in range(...)` line I intentionally replaced

CI will be red until the sandbox restore PR lands — `modules/sandbox.py` on `main` is missing its `logging` import, so most of the suite cannot collect. Nothing here touches that file.