### PR TITLE
feat: add streaming LLM output for real-time progress

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,10 @@ Examples:
     parser.add_argument("--api-key", default=None,
                         help="Anthropic API key (default: ANTHROPIC_API_KEY env var)")
 
+    # Streaming
+    parser.add_argument("--stream", action="store_true",
+                        help="Enable streaming LLM output for real-time progress")
+
     return parser.parse_args()
 
 
@@ -139,6 +143,7 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+        stream=args.stream,
     )
 
     try:

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -65,6 +65,7 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
+    stream: bool = False
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
@@ -97,7 +98,7 @@ class AutonomousAgent:
 
         # Instantiate modules
         self.logger = AgentLogger(self.log_dir, self.run_id, verbose=True)
-        self.llm = LLMClient(api_key=cfg.anthropic_api_key)
+        self.llm = LLMClient(api_key=cfg.anthropic_api_key, stream=cfg.stream)
         self.modifier = CodeModificationEngine(cfg.repo_root, self.backup_dir)
         self.sandbox = SubprocessSandbox(cfg.repo_root, timeout_seconds=cfg.timeout_seconds)
 

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -17,7 +17,7 @@ try:
 except ImportError:
     _ANTHROPIC_AVAILABLE = False
 
-MODEL = "claude-sonnet-4-20250514"
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
 MAX_TOKENS = 8192
 
 # ─────────────────────────────────────────────
@@ -123,7 +123,7 @@ class LLMResponse:
 # ─────────────────────────────────────────────
 
 class LLMClient:
-    def __init__(self, api_key: Optional[str] = None):
+    def __init__(self, api_key: Optional[str] = None, model: Optional[str] = None, stream: bool = False):
         if not _ANTHROPIC_AVAILABLE:
             raise RuntimeError(
                 "anthropic package not installed. Run: pip install anthropic"
@@ -132,13 +132,17 @@ class LLMClient:
         if not key:
             raise ValueError("ANTHROPIC_API_KEY not set")
         self.client = anthropic.Anthropic(api_key=key)
+        self.model = model or os.environ.get("AGENT_MODEL") or DEFAULT_MODEL
+        self.stream = stream
 
     def _call(self, prompt: str, retries: int = 3) -> str:
         """Raw API call with retry on transient errors."""
+        if self.stream:
+            return self._call_streaming(prompt, retries)
         for attempt in range(retries):
             try:
                 response = self.client.messages.create(
-                    model=MODEL,
+                    model=self.model,
                     max_tokens=MAX_TOKENS,
                     system=SYSTEM_PROMPT,
                     messages=[{"role": "user", "content": prompt}],
@@ -150,6 +154,34 @@ class LLMClient:
                 wait = 2 ** attempt
                 time.sleep(wait)
         raise RuntimeError("LLM call failed after retries")
+
+    def _call_streaming(self, prompt: str, retries: int = 3) -> str:
+        """Streaming API call — prints tokens as they arrive."""
+        import sys
+        for attempt in range(retries):
+            try:
+                collected = []
+                print("\n  [LLM Streaming] ", end="", flush=True)
+                with self.client.messages.stream(
+                    model=self.model,
+                    max_tokens=MAX_TOKENS,
+                    system=SYSTEM_PROMPT,
+                    messages=[{"role": "user", "content": prompt}],
+                ) as stream:
+                    for text in stream.text_stream:
+                        collected.append(text)
+                        # Print a dot every 50 chars for progress
+                        if sum(len(t) for t in collected) % 200 < len(text):
+                            sys.stdout.write(".")
+                            sys.stdout.flush()
+                print(" done", flush=True)
+                return "".join(collected)
+            except Exception as e:
+                if attempt == retries - 1:
+                    raise
+                wait = 2 ** attempt
+                time.sleep(wait)
+        raise RuntimeError("LLM streaming call failed after retries")
 
     def _parse_response(self, raw: str) -> LLMResponse:
         """Extract and parse JSON from LLM output."""


### PR DESCRIPTION
Fixes #23

- Add _call_streaming to AnthropicLLMClient to print tokens as they arrive
- Add --stream CLI flag in main.py to enable streaming output
- Thread stream config through AgentConfig to LLMClient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional streaming mode for LLM responses through the command-line interface.
  - Responses can now appear progressively with visible progress updates.
  - Added configurable model selection, including support for an environment-based model setting.
  - Added retry handling while streaming and improved collection of completed response text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->