### PR TITLE
feat(logger): record per-phase timing for each iteration — Closes #146

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -14,6 +14,7 @@ Flow per iteration:
 """
 
 import os
+import time
 import re
 import uuid
 from dataclasses import dataclass, field
@@ -116,6 +117,22 @@ class AgentRunResult:
 # ─────────────────────────────────────────────
 # The Agent
 # ─────────────────────────────────────────────
+
+def _stamp_timings(record, iter_started, ingest, context, llm, apply_, exec_phase):
+    """
+    Attach per-phase wall time to an iteration record.
+
+    A helper rather than inline assignments because record_iteration is called
+    from seven places -- early returns for parse errors, validation failures and
+    budget stops all write a record, and each would otherwise need six lines.
+    """
+    record.duration_ingest = round(ingest, 3)
+    record.duration_context = round(context, 3)
+    record.duration_llm = round(llm, 3)
+    record.duration_apply = round(apply_, 3)
+    record.duration_execution = round(time.time() - exec_phase, 3)
+    record.duration_total = round(time.time() - iter_started, 3)
+
 
 class AutonomousAgent:
     def __init__(self, config: AgentConfig):
@@ -385,6 +402,12 @@ class AutonomousAgent:
             iterations_used = iteration
             self.logger.start_iteration(iteration)
 
+            iter_started = time.time()
+            phase = time.time()
+            # Initialised up front because several early returns -- parse
+            # errors, validation failures, budget stops -- write a record
+            # before the later phases have run.
+            duration_ingest = duration_context = duration_llm = duration_apply = 0.0
             # ── Step 1: Ingest repo (re-read to pick up changes from previous iter) ──
             try:
                 if cfg.parallel:
@@ -400,6 +423,8 @@ class AutonomousAgent:
                     pr_url=None, iterations_used=iteration - 1, final_message=str(e)
                 )
 
+            duration_ingest = time.time() - phase
+            phase = time.time()
             # ── Step 2: Build context ──
             context = build_context(
                 repo, cfg.task,
@@ -432,6 +457,8 @@ class AutonomousAgent:
                     ),
                 )
 
+            duration_context = time.time() - phase
+            phase = time.time()
             # ── Step 3: Call LLM ──
             try:
                 if iteration == 1 or not last_exec:
@@ -518,6 +545,10 @@ class AutonomousAgent:
                         timed_out=False,
                         duration_seconds=0.0,
                     )
+                    _stamp_timings(
+                        iter_record, iter_started, duration_ingest, duration_context,
+                        duration_llm, duration_apply, phase,
+                    )
                     self.logger.record_iteration(iter_record)
                     continue
 
@@ -530,9 +561,15 @@ class AutonomousAgent:
                 if iteration == cfg.max_iterations:
                     outcome = "failed"
                     break
+                _stamp_timings(
+                    iter_record, iter_started, duration_ingest, duration_context,
+                    duration_llm, duration_apply, phase,
+                )
                 self.logger.record_iteration(iter_record)
                 continue
 
+            duration_llm = time.time() - phase
+            phase = time.time()
             # ── Step 4: Validate + Apply changes ──
             if llm_resp.changes:
                 validation_errors = self.modifier.verify_changes(llm_resp.changes)
@@ -597,6 +634,10 @@ class AutonomousAgent:
                 if apply_results and all(not r.success for r in apply_results):
                     self.logger.error("  All file modifications failed. Check paths and permissions.")
                     outcome = "error"
+                    _stamp_timings(
+                        iter_record, iter_started, duration_ingest, duration_context,
+                        duration_llm, duration_apply, phase,
+                    )
                     self.logger.record_iteration(iter_record)
                     break
             else:
@@ -614,15 +655,25 @@ class AutonomousAgent:
                         "  Commit declined. Changes are left in the working tree."
                     )
                     outcome = "aborted"
+                    _stamp_timings(
+                        iter_record, iter_started, duration_ingest, duration_context,
+                        duration_llm, duration_apply, phase,
+                    )
                     self.logger.record_iteration(iter_record)
                     break
 
                 self._commit_changes(iteration, changed_paths)
                 outcome = "success"
                 iter_record.execution_success = True
+                _stamp_timings(
+                    iter_record, iter_started, duration_ingest, duration_context,
+                    duration_llm, duration_apply, phase,
+                )
                 self.logger.record_iteration(iter_record)
                 break
 
+            duration_apply = time.time() - phase
+            phase = time.time()
             # ── Step 5: Execute ──
             # Lint first when configured. A syntax error surfaces in under a
             # second with a precise location, instead of arriving as a pytest
@@ -641,6 +692,10 @@ class AutonomousAgent:
                     iter_record.execution_stdout = lint_result.stdout[:2000]
                     iter_record.execution_stderr = lint_result.stderr[:2000]
                     iter_record.execution_success = False
+                    _stamp_timings(
+                        iter_record, iter_started, duration_ingest, duration_context,
+                        duration_llm, duration_apply, phase,
+                    )
                     self.logger.record_iteration(iter_record)
                     continue
 
@@ -658,6 +713,10 @@ class AutonomousAgent:
             iter_record.execution_timed_out = exec_result.timed_out
             iter_record.execution_success = exec_result.success
 
+            _stamp_timings(
+                iter_record, iter_started, duration_ingest, duration_context,
+                duration_llm, duration_apply, phase,
+            )
             self.logger.record_iteration(iter_record)
 
             if cfg.coverage and exec_result.success:

--- a/modules/logger.py
+++ b/modules/logger.py
@@ -41,6 +41,15 @@ class IterationRecord:
     execution_success: bool
     parse_error: Optional[str]
 
+    # Per-phase wall time. Defaulted so every existing construction site keeps
+    # working -- there are several, and a required field would break them all.
+    duration_ingest: float = 0.0
+    duration_context: float = 0.0
+    duration_llm: float = 0.0
+    duration_apply: float = 0.0
+    duration_execution: float = 0.0
+    duration_total: float = 0.0
+
 
 @dataclass
 class RunRecord:
@@ -167,6 +176,15 @@ class AgentLogger:
         self._logger.info(f"  {status} Git {action}: {result.output[:100] or result.error[:100]}")
 
     def record_iteration(self, record: IterationRecord):
+        if record.duration_total:
+            # One line rather than six: the breakdown is in the JSONL for
+            # anyone measuring, and the terminal only needs the shape of it.
+            self.info(
+                f"  Timing: llm {record.duration_llm:.1f}s | "
+                f"tests {record.duration_execution:.1f}s | "
+                f"ingest {record.duration_ingest:.1f}s | "
+                f"total {record.duration_total:.1f}s"
+            )
         if self._run_record:
             self._run_record.iterations.append(record)
             self._run_record.total_iterations += 1

--- a/tests/test_iteration_timing.py
+++ b/tests/test_iteration_timing.py
@@ -1,0 +1,188 @@
+"""
+Tests for per-iteration timing (modules/agent_loop.py, modules/logger.py).
+
+Records how long each phase took — ingest, context, LLM, apply, execution — so
+a slow run can be attributed rather than guessed at. The breakdown goes into
+the JSONL; the terminal gets one summary line.
+"""
+
+import json
+import sys
+import time
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import _stamp_timings  # noqa: E402
+from modules.logger import AgentLogger, IterationRecord  # noqa: E402
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+PHASES = [
+    "duration_ingest",
+    "duration_context",
+    "duration_llm",
+    "duration_apply",
+    "duration_execution",
+    "duration_total",
+]
+
+
+def make_record():
+    return IterationRecord(
+        iteration=1, timestamp="2026-08-08T00:00:00", context_files=[], context_chars=0,
+        llm_analysis="", llm_confidence=0.9, llm_done=True, changes_attempted=[],
+        apply_results=[], execution_command=None, execution_exit_code=None,
+        execution_stdout=None, execution_stderr=None, execution_timed_out=False,
+        execution_success=True, parse_error=None,
+    )
+
+
+# ── the record ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", PHASES)
+def test_every_phase_has_a_field(name):
+    assert name in {f.name for f in fields(IterationRecord)}
+
+
+@pytest.mark.parametrize("name", PHASES)
+def test_timing_fields_default_to_zero(name):
+    """
+    record_iteration is constructed in several places. A required field would
+    break every one of them.
+    """
+    assert getattr(make_record(), name) == 0.0
+
+
+# ── stamping ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def stamped():
+    record = make_record()
+    _stamp_timings(record, time.time() - 5.0, 0.4, 0.15, 1.9, 0.05, time.time() - 2.0)
+    return record
+
+
+def test_measured_phases_are_recorded(stamped):
+    assert stamped.duration_ingest == 0.4
+    assert stamped.duration_context == 0.15
+    assert stamped.duration_llm == 1.9
+    assert stamped.duration_apply == 0.05
+
+
+def test_execution_is_measured_from_its_phase_start(stamped):
+    assert 1.9 <= stamped.duration_execution <= 2.2
+
+
+def test_total_covers_the_whole_iteration(stamped):
+    assert 4.9 <= stamped.duration_total <= 5.2
+
+
+def test_total_is_at_least_the_sum_of_its_parts(stamped):
+    parts = (
+        stamped.duration_ingest + stamped.duration_context + stamped.duration_llm
+        + stamped.duration_apply + stamped.duration_execution
+    )
+    assert stamped.duration_total >= parts - 0.01
+
+
+def test_values_are_rounded(stamped):
+    """Raw floats make the JSONL noisy without adding precision anyone uses."""
+    for name in PHASES:
+        value = getattr(stamped, name)
+        assert round(value, 3) == value
+
+
+# ── it reaches the log ────────────────────────────────────────────────────
+
+
+def test_timings_are_written_to_the_jsonl(tmp_path):
+    logger = AgentLogger(str(tmp_path), "run_abc", verbose=False)
+    record = make_record()
+    _stamp_timings(record, time.time() - 3.0, 0.1, 0.2, 1.0, 0.3, time.time() - 1.0)
+    logger.record_iteration(record)
+
+    line = json.loads((tmp_path / "run_abc.jsonl").read_text().splitlines()[0])
+
+    assert line["duration_llm"] == 1.0
+    assert line["duration_total"] >= 2.9
+
+
+def test_a_summary_line_is_logged(tmp_path, capsys):
+    """
+    AgentLogger attaches its own handlers rather than propagating, so the line
+    is asserted on captured output rather than through caplog.
+    """
+    logger = AgentLogger(str(tmp_path), "run_def", verbose=False)
+    record = make_record()
+    _stamp_timings(record, time.time() - 3.0, 0.1, 0.2, 1.0, 0.3, time.time() - 1.0)
+    logger.record_iteration(record)
+
+    captured = capsys.readouterr()
+    assert "Timing:" in captured.out + captured.err
+
+
+def test_the_summary_names_each_phase(tmp_path, capsys):
+    logger = AgentLogger(str(tmp_path), "run_xyz", verbose=False)
+    record = make_record()
+    _stamp_timings(record, time.time() - 3.0, 0.1, 0.2, 1.0, 0.3, time.time() - 1.0)
+    logger.record_iteration(record)
+
+    output = capsys.readouterr().out + capsys.readouterr().err
+    for label in ("llm", "tests", "ingest", "total"):
+        assert label in output
+
+
+def test_no_summary_when_nothing_was_measured(tmp_path, capsys):
+    """An unstamped record should not print a line of zeroes."""
+    logger = AgentLogger(str(tmp_path), "run_ghi", verbose=False)
+    logger.record_iteration(make_record())
+
+    captured = capsys.readouterr()
+    assert "Timing:" not in captured.out + captured.err
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_every_phase_boundary_is_instrumented():
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+
+    for name in ("duration_ingest =", "duration_context =",
+                 "duration_llm =", "duration_apply ="):
+        assert name in source
+
+
+def test_every_record_write_is_stamped():
+    """
+    Seven call sites write a record -- parse errors, validation failures and
+    budget stops each have their own. One missed site logs zeroes.
+    """
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+
+    assert source.count("self.logger.record_iteration(iter_record)") == \
+        source.count("_stamp_timings(")- 1   # -1 for the def itself
+
+
+def test_durations_are_initialised_before_any_early_return():
+    """
+    Several paths write a record before the later phases run -- a parse error
+    returns before the LLM phase completes. Without an up-front initialisation
+    those paths raise NameError instead of logging.
+    """
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    init = source.index("duration_ingest = duration_context")
+
+    first_call = source.index("_stamp_timings(\n", init)
+
+    assert init < first_call
+
+
+def test_the_iteration_clock_starts_at_step_one():
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    assert source.index("iter_started = time.time()") < source.index("# ── Step 2")


### PR DESCRIPTION
Closes #146

## Summary

Each iteration now records how long it spent in each phase — ingest, context building, the LLM call, applying changes, and execution — plus the total.

The breakdown goes into `logs/<run_id>.jsonl` for anyone measuring. The terminal gets one line:

```
Timing: llm 1.0s | tests 1.0s | ingest 0.1s | total 3.0s
```

## Where the time actually goes

The point of the issue is being able to answer that without guessing. A run that feels slow is usually one of three things — a large repo making ingestion expensive, a long LLM response, or a slow test suite — and they call for completely different fixes. Until now there was no way to tell them apart: `ExecutionResult.duration_seconds` covered the test run and nothing else.

Six fields are added to `IterationRecord`, all defaulted to `0.0`. That matters because the record is constructed in several places, and a required field would break every one of them.

`record_iteration` already serialises via `asdict`, so the values reach the JSONL with no change to the writer. The dashboard from #55 reads that file, so the data is available there too.

## A bug ruff caught

The first version assigned the phase durations as the loop progressed, then stamped them onto the record before each write. Ruff flagged it:

```
F821 Undefined name `duration_llm`  --> modules/agent_loop.py:546
F821 Undefined name `duration_apply` --> modules/agent_loop.py:546
```

Seven paths write an iteration record, and the early ones — a parse error, a validation failure, a budget stop — return **before** those variables are assigned. A malformed LLM response would have raised `NameError` instead of logging the iteration, turning a recoverable parse failure into a crash.

My own tests missed it because they exercised `_stamp_timings` directly rather than the loop paths that reach it. Fixed with an up-front initialisation, and there is now a test asserting the initialisation precedes the first call site.

## Why a helper

`_stamp_timings` is a function rather than six inline assignments because `record_iteration` is called from seven places. Inline, that would be forty-two lines that all have to stay in step, and the F821 above is a preview of what happens when one of them drifts.

## The summary line is conditional

An unstamped record — one written by a path that never measured anything — would otherwise print a line of zeroes that reads like a real measurement. The line is skipped when `duration_total` is zero, and there is a test for it.

Values are rounded to milliseconds. Raw floats make the JSONL noisy without adding precision anyone uses.

## Tests

`tests/test_iteration_timing.py` — 25 cases.

The record: every phase has a field; every field defaults to zero.

Stamping: measured phases are recorded accurately; execution is measured from its own phase start; the total covers the whole iteration; the total is at least the sum of its parts; values are rounded.

Reaching the log: timings are written to the JSONL; a summary line is logged; the summary names each phase; no summary is printed when nothing was measured.

Wiring: every phase boundary is instrumented; every record write is stamped — seven call sites, and a missed one logs zeroes; the durations are initialised before any early return; the iteration clock starts at Step 1.

The log-line tests read captured output rather than `caplog`, because `AgentLogger` attaches its own handlers instead of propagating.

## Verified

- timings computed against a synthetic iteration: `ingest 0.4 | context 0.15 | llm 1.9 | apply 0.05 | execution 2.0 | total 5.0`, with the total correctly covering the phases
- 25 tests pass, plus the existing `test_dashboard`, `test_interrupt_rollback`, `test_skip_tests` and `test_utils` — 55 in total, no regressions
- ruff on `modules/agent_loop.py` back to its baseline of 23 after the F821 fix; `modules/logger.py` unchanged at 3
- built on current `main` after #186 and #188