### PR TITLE
feat: add parallel file processing for large refactoring tasks

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,12 @@ Examples:
     parser.add_argument("--max-iter", type=int, default=5,
                         help="Maximum number of agent iterations (default: 5)")
 
+    # Parallel Processing
+    parser.add_argument("--parallel", action="store_true",
+                        help="Enable parallel file processing (ingestion and modification)")
+    parser.add_argument("--workers", type=int, default=10,
+                        help="Number of worker threads for parallel processing (default: 10)")
+
     # Git
     parser.add_argument("--no-git", action="store_true",
                         help="Disable git operations entirely")
@@ -98,12 +104,12 @@ def main():
 
     repo_root = os.path.abspath(args.repo)
     if args.rollback:
-    modifier = CodeModificationEngine(
-        repo_root=repo_root,
-        backup_dir="backups"
-    )
-    success = modifier.git_stash_pop(repo_root)
-    sys.exit(0 if success else 1)
+        modifier = CodeModificationEngine(
+            repo_root=repo_root,
+            backup_dir="backups"
+        )
+        success = modifier.git_stash_pop(repo_root)
+        sys.exit(0 if success else 1)
     if not os.path.isdir(repo_root):
         print(f"ERROR: Repository path does not exist: {repo_root}", file=sys.stderr)
         sys.exit(1)
@@ -139,6 +145,10 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+
+        # Parallel
+        parallel=args.parallel,
+        workers=args.workers,
     )
 
     try:

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
-from modules.repo_ingestion import ingest_repository, Repository
+from modules.repo_ingestion import ingest_repository, ingest_repository_parallel, Repository
 from modules.context_builder import build_context
 from modules.llm_client import LLMClient, LLMResponse, FileChange
 from modules.code_modifier import CodeModificationEngine, ApplyResult
@@ -69,6 +69,9 @@ class AgentConfig:
     # Context
     force_include_paths: Optional[list] = None  # always include these files
 
+    # Parallel Processing
+    parallel: bool = False
+    workers: int = 10
 
 @dataclass
 class AgentRunResult:
@@ -172,7 +175,10 @@ class AutonomousAgent:
 
             # ── Step 1: Ingest repo (re-read to pick up changes from previous iter) ──
             try:
-                repo: Repository = ingest_repository(cfg.repo_root)
+                if cfg.parallel:
+                    repo: Repository = ingest_repository_parallel(cfg.repo_root, max_workers=cfg.workers)
+                else:
+                    repo: Repository = ingest_repository(cfg.repo_root)
             except Exception as e:
                 self.logger.error(f"Repo ingestion failed: {e}")
                 outcome = "error"
@@ -307,7 +313,10 @@ class AutonomousAgent:
                     )
 
                 self.modifier.git_stash_before_apply(self.config.repo_root)
-                apply_results = self.modifier.apply_changes(valid_changes)
+                if cfg.parallel and len(valid_changes) > 1:
+                    apply_results = self.modifier.apply_changes_parallel(valid_changes, max_workers=cfg.workers)
+                else:
+                    apply_results = self.modifier.apply_changes(valid_changes)
                 self.logger.log_apply_results(apply_results)
                 last_changes = valid_changes
                 last_apply_results = apply_results

--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from modules.llm_client import FileChange
 
@@ -125,11 +126,23 @@ class CodeModificationEngine:
             )
 
     def apply_changes(self, changes: list[FileChange]) -> list[ApplyResult]:
-        """Apply a list of file changes. Returns per-file results."""
+        """Apply a list of file changes sequentially. Returns per-file results."""
         results = []
         for change in changes:
             result = self._apply_single(change)
             results.append(result)
+        return results
+
+    def apply_changes_parallel(self, changes: list[FileChange], max_workers: int = 10) -> list[ApplyResult]:
+        """Apply a list of file changes in parallel using ThreadPoolExecutor."""
+        results = []
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            # We must map futures to changes to preserve order if needed, 
+            # though as_completed returns them out of order.
+            # We'll just collect them and return.
+            futures = [executor.submit(self._apply_single, change) for change in changes]
+            for future in as_completed(futures):
+                results.append(future.result())
         return results
 
     def rollback(self, results: list[ApplyResult]) -> list[str]:

--- a/modules/repo_ingestion.py
+++ b/modules/repo_ingestion.py
@@ -7,6 +7,7 @@ import os
 import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 
 IGNORE_DIRS = {
@@ -170,4 +171,78 @@ def ingest_repository(repo_root: str) -> Repository:
             repo.files.append(record)
             repo.total_bytes += size
 
+    return repo
+
+
+def ingest_repository_parallel(repo_root: str, max_workers: int = 10) -> Repository:
+    """
+    Parallel version of ingest_repository using ThreadPoolExecutor.
+    """
+    root = os.path.abspath(repo_root)
+    if not os.path.isdir(root):
+        raise ValueError(f"Not a directory: {root}")
+
+    repo = Repository(root=root)
+    
+    # First pass: collect all files to process
+    paths_to_process = []
+    
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if not _should_ignore_dir(d)]
+        for filename in filenames:
+            abs_path = os.path.join(dirpath, filename)
+            rel_path = os.path.relpath(abs_path, root).replace(os.sep, "/")
+            
+            if _should_ignore_file(abs_path):
+                repo.skipped.append(rel_path)
+                continue
+                
+            try:
+                size = os.path.getsize(abs_path)
+            except OSError:
+                repo.skipped.append(rel_path)
+                continue
+                
+            if size > MAX_FILE_SIZE_BYTES:
+                repo.skipped.append(f"{rel_path} (too large: {size} bytes)")
+                continue
+                
+            paths_to_process.append((abs_path, rel_path, size))
+
+    # Process files in parallel
+    def process_file(file_info):
+        abs_path, rel_path, size = file_info
+        try:
+            with open(abs_path, "r", encoding="utf-8", errors="strict") as fh:
+                content = fh.read()
+            ext = Path(abs_path).suffix.lower()
+            checksum = hashlib.sha256(content.encode()).hexdigest()[:16]
+            return FileRecord(
+                path=rel_path,
+                abs_path=abs_path,
+                content=content,
+                size=size,
+                extension=ext,
+                language=infer_language(abs_path),
+                checksum=checksum,
+            )
+        except (UnicodeDecodeError, PermissionError):
+            return rel_path # return string to indicate failure
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(process_file, info): info for info in paths_to_process}
+        for future in as_completed(futures):
+            result = future.result()
+            if isinstance(result, str):
+                repo.skipped.append(f"{result} (binary or unreadable)")
+            else:
+                if repo.total_bytes + result.size > MAX_TOTAL_BYTES:
+                    repo.skipped.append(f"{result.path} (repo budget exhausted)")
+                else:
+                    repo.files.append(result)
+                    repo.total_bytes += result.size
+
+    # Sort files to ensure deterministic order (important for LLM context consistency)
+    repo.files.sort(key=lambda x: x.path)
+    
     return repo


### PR DESCRIPTION
Fixes #25

- Add ingest_repository_parallel to repo_ingestion.py using ThreadPoolExecutor
- Add apply_changes_parallel to code_modifier.py
- Add --parallel and --workers CLI flags in main.py
- Update agent_loop.py to use parallel methods when configured