### PR TITLE
ci: fail the build when a module cannot be imported

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -1,0 +1,86 @@
+name: Import Guard
+
+# Catches the failure mode that has broken `main` twice: a merge drops a
+# definition (an import, a base class, a constant) while keeping every
+# reference to it. Nothing in the existing checks fails on that, because the
+# test suite cannot even be collected once a module stops importing.
+#
+# Deliberately does not run the test suite. This is the check that must stay
+# green when everything else is red, so it has no dependency on test state.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  imports:
+    name: Package imports and CLI starts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Every module imports
+        # Walks modules/ rather than naming them, so a new module is covered
+        # the day it lands instead of whenever someone remembers to add it.
+        run: |
+          python - <<'PY'
+          import importlib, pathlib, sys
+
+          failures = []
+          for path in sorted(pathlib.Path("modules").glob("*.py")):
+              if path.stem == "__init__":
+                  continue
+              name = f"modules.{path.stem}"
+              try:
+                  importlib.import_module(name)
+              except Exception as exc:
+                  failures.append((name, f"{type(exc).__name__}: {exc}"))
+
+          for name, err in failures:
+              print(f"FAIL {name}: {err}")
+
+          if failures:
+              print(f"\n{len(failures)} module(s) could not be imported.")
+              print("This usually means a merge dropped a definition while")
+              print("keeping the references to it.")
+              sys.exit(1)
+
+          print("all modules import")
+          PY
+
+      - name: CLI starts
+        # --help exercises argparse, which catches duplicate flags and repeated
+        # keyword arguments that a plain import does not reach.
+        run: python main.py --help > /dev/null
+
+      - name: No duplicate CLI flags
+        run: |
+          python - <<'PY'
+          import collections, re, sys
+
+          flags = re.findall(r'add_argument\(\s*"(--[a-z0-9-]+)"', open("main.py").read())
+          dupes = {f: c for f, c in collections.Counter(flags).items() if c > 1}
+
+          if dupes:
+              for flag, count in sorted(dupes.items()):
+                  print(f"FAIL {flag} registered {count} times")
+              sys.exit(1)
+
+          print(f"{len(flags)} CLI flags, no duplicates")
+          PY


### PR DESCRIPTION
Adds a workflow that fails when the package does not import or the CLI cannot start.

## Why

`main` has been left unimportable twice in two days, and I was responsible for one of those. The failure mode is always the same: a merge drops a definition — an import, a base class, a constant — while keeping every reference to it. The merge itself looks clean.

Nothing in the existing checks fails on that. The test suite cannot even be *collected* once a module stops importing, so a broken `main` and a red test run look identical.

## What it does

Three steps, no test dependency:

1. **Every module imports.** Walks `modules/*.py` and imports each, reporting all failures rather than stopping at the first.
2. **The CLI starts.** `python main.py --help` — this exercises argparse, which catches duplicate flags and repeated keyword arguments that a plain import never reaches.
3. **No duplicate CLI flags.** Counts `add_argument("--flag")` occurrences in `main.py`.

It walks the directory rather than naming modules, so a new module is covered the day it lands instead of whenever someone remembers to add it.

## Verified against the actual breakage

Run against `main` as it stands, every step fails and names the problem:

```
FAIL modules.agent_loop: NameError: name 're' is not defined
FAIL modules.code_modifier: NameError: name 'BaseLLMClient' is not defined
FAIL modules.context_builder: NameError: name 're' is not defined
FAIL modules.llm_client: NameError: name 'BaseLLMClient' is not defined
FAIL modules.repo_ingestion: NameError: name 're' is not defined
  imports step exit: 1
  --help step exit:  1
FAIL --config registered 2 times
FAIL --model registered 3 times
FAIL --provider registered 2 times
  dup-flag step exit: 1
```

Against the repaired tree, all three pass.

## Deliberately does not run the tests

This is the check that must stay green when everything else is red, so it has no dependency on test state. A module that imports is a lower bar than a passing suite, and that is the point — it is the bar that has actually been failing.

## Honest limits

It catches import-time damage, which is most of what has gone wrong, but not all. Two of the bugs in the companion restore PR — a missing `_process_file` inside a function, and a dataclass field removed while its caller still passed it — only surface at runtime and would pass this guard. A smoke test that ingests a temp repo and runs one iteration against a stub client would catch those; happy to add it if wanted, though it is a larger change than this.

Follows the Python setup and action versions already used in `agent-fix.yml`.