### PR TITLE
feat(llm): add --verbose to dump raw LLM payloads (Closes #141)

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,6 +116,9 @@ Examples:
                         help="Directory for log files (default: logs/ inside repo)")
     parser.add_argument("--backup-dir", default="backups",
                         help="Directory for file backups (default: backups/ inside repo)")
+    parser.add_argument("--verbose", dest="verbose_payloads", action="store_true",
+                        help="Print the exact prompt sent to the LLM and the raw "
+                             "response, to stderr. Known secret patterns are masked.")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress verbose output")
     parser.add_argument("--context-only", action="store_true",
@@ -273,6 +276,7 @@ def main():
 
         # LLM
         anthropic_api_key=args.api_key,
+        verbose_payloads=args.verbose_payloads,
         model=args.model,
         provider=args.provider,
     )

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -91,6 +91,7 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
+    verbose_payloads: bool = False         # dump raw LLM request/response
     model: Optional[str] = None
     provider: str = "anthropic"
 
@@ -134,7 +135,12 @@ class AutonomousAgent:
 
         # Instantiate modules
         self.logger = AgentLogger(self.log_dir, self.run_id, verbose=True)
-        self.llm = LLMClient(api_key=cfg.anthropic_api_key, model=cfg.model, provider=cfg.provider)
+        self.llm = LLMClient(
+            api_key=cfg.anthropic_api_key,
+            model=cfg.model,
+            provider=cfg.provider,
+            verbose=cfg.verbose_payloads,
+        )
         self.modifier = CodeModificationEngine(cfg.repo_root, self.backup_dir)
         self.sandbox = SubprocessSandbox(cfg.repo_root, timeout_seconds=cfg.timeout_seconds)
         self.token_tracker = TokenTracker()

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -277,6 +277,38 @@ def _end_progress(chars: int) -> None:
     sys.stderr.flush()
 
 
+def _redact_secrets(text: str) -> str:
+    """
+    Mask anything matching a known secret pattern before it is printed.
+
+    --verbose dumps the full prompt, which is repository file contents. If a
+    key is committed somewhere in the repo it would otherwise be echoed to the
+    terminal and into whatever captures that output. Reuses the patterns from
+    secret_scanner so the two cannot drift apart.
+    """
+    from modules.secret_scanner import SECRET_PATTERNS
+
+    for pattern in SECRET_PATTERNS:
+        text = re.sub(
+            pattern["regex"],
+            lambda m: m.group(0)[:4] + "[REDACTED]",
+            text,
+            flags=re.IGNORECASE,
+        )
+    return text
+
+
+def _dump_payload(label: str, body: str, redact: bool = True) -> None:
+    """Print one labelled payload to stderr, so stdout stays parseable."""
+    if redact:
+        body = _redact_secrets(body)
+    rule = "=" * 72
+    print(f"\n{rule}\n[verbose] {label} ({len(body):,} chars)\n{rule}",
+          file=sys.stderr)
+    print(body, file=sys.stderr)
+    print(rule, file=sys.stderr, flush=True)
+
+
 class BudgetExceededError(RuntimeError):
     """
     Raised when accumulated spend reaches the configured --max-cost.
@@ -297,8 +329,9 @@ class BaseLLMClient:
     methods that went with it.
     """
 
-    def __init__(self, model: str = MODEL):
+    def __init__(self, model: str = MODEL, verbose: bool = False):
         self.model = model
+        self.verbose = verbose
         self.input_tokens_used = 0
         self.output_tokens_used = 0
         self.total_cost = 0.0
@@ -380,7 +413,12 @@ class BaseLLMClient:
     def initial_request(self, task: str, context_str: str) -> LLMResponse:
         prompt = TASK_PROMPT_TEMPLATE.format(task=task, context=context_str)
         input_tok = self._estimate_tokens(prompt + SYSTEM_PROMPT)
+        if self.verbose:
+            _dump_payload("system prompt", SYSTEM_PROMPT)
+            _dump_payload("request", prompt)
         raw = self._call(prompt)
+        if self.verbose:
+            _dump_payload("response", raw)
         return self._parse_response(raw, input_tok)
 
     def retry_request(
@@ -406,7 +444,12 @@ class BaseLLMClient:
             context=context_str,
         )
         input_tok = self._estimate_tokens(prompt + SYSTEM_PROMPT)
+        if self.verbose:
+            _dump_payload("system prompt", SYSTEM_PROMPT)
+            _dump_payload("request", prompt)
         raw = self._call(prompt)
+        if self.verbose:
+            _dump_payload("response", raw)
         return self._parse_response(raw, input_tok)
 
 
@@ -577,8 +620,9 @@ class OllamaClient(BaseLLMClient):
 class LLMClient(BaseLLMClient):
     """Facade class maintaining backward compatibility while wrapping dynamic clients."""
     
-    def __init__(self, api_key: Optional[str] = None, model: str = MODEL, provider: str = "anthropic"):
-        super().__init__(model)
+    def __init__(self, api_key: Optional[str] = None, model: str = MODEL,
+                 provider: str = "anthropic", verbose: bool = False):
+        super().__init__(model, verbose)
         self.provider = provider.lower()
         if self.provider == "openai":
             self.underlying_client = OpenAIClient(api_key, model)
@@ -588,6 +632,10 @@ class LLMClient(BaseLLMClient):
             self.underlying_client = OllamaClient(model)
         else:
             self.underlying_client = AnthropicClient(api_key, model)
+
+        # Set once after the chain rather than in each branch: the flag applies
+        # to whichever provider was chosen, and one line cannot drift.
+        self.underlying_client.verbose = verbose
 
     def _call(self, prompt: str) -> str:
         return self.underlying_client._call(prompt)

--- a/tests/test_verbose_payloads.py
+++ b/tests/test_verbose_payloads.py
@@ -1,0 +1,189 @@
+"""
+Tests for --verbose (modules/llm_client.py).
+
+Prints the exact prompt sent to the model and the raw text returned, for
+debugging a response that parsed wrongly or a context that selected the wrong
+files.
+
+The prompt is repository file contents, so the property that matters most is
+that a key committed somewhere in the repo is not echoed to the terminal.
+"""
+
+import io
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.llm_client import (  # noqa: E402
+    BaseLLMClient,
+    _dump_payload,
+    _redact_secrets,
+)
+
+OK = '{"analysis":"ok","changes":[],"confidence":0.9,"done":true}'
+
+
+class Stub(BaseLLMClient):
+    def __init__(self, verbose=False, raw=OK):
+        super().__init__(verbose=verbose)
+        self.raw = raw
+        self.prompts = []
+
+    def _call(self, prompt):
+        self.prompts.append(prompt)
+        return self.raw
+
+
+def capture(client, method="initial", **kwargs):
+    err = io.StringIO()
+    with redirect_stderr(err):
+        if method == "initial":
+            client.initial_request(kwargs.get("task", "t"), kwargs.get("context", "c"))
+        else:
+            client.retry_request(
+                kwargs.get("task", "t"), kwargs.get("context", "c"),
+                [], "out", "err", 1,
+            )
+    return err.getvalue()
+
+
+# ── off by default ────────────────────────────────────────────────────────
+
+
+def test_verbose_is_off_by_default():
+    assert Stub().verbose is False
+    assert AgentConfig(repo_root=".", task="t").verbose_payloads is False
+
+
+def test_nothing_is_printed_when_off():
+    assert capture(Stub(verbose=False)) == ""
+
+
+def test_the_response_still_parses_when_off():
+    assert Stub(verbose=False).initial_request("t", "c").confidence == 0.9
+
+
+# ── what gets dumped ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def dumped():
+    return capture(Stub(verbose=True))
+
+
+def test_the_system_prompt_is_dumped(dumped):
+    assert "system prompt" in dumped
+
+
+def test_the_request_is_dumped(dumped):
+    assert "request" in dumped
+
+
+def test_the_response_is_dumped(dumped):
+    assert "response" in dumped
+    assert '"confidence":0.9' in dumped
+
+
+def test_the_context_appears_in_the_request():
+    """The point of the flag: seeing which files were actually sent."""
+    assert "utils.py contents here" in capture(
+        Stub(verbose=True), context="utils.py contents here"
+    )
+
+
+def test_retries_are_dumped_too():
+    """A retry prompt carries the failure output and is worth seeing."""
+    assert "[verbose]" in capture(Stub(verbose=True), method="retry")
+
+
+def test_character_counts_are_reported(dumped):
+    assert "chars" in dumped
+
+
+# ── it goes to stderr ─────────────────────────────────────────────────────
+
+
+def test_output_goes_to_stderr_not_stdout():
+    """
+    stdout carries --context-only and the dry-run manifest, which are meant to
+    be piped. Debug output on stdout would corrupt them.
+    """
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        Stub(verbose=True).initial_request("t", "c")
+
+    assert out.getvalue() == ""
+    assert err.getvalue() != ""
+
+
+# ── secrets are masked ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "AKIAIOSFODNN7EXAMPLE",
+        "ghp_1234567890123456789012345678901234ab",
+        "sk-ant-api03-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    ],
+)
+def test_known_secrets_are_masked_in_the_dump(secret):
+    """
+    The prompt is repository content. A key committed anywhere in the repo
+    would otherwise be echoed to the terminal and into whatever captures it.
+    """
+    dumped = capture(Stub(verbose=True), context=f"config = '{secret}'")
+
+    assert secret not in dumped
+    assert "[REDACTED]" in dumped
+
+
+def test_redaction_keeps_a_prefix_so_the_finding_is_identifiable():
+    assert _redact_secrets("AKIAIOSFODNN7EXAMPLE").startswith("AKI")
+
+
+def test_ordinary_text_is_untouched():
+    text = "def add(a, b):\n    return a + b\n"
+    assert _redact_secrets(text) == text
+
+
+def test_redaction_can_be_turned_off_for_callers_that_need_raw():
+    err = io.StringIO()
+    with redirect_stderr(err):
+        _dump_payload("raw", "AKIAIOSFODNN7EXAMPLE", redact=False)
+
+    assert "AKIAIOSFODNN7EXAMPLE" in err.getvalue()
+
+
+def test_redaction_reuses_the_scanner_patterns():
+    """Two copies of the pattern list would drift apart."""
+    source = (Path(__file__).resolve().parents[1] / "modules" / "llm_client.py")
+    assert "SECRET_PATTERNS" in source.read_text(encoding="utf-8")
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_flag_reaches_the_client():
+    """
+    A config field that never reaches the client would make --verbose a no-op
+    that looks wired up.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "verbose=cfg.verbose_payloads" in source
+
+
+def test_the_facade_forwards_to_the_chosen_provider():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "llm_client.py"
+    ).read_text(encoding="utf-8")
+
+    assert "self.underlying_client.verbose = verbose" in source


### PR DESCRIPTION
Closes #141

## Summary

`--verbose` prints the exact prompt sent to the model and the raw text returned, for debugging a response that parsed wrongly or a context that selected the wrong files.

```bash
python main.py --repo . --task "Fix the parser" --verbose
```

Off by default.

## Three deliberate choices

**Output goes to stderr.** `--context-only` and the dry-run manifest write to stdout and are meant to be piped. Debug output there would corrupt them. Verified: with `--verbose` on, stdout is empty and stderr carries all three sections.

**Secrets are masked.** The prompt *is* repository file contents. If a key is committed anywhere in the repo it would otherwise be echoed to the terminal and into whatever captures that output — a CI log, a pasted bug report. `_redact_secrets` reuses `secret_scanner.SECRET_PATTERNS` rather than keeping a second copy that would drift:

```
context: cfg = 'AKIAIOSFODNN7EXAMPLE'
dumped : cfg = 'AKI[REDACTED]'
```

A four-character prefix is kept so the finding is still identifiable. `_dump_payload(..., redact=False)` exists for callers that genuinely need raw output.

**Hooked in the base class, not the providers.** `initial_request` and `retry_request` live on `BaseLLMClient`, so one hook covers Anthropic, OpenAI, Gemini and Ollama without touching four separate `_call` implementations. The `LLMClient` facade forwards the flag to whichever provider was selected, set once after the branch rather than in each arm so it cannot drift.

## Tests

`tests/test_verbose_payloads.py` — 19 cases.

Off by default and silent when off; the response still parses. When on: system prompt, request and response are all dumped, the context appears in the request, retries are dumped too, character counts are reported. Output goes to stderr and not stdout. Three real secret formats — AWS access key, GitHub token, Anthropic key — are each masked, ordinary code is untouched, redaction can be disabled, and the scanner patterns are reused rather than duplicated. Two wiring tests assert the flag actually reaches the client, since a config field that never arrives would make the flag a no-op that looks wired up.

## Verified

- behaviour above, against a stubbed provider
- 19 tests pass
- no new ruff findings; `llm_client.py` and `agent_loop.py` each drop by one
- built on current `main` after #186; the branch touches four files and reverts nothing