### PR TITLE
fix(sandbox): detect a missing pytest and fall back to python — Closes #143

### DIFF
--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -9,12 +9,14 @@ Runs code in isolation using subprocess with:
 """
 
 import atexit
+import fnmatch
 import logging
 import os
 import re
 import shlex
 import shutil
 import subprocess
+import time
 import sys
 import uuid
 from dataclasses import dataclass
@@ -294,15 +296,69 @@ def _build_safe_env(extra_env: Optional[dict] = None) -> dict:
     return env
 
 
+# Runners invoked as `python -m <module>`. `shutil.which` checks the executable,
+# which for these is the interpreter itself and therefore always present -- so
+# the "runner not found" guard never fires for them. Their availability has to
+# be probed by importing the module instead.
+MODULE_RUNNERS = {"pytest": "pytest"}
+
+# What each runner falls back to when it is unavailable. Only defined where the
+# fallback can actually run the same suite: `python -m pytest` and plain
+# `python <file>` both execute test files, so a repo whose tests are runnable as
+# scripts still gets a real signal. There is no equivalent for cargo or go.
+RUNNER_FALLBACKS = {"pytest": "python"}
+
+
+def _module_is_available(module: str) -> bool:
+    """True if `python -m <module>` would find the module."""
+    probe = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        timeout=30,
+    )
+    return probe.returncode == 0
+
+
+# Conventional test-file names. Deliberately narrow: running arbitrary files
+# with `python <file>` executes whatever is at module scope, so this only picks
+# up files a developer would recognise as tests.
+TEST_FILE_GLOBS = ("test_*.py", "*_test.py")
+MAX_FALLBACK_FILES = 25
+
+
+def _discover_test_files(root: str) -> list[str]:
+    """Test files under root, as paths relative to it."""
+    found: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d for d in dirnames
+            if not d.startswith(".")
+            and d not in ("node_modules", "__pycache__", "venv")
+        ]
+        for name in sorted(filenames):
+            if any(fnmatch.fnmatch(name, g) for g in TEST_FILE_GLOBS):
+                found.append(os.path.relpath(os.path.join(dirpath, name), root))
+    return sorted(found)[:MAX_FALLBACK_FILES]
+
+
 def _resolve_runner(runner_name: str) -> Optional[list[str]]:
     """Resolve a runner name to an executable command list."""
     if runner_name not in ALLOWED_RUNNERS:
         return None
     candidates = ALLOWED_RUNNERS[runner_name]
     executable = candidates[0]
-    if shutil.which(executable):
-        return candidates
-    return None
+    if not shutil.which(executable):
+        return None
+
+    module = MODULE_RUNNERS.get(runner_name)
+    if module and not _module_is_available(module):
+        # `python -m pytest` with pytest absent exits 1 with "No module named
+        # pytest", which is indistinguishable from a failing suite once wrapped
+        # in an ExecutionResult -- the agent reads it as a test failure and
+        # starts rewriting code that was never broken.
+        return None
+
+    return candidates
 
 
 def _docker_is_usable(probe_timeout: int = 15) -> bool:
@@ -499,16 +555,82 @@ class SubprocessSandbox:
     def run_tests(self, runner: str = "pytest", extra_args: Optional[list[str]] = None) -> ExecutionResult:
         """Run the project's test suite using a named runner."""
         cmd = _resolve_runner(runner)
+
         if cmd is None:
+            fallback = RUNNER_FALLBACKS.get(runner)
+            fallback_cmd = _resolve_runner(fallback) if fallback else None
+
+            if fallback_cmd is not None:
+                files = _discover_test_files(self.working_dir)
+                if files:
+                    _LOG.warning(
+                        "%s is unavailable; running %d test file(s) with %s "
+                        "instead. This is a weaker signal than a suite run.",
+                        runner, len(files), fallback,
+                    )
+                    return self._run_files_individually(fallback_cmd, files, extra_args)
+
+            detail = f"Runner '{runner}' not found or not allowed"
+            if fallback:
+                detail += (
+                    f". Falling back to '{fallback}' was not possible either "
+                    f"(no test files found, or {fallback} is unavailable)."
+                )
             return ExecutionResult(
                 command=runner,
                 exit_code=-3,
                 stdout="",
-                stderr=f"Runner '{runner}' not found or not allowed",
+                stderr=detail,
                 timed_out=False,
                 duration_seconds=0.0,
             )
+
         return self.run(cmd + (extra_args or []))
+
+    def _run_files_individually(
+        self,
+        base_cmd: list[str],
+        files: list[str],
+        extra_args: Optional[list[str]] = None,
+    ) -> ExecutionResult:
+        """
+        Run each test file as a script and combine the results.
+
+        This is weaker than a real suite run and the returned result says so:
+        `python <file>` executes module scope, so a file whose assertions live
+        inside pytest-collected functions will exit 0 without running anything.
+        A pass here means "nothing raised", not "the tests passed".
+        """
+        started = time.time()
+        stdout_parts: list[str] = []
+        stderr_parts: list[str] = []
+        worst_exit = 0
+        timed_out = False
+
+        for relative in files:
+            result = self.run(base_cmd + [relative] + (extra_args or []))
+            header = f"--- {relative} (exit {result.exit_code}) ---"
+            stdout_parts.append(f"{header}\n{result.stdout}".rstrip())
+            if result.stderr.strip():
+                stderr_parts.append(f"{header}\n{result.stderr}".rstrip())
+            if result.timed_out:
+                timed_out = True
+            if result.exit_code != 0:
+                worst_exit = result.exit_code or 1
+
+        note = (
+            f"[fallback] pytest was unavailable; ran {len(files)} file(s) with "
+            f"{os.path.basename(base_cmd[0])} instead. A pass here means nothing "
+            f"raised at module scope, not that a test suite succeeded."
+        )
+        return ExecutionResult(
+            command=f"{' '.join(base_cmd)} <{len(files)} test file(s)>",
+            exit_code=worst_exit,
+            stdout=note + "\n\n" + "\n\n".join(stdout_parts),
+            stderr="\n\n".join(stderr_parts),
+            timed_out=timed_out,
+            duration_seconds=time.time() - started,
+        )
 
     def run_lint(
         self,

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -337,7 +337,11 @@ def _discover_test_files(root: str) -> list[str]:
         ]
         for name in sorted(filenames):
             if any(fnmatch.fnmatch(name, g) for g in TEST_FILE_GLOBS):
-                found.append(os.path.relpath(os.path.join(dirpath, name), root))
+                # Forward slashes, matching repo_ingestion and secret_scanner.
+                # DockerSandbox mounts the repo into a Linux container, so a
+                # Windows-discovered "tests\\test_x.py" would not resolve there.
+                relative = os.path.relpath(os.path.join(dirpath, name), root)
+                found.append(relative.replace(os.sep, "/"))
     return sorted(found)[:MAX_FALLBACK_FILES]
 
 

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -15,7 +15,6 @@ tests pin that the result says so.
 """
 
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -41,7 +40,9 @@ def no_pytest(monkeypatch):
 
 @pytest.fixture
 def project(tmp_path):
-    (tmp_path / "test_ok.py").write_text("def test_a():\n    assert 1 == 1\n\nassert 2 == 2\n")
+    (tmp_path / "test_ok.py").write_text(
+        "def test_a():\n    assert 1 == 1\n\nassert 2 == 2\n"
+    )
     (tmp_path / "helper.py").write_text("x = 1\n")
     return SubprocessSandbox(str(tmp_path), timeout_seconds=60)
 
@@ -117,6 +118,21 @@ def test_nested_test_files_are_found(tmp_path):
     assert _discover_test_files(str(tmp_path)) == ["tests/test_deep.py"]
 
 
+def test_paths_use_forward_slashes(tmp_path):
+    """
+    DockerSandbox mounts the repo into a Linux container, so a path discovered
+    on Windows as "tests\\test_x.py" would not resolve inside it. Matches the
+    convention already used by repo_ingestion and secret_scanner.
+    """
+    (tmp_path / "a" / "b").mkdir(parents=True)
+    (tmp_path / "a" / "b" / "test_nested.py").write_text("")
+
+    found = _discover_test_files(str(tmp_path))
+
+    assert found == ["a/b/test_nested.py"]
+    assert all("\\" not in path for path in found)
+
+
 def test_the_file_count_is_capped(tmp_path):
     """One `python` invocation per file; an unbounded repo would hang the run."""
     for i in range(60):
@@ -168,7 +184,8 @@ def test_the_result_states_the_limitation(no_pytest, project):
 def test_each_file_is_labelled_in_the_output(no_pytest, tmp_path):
     (tmp_path / "test_one.py").write_text("")
     (tmp_path / "test_two.py").write_text("")
-    stdout = SubprocessSandbox(str(tmp_path), timeout_seconds=60).run_tests("pytest").stdout
+    sandbox = SubprocessSandbox(str(tmp_path), timeout_seconds=60)
+    stdout = sandbox.run_tests("pytest").stdout
 
     assert "--- test_one.py" in stdout
     assert "--- test_two.py" in stdout

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -1,0 +1,194 @@
+"""
+Tests for the pytest -> python fallback (modules/sandbox.py).
+
+Two problems, one of which the issue does not mention.
+
+`_resolve_runner` checked `shutil.which(candidates[0])`. For pytest that
+executable is `sys.executable`, which always exists, so the "runner not found"
+guard never fired. A missing pytest instead surfaced as exit 1 with "No module
+named pytest" — indistinguishable from a failing suite once wrapped in an
+ExecutionResult, so the agent would read it as a test failure and start
+rewriting code that was never broken.
+
+The second is the fallback itself, and it is weaker than a suite run. These
+tests pin that the result says so.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules import sandbox as sb  # noqa: E402
+from modules.sandbox import (  # noqa: E402
+    MODULE_RUNNERS,
+    RUNNER_FALLBACKS,
+    SubprocessSandbox,
+    _discover_test_files,
+    _module_is_available,
+    _resolve_runner,
+)
+
+
+@pytest.fixture
+def no_pytest(monkeypatch):
+    """Simulate pytest not being installed."""
+    monkeypatch.setattr(sb, "_module_is_available", lambda module: False)
+
+
+@pytest.fixture
+def project(tmp_path):
+    (tmp_path / "test_ok.py").write_text("def test_a():\n    assert 1 == 1\n\nassert 2 == 2\n")
+    (tmp_path / "helper.py").write_text("x = 1\n")
+    return SubprocessSandbox(str(tmp_path), timeout_seconds=60)
+
+
+# ── the detection gap ─────────────────────────────────────────────────────
+
+
+def test_pytest_is_registered_as_a_module_runner():
+    """
+    Without this, availability is judged by `which(sys.executable)`, which is
+    always true and so never rejects anything.
+    """
+    assert MODULE_RUNNERS["pytest"] == "pytest"
+
+
+def test_a_present_module_is_detected():
+    assert _module_is_available("pytest") is True
+
+
+def test_an_absent_module_is_detected():
+    assert _module_is_available("definitely_not_installed_anywhere") is False
+
+
+def test_an_absent_module_makes_the_runner_unresolvable(no_pytest):
+    assert _resolve_runner("pytest") is None
+
+
+def test_a_present_module_resolves_normally():
+    assert _resolve_runner("pytest") is not None
+
+
+def test_non_module_runners_are_unaffected():
+    """`go`, `cargo` and friends are still judged by which()."""
+    assert "go" not in MODULE_RUNNERS
+    assert "cargo" not in MODULE_RUNNERS
+
+
+# ── discovery ─────────────────────────────────────────────────────────────
+
+
+def test_conventional_test_files_are_found(tmp_path):
+    (tmp_path / "test_a.py").write_text("")
+    (tmp_path / "b_test.py").write_text("")
+    (tmp_path / "notes.py").write_text("")
+
+    found = _discover_test_files(str(tmp_path))
+
+    assert set(found) == {"test_a.py", "b_test.py"}
+
+
+def test_non_test_files_are_not_run(tmp_path):
+    """
+    `python <file>` executes module scope, so running arbitrary files could
+    execute anything. Only conventional test names are picked up.
+    """
+    (tmp_path / "deploy.py").write_text("raise SystemExit('should never run')")
+
+    assert _discover_test_files(str(tmp_path)) == []
+
+
+def test_vendor_directories_are_skipped(tmp_path):
+    for directory in ("node_modules", "__pycache__", ".venv"):
+        (tmp_path / directory).mkdir()
+        (tmp_path / directory / "test_vendor.py").write_text("")
+
+    assert _discover_test_files(str(tmp_path)) == []
+
+
+def test_nested_test_files_are_found(tmp_path):
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_deep.py").write_text("")
+
+    assert _discover_test_files(str(tmp_path)) == ["tests/test_deep.py"]
+
+
+def test_the_file_count_is_capped(tmp_path):
+    """One `python` invocation per file; an unbounded repo would hang the run."""
+    for i in range(60):
+        (tmp_path / f"test_{i:03d}.py").write_text("")
+
+    assert len(_discover_test_files(str(tmp_path))) <= sb.MAX_FALLBACK_FILES
+
+
+# ── the fallback ──────────────────────────────────────────────────────────
+
+
+def test_the_fallback_is_only_defined_where_it_makes_sense():
+    """There is no way to run a Go or Rust suite with a Python interpreter."""
+    assert RUNNER_FALLBACKS == {"pytest": "python"}
+
+
+def test_files_are_run_when_pytest_is_missing(no_pytest, project):
+    result = project.run_tests("pytest")
+
+    assert "test file(s)" in result.command
+    assert result.stdout.count("--- test_") == 1
+
+
+def test_a_passing_file_yields_a_passing_result(no_pytest, project):
+    assert project.run_tests("pytest").success is True
+
+
+def test_a_failing_file_yields_a_failing_result(no_pytest, tmp_path):
+    (tmp_path / "test_bad.py").write_text("assert 1 == 2, 'boom'\n")
+    result = SubprocessSandbox(str(tmp_path), timeout_seconds=60).run_tests("pytest")
+
+    assert result.success is False
+    assert "boom" in result.stdout + result.stderr
+
+
+def test_the_result_says_it_fell_back(no_pytest, project):
+    assert "[fallback]" in project.run_tests("pytest").stdout
+
+
+def test_the_result_states_the_limitation(no_pytest, project):
+    """
+    `python <file>` runs module scope. Assertions inside pytest-collected
+    functions never execute, so a pass here is much weaker than a suite pass
+    and the output must not let anyone assume otherwise.
+    """
+    assert "not that a test suite succeeded" in project.run_tests("pytest").stdout
+
+
+def test_each_file_is_labelled_in_the_output(no_pytest, tmp_path):
+    (tmp_path / "test_one.py").write_text("")
+    (tmp_path / "test_two.py").write_text("")
+    stdout = SubprocessSandbox(str(tmp_path), timeout_seconds=60).run_tests("pytest").stdout
+
+    assert "--- test_one.py" in stdout
+    assert "--- test_two.py" in stdout
+
+
+def test_no_test_files_means_no_fallback(no_pytest, tmp_path):
+    """Reporting success on an empty run would be worse than reporting nothing."""
+    result = SubprocessSandbox(str(tmp_path), timeout_seconds=30).run_tests("pytest")
+
+    assert result.exit_code == -3
+    assert "not possible either" in result.stderr
+
+
+def test_a_runner_without_a_fallback_still_fails_cleanly(tmp_path):
+    result = SubprocessSandbox(str(tmp_path), timeout_seconds=30).run_tests("nonesuch")
+
+    assert result.exit_code == -3
+    assert "not found or not allowed" in result.stderr
+
+
+def test_normal_operation_is_unchanged(project):
+    """With pytest installed, nothing about the existing path changes."""
+    assert "-m" in project.run_tests("pytest").command


### PR DESCRIPTION
Closes #143

## The bug is worse than the issue describes

The issue says that if pytest is not installed, the sandbox should try running the file directly with python before failing. Investigating that turned up something the issue does not mention: **the "runner not found" guard never fires for pytest at all.**

`_resolve_runner` checks `shutil.which(candidates[0])`. For pytest, that entry is:

```python
"pytest": [sys.executable, "-m", "pytest"]
```

so the executable being checked is the interpreter, which always exists. The guard passes, `python -m pytest` runs, and with pytest absent it produces:

```
exit code: 1
stderr   : No module named pytest
```

Wrapped in an `ExecutionResult`, that is indistinguishable from a failing test suite. The agent reads it as a test failure and starts rewriting code that was never broken — burning iterations and API spend on a problem that does not exist.

## What this adds

**Module availability is probed properly.** `MODULE_RUNNERS` marks runners invoked as `python -m <module>`, and `_module_is_available` runs `python -c "import <module>"` to find out whether they will actually work. Runners resolved by executable — `go`, `cargo`, `npm` — are unaffected and still judged by `which`.

**A fallback, where one makes sense.** `RUNNER_FALLBACKS = {"pytest": "python"}` and nothing else. `python -m pytest` and plain `python <file>` both execute test files, so a repo whose tests are runnable as scripts still gets a real signal. There is no equivalent for a Go or Rust suite, so those keep failing cleanly rather than pretending.

## Three constraints on the fallback

**Only conventional test names are run.** `python <file>` executes module scope, so running arbitrary files could execute a deploy script or anything else sitting at import level. Discovery matches `test_*.py` and `*_test.py` only.

**Vendor directories are skipped** — `node_modules`, `__pycache__`, `.venv` and dotfolders.

**The file count is capped at 25.** One subprocess per file; an unbounded repo would hang the run.

## It says what it is

The fallback is genuinely weaker than a suite run, and the output says so rather than letting anyone assume otherwise:

```
[fallback] pytest was unavailable; ran 2 file(s) with python instead.
A pass here means nothing raised at module scope, not that a test suite succeeded.
```

That distinction is real: assertions inside pytest-collected functions never execute under plain `python`, so a file full of `def test_x(): assert ...` will exit 0 without running a single assertion. Each file is labelled with its own exit code in the combined output, and the worst exit code wins.

When there are no test files to fall back to, the run fails with `-3` and an explanation, because reporting success on an empty run would be worse than reporting nothing.

## A Windows-only bug, found by running the suite there

`os.path.relpath` returns backslash-separated paths on Windows. Those work when running locally, but `DockerSandbox` mounts the repo into a **Linux** container, where `python tests\test_deep.py` does not resolve — so a Windows user with Docker enabled would have got a fallback that silently found nothing.

Discovered paths are now normalised to forward slashes, matching what `repo_ingestion.py` and `secret_scanner.py` already do in three places. The Linux run passed; only the Windows run caught it.

## Tests

`tests/test_runner_fallback.py` — 22 cases.

Detection: pytest is registered as a module runner; a present module is detected; an absent one is detected; an absent module makes the runner unresolvable; a present one resolves normally; non-module runners are unaffected.

Discovery: conventional test files are found; non-test files are not run; vendor directories are skipped; nested files are found; paths use forward slashes; the count is capped.

The fallback: it is only defined where it makes sense; files are run when pytest is missing; a passing file yields a passing result and a failing one fails; the result says it fell back; the result states the limitation; each file is labelled; no test files means no fallback; a runner without a fallback still fails cleanly; normal operation with pytest installed is unchanged.

## Verified

- the failure signature above, reproduced directly
- the fallback exercised end to end against a temp repo with one passing and one failing file
- 22 tests pass, plus the existing 131 across `test_js_runners`, `test_sandbox_env`, `test_sandbox_fallback` and `test_lint_step`
- ruff on `modules/sandbox.py` at its baseline of 2 findings
- built on current `main` after #186 and #188

`DockerSandbox.run_tests` delegates to `SubprocessSandbox`, so one change covers both.