### PR TITLE
fix(modifier): remove created files on rollback — Closes #139

### DIFF
--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -352,12 +352,36 @@ class CodeModificationEngine:
                 results.append(future.result())
         return results
 
+    def _prune_empty_dirs(self, start: str) -> None:
+        """
+        Remove directories left empty by removing a created file.
+
+        `create` makes intermediate directories, so deleting pkg/new.py without
+        this leaves an empty pkg/ behind -- which git ignores but a developer
+        looking at their tree does not. Walks up only while directories are
+        empty, and never past the repo root.
+        """
+        root = os.path.abspath(self.repo_root)
+        current = os.path.abspath(start)
+        while current.startswith(root) and current != root:
+            try:
+                if os.listdir(current):
+                    return
+                os.rmdir(current)
+            except OSError:
+                return
+            current = os.path.dirname(current)
+
     def rollback(self, results: list[ApplyResult]) -> list[str]:
         """
-        Restore all backed-up files. Used if the iteration should be fully reverted.
-        Returns list of restored paths.
+        Revert an applied set of changes.
+
+        Restores backed-up files, removes files that were created (they have no
+        backup to restore), and removes the destination of a rename. Returns
+        every path that was reverted, restored or removed alike.
         """
         restored = []
+        removed: list[str] = []
         for result in results:
             # A rename left a file at the destination. Restoring the backup to
             # the original path is not enough on its own -- without this the
@@ -370,6 +394,23 @@ class CodeModificationEngine:
                 except Exception:
                     pass
 
+            # A successful "create" has no backup -- _backup returns None when
+            # the file did not exist -- so restoring backups alone leaves the
+            # new file in the tree. `git status` then shows an untracked file
+            # after a rollback that reported success.
+            if result.action == "create" and result.success:
+                try:
+                    abs_path = self._safe_abs_path(result.path)
+                    if os.path.isfile(abs_path):
+                        os.remove(abs_path)
+                        removed.append(result.path)
+                        self._prune_empty_dirs(os.path.dirname(abs_path))
+                except OSError as exc:
+                    _LOG.warning(
+                        "could not remove created file %s: %s", result.path, exc
+                    )
+                continue
+
             if result.backup_path and os.path.exists(result.backup_path):
                 try:
                     abs_path = self._safe_abs_path(result.path)
@@ -377,7 +418,9 @@ class CodeModificationEngine:
                     restored.append(result.path)
                 except Exception:
                     pass
-        return restored
+        # Removed creations are reverted paths too. Callers report this count
+        # to the user, and omitting them would understate what was undone.
+        return restored + removed
 
     def verify_changes(self, changes: list[FileChange]) -> list[str]:
         """

--- a/tests/test_rollback_created_files.py
+++ b/tests/test_rollback_created_files.py
@@ -1,0 +1,171 @@
+"""
+Tests for rollback leaving nothing behind (modules/code_modifier.py).
+
+`_backup` returns None when a file does not already exist, so a "create" has
+nothing to restore from — and rollback, which only restored backups, left the
+new file in the tree. `git status` then showed untracked files after a rollback
+that reported success, which is what #139 describes.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.code_modifier import CodeModificationEngine  # noqa: E402
+from modules.llm_client import FileChange  # noqa: E402
+
+
+@pytest.fixture
+def engine(tmp_path):
+    (tmp_path / "existing.py").write_text("original\n")
+    return CodeModificationEngine(str(tmp_path), str(tmp_path / ".backups"))
+
+
+def visible(root):
+    return sorted(p for p in os.listdir(root) if not p.startswith("."))
+
+
+def change(path, action="create", content="new\n"):
+    return FileChange(path=path, action=action, content=content, explanation="e")
+
+
+# ── the reported bug ──────────────────────────────────────────────────────
+
+
+def test_a_created_file_is_removed(engine, tmp_path):
+    results = engine.apply_changes([change("brand_new.py")])
+    assert (tmp_path / "brand_new.py").exists()
+
+    engine.rollback(results)
+
+    assert not (tmp_path / "brand_new.py").exists()
+
+
+def test_nothing_is_left_behind(engine, tmp_path):
+    """The whole point: `git status` clean after a rollback."""
+    results = engine.apply_changes([
+        change("existing.py", action="modify", content="edited\n"),
+        change("brand_new.py"),
+        change("pkg/nested_new.py", content="nested\n"),
+    ])
+
+    engine.rollback(results)
+
+    assert visible(tmp_path) == ["existing.py"]
+
+
+def test_a_modified_file_is_still_restored(engine, tmp_path):
+    """The existing behaviour must not regress."""
+    results = engine.apply_changes(
+        [change("existing.py", action="modify", content="edited\n")]
+    )
+
+    engine.rollback(results)
+
+    assert (tmp_path / "existing.py").read_text() == "original\n"
+
+
+# ── directories ───────────────────────────────────────────────────────────
+
+
+def test_a_directory_created_for_the_file_is_pruned(engine, tmp_path):
+    """`create` makes intermediate directories; an empty pkg/ is still litter."""
+    results = engine.apply_changes([change("pkg/new.py")])
+
+    engine.rollback(results)
+
+    assert not (tmp_path / "pkg").exists()
+
+
+def test_nested_directories_are_pruned(engine, tmp_path):
+    results = engine.apply_changes([change("a/b/c/new.py")])
+
+    engine.rollback(results)
+
+    assert not (tmp_path / "a").exists()
+
+
+def test_a_directory_that_still_has_files_is_kept(engine, tmp_path):
+    (tmp_path / "pkg").mkdir()
+    (tmp_path / "pkg" / "keep.py").write_text("keep me\n")
+    results = engine.apply_changes([change("pkg/new.py")])
+
+    engine.rollback(results)
+
+    assert (tmp_path / "pkg" / "keep.py").exists()
+
+
+def test_the_repo_root_is_never_removed(engine, tmp_path):
+    results = engine.apply_changes([change("top_level.py")])
+
+    engine.rollback(results)
+
+    assert tmp_path.is_dir()
+
+
+# ── reporting ─────────────────────────────────────────────────────────────
+
+
+def test_removed_files_are_reported(engine):
+    """
+    agent_loop logs "Rolled back N file(s)". Omitting removals would understate
+    what was actually undone.
+    """
+    results = engine.apply_changes([
+        change("existing.py", action="modify", content="edited\n"),
+        change("brand_new.py"),
+    ])
+
+    reverted = engine.rollback(results)
+
+    assert sorted(reverted) == ["brand_new.py", "existing.py"]
+
+
+def test_rollback_returns_paths_not_none(engine):
+    assert isinstance(engine.rollback(engine.apply_changes([change("x.py")])), list)
+
+
+# ── it does not overreach ─────────────────────────────────────────────────
+
+
+def test_a_failed_create_does_not_remove_an_existing_file(engine, tmp_path):
+    """
+    A create that failed validation must not cause rollback to delete whatever
+    happens to sit at that path.
+    """
+    from modules.code_modifier import ApplyResult
+
+    fake = ApplyResult(
+        path="existing.py", action="create", success=False,
+        backup_path=None, error="refused",
+    )
+
+    engine.rollback([fake])
+
+    assert (tmp_path / "existing.py").read_text() == "original\n"
+
+
+def test_rollback_is_safe_to_run_twice(engine, tmp_path):
+    """The second pass finds the file already gone."""
+    results = engine.apply_changes([change("brand_new.py")])
+
+    engine.rollback(results)
+    engine.rollback(results)
+
+    assert not (tmp_path / "brand_new.py").exists()
+
+
+def test_other_actions_still_roll_back(engine, tmp_path):
+    """delete restores from its backup; create is the only new path."""
+    results = engine.apply_changes(
+        [FileChange(path="existing.py", action="delete", content="", explanation="e")]
+    )
+    assert not (tmp_path / "existing.py").exists()
+
+    engine.rollback(results)
+
+    assert (tmp_path / "existing.py").read_text() == "original\n"


### PR DESCRIPTION
Closes #139

## Reproduced

Applied three changes to a temp repo — one modify, two creates — then rolled back:

```
after rollback:
  brand_new.py         <- created file survived
  existing.py          <- correctly restored
  pkg/nested_new.py    <- survived, plus an empty pkg/
```

So `git status` shows untracked files after a rollback that reported success, which is exactly what the issue describes.

## Cause

`rollback()` restores `backup_path` back to `result.path`. `_backup()` returns `None` when the file does not already exist:

```python
def _backup(self, abs_path, relative_path):
    if not os.path.exists(abs_path):
        return None
```

A `create` therefore has nothing to restore from, and restoring backups alone is a no-op for it. The file stays.

This is the same shape as the rename case already handled a few lines above — restoring the source is not enough when the operation also *added* something — but `create` was never given the equivalent treatment.

## The fix

A successful `create` is removed rather than restored, and the directories the create made are pruned:

```
files left     : ['existing.py']
pkg/ pruned    : True
reverted paths : ['brand_new.py', 'existing.py', 'pkg/nested_new.py']
```

`_prune_empty_dirs` walks upward only while directories are empty and stops at the repo root. `create` makes intermediate directories, so deleting `pkg/new.py` without this leaves an empty `pkg/` — invisible to git, but not to whoever is looking at their tree.

## Removals are reported

`rollback()` returns removed paths alongside restored ones, because `agent_loop` logs:

```python
self.logger.info(f"  Rolled back {len(restored)} file(s): {restored}")
```

Omitting removals would understate what was actually undone — a rollback of two creates would have reported "0 file(s)" while deleting two files.

## It does not overreach

Three ways this could have been dangerous, each with a test:

**A failed create must not delete anything.** A create rejected by validation leaves whatever was already at that path untouched. Only `success=True` results are removed.

**Running rollback twice is safe.** The second pass finds the file already gone and moves on.

**Directories with other contents are kept.** Only genuinely empty directories are pruned.

## Tests

`tests/test_rollback_created_files.py` — 12 cases.

The bug: a created file is removed; nothing is left behind after a mixed modify/create rollback; a modified file is still restored.

Directories: a directory created for the file is pruned; nested directories are pruned; a directory that still has files is kept; the repo root is never removed.

Reporting: removed files are reported; rollback returns a list.

Not overreaching: a failed create does not remove an existing file; rollback is safe to run twice; `delete` still rolls back from its backup.

## Verified

- the before/after traces above, against a real `CodeModificationEngine`
- 12 tests pass, plus `test_interrupt_rollback` and `test_module_logging` with no regressions
- ruff on `modules/code_modifier.py` at its baseline of 30 findings
- built on current `main` after #186 and #188

## Pre-existing, not touched

`tests/test_rename_action.py` fails 2 on `main` already — those tests call `_parse_response` with the signature it had before the multi-provider refactor added `input_tok`. Unrelated to this change, but it should probably get its own fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rollback now removes newly created files and cleans up empty directories.
  * Existing files and directories are preserved during rollback.
  * Rollback reports both restored and removed paths.
  * Repeated rollbacks are handled safely, with removal failures logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->