### PR TITLE
docs: add a troubleshooting section to the README — Closes #142

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,6 @@ python main.py --repo . --task "Fix the failing parser test"
 
 ---
 
-
 ### `dashboard.py` — run viewer
 
 Renders a run log as a readable timeline — the model's analysis, its file
@@ -441,7 +440,6 @@ DockerSandbox.sweep_orphaned_containers()   # returns the ids removed
 It is deliberately not automatic. A sweep cannot tell a leaked container from
 one belonging to another agent running right now, so the decision stays with the
 caller.
-
 
 ---
 
@@ -505,6 +503,131 @@ To check the flags against a real daemon rather than trusting the argv:
 
 ```bash
 python scripts/verify_docker_sandbox.py
+```
+
+---
+
+## Troubleshooting
+
+Problems people hit in practice, with the exact message each one produces.
+
+### `ValueError: ANTHROPIC_API_KEY not set`
+
+The key is read from the environment at client construction.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...        # macOS / Linux
+setx ANTHROPIC_API_KEY "sk-ant-..."        # Windows, new shell required
+```
+
+`--api-key` works too, but a key on the command line lands in your shell
+history. For a different provider, `--provider openai|gemini|ollama` reads that
+provider's own variable instead.
+
+### `RuntimeError: anthropic package not installed`
+
+```bash
+pip install -r requirements.txt
+```
+
+### `ERROR: --repo is required (except with --update)`
+
+Every run needs a target repository. `--update` is the one exception, since it
+operates on RepoPilot's own checkout.
+
+### Docker is installed but the sandbox is not isolated
+
+The log says:
+
+```
+DockerSandbox: Docker is unavailable (no CLI on PATH, or no daemon answering).
+Network isolation, the 512MB memory cap and the 1-CPU limit are NOT in effect.
+```
+
+Docker Desktop installed but not _running_ is the usual cause — the binary is on
+PATH, so a presence check passes while the daemon does not answer. Start Docker
+Desktop, or on Linux add yourself to the `docker` group:
+
+```bash
+sudo usermod -aG docker $USER      # log out and back in
+```
+
+Pass `strict=True` to `DockerSandbox` to make an unavailable daemon an error
+rather than a silent fallback.
+
+### Tests "fail" but the code is fine
+
+If the runner itself is missing, its failure looks like a failing suite. A
+missing pytest now falls back to running test files with `python` and says so:
+
+```
+[fallback] pytest was unavailable; ran 3 file(s) with python instead.
+```
+
+Install the runner, or point `--runner` at one that exists. `--runner` accepts
+`pytest`, `npm_test`, `vitest`, `jest`, `go`, `cargo`, `ruby`, `rspec`, `bash`
+and `make`.
+
+### `Runner '<name>' not found or not allowed`
+
+The name is not in `ALLOWED_RUNNERS`, or its executable is not on PATH. The
+allowlist is deliberate — arbitrary commands are not accepted.
+
+### The agent burns iterations without converging
+
+Check what it actually saw before blaming the model:
+
+```bash
+python main.py --repo . --task "..." --context-only     # no API call, no cost
+python main.py --repo . --task "..." --verbose          # exact prompt and response
+```
+
+`--context-only` prints the compiled context and exits, so you can confirm the
+right files were selected without spending anything. `--verbose` prints the
+prompt and the raw reply, with known secret patterns masked.
+
+### Runs cost more than expected
+
+```bash
+python main.py --repo . --task "..." --max-cost 1.00
+```
+
+Stops before the next call once that much has been spent. `--plan-first` costs
+one extra call on the first iteration.
+
+### A run was interrupted or went wrong
+
+```bash
+python main.py --repo . --rollback
+```
+
+Undoes the last run by popping the git stash it took before applying changes.
+
+### `python -m pytest` from the repository root fails to collect
+
+Running the suite from the root fails for reasons unrelated to your change:
+three files share the basename `test_utils.py`, there is no `__init__.py`, and
+there is no pytest configuration. Run targeted paths instead:
+
+```bash
+python -m pytest tests/test_sandbox_env.py -q
+```
+
+### Non-ASCII output looks mangled on Windows
+
+`Path.read_text()` and `open()` default to the locale encoding, which is cp1252
+on a default Windows install. Pass `encoding="utf-8"` explicitly when reading
+project files.
+
+### PowerShell mangles a multi-line `python -c`
+
+The `>>` continuation prompt breaks the string. Write a file instead:
+
+```powershell
+@'
+print("hello")
+'@ | Set-Content -Encoding utf8 tmp.py
+python tmp.py
 ```
 
 ---


### PR DESCRIPTION
Closes #142

## Summary

Adds a `Troubleshooting` section covering the problems people actually hit, each with the exact message it produces.

## Every message is real, not paraphrased

I ran each failure and captured the output rather than writing what I assumed it said:

| situation | actual message |
| --------- | -------------- |
| no API key | `ValueError: ANTHROPIC_API_KEY not set` |
| missing dependency | `RuntimeError: anthropic package not installed. Run: pip install anthropic` |
| no `--repo` | `ERROR: --repo is required (except with --update).` |
| unknown runner | `Runner 'nonesuch' not found or not allowed` |
| Docker installed but not running | the full `DockerSandbox` fallback warning |

That matters because someone searching for their error string only finds the docs if the string matches.

## Every flag was checked against `--help`

And that caught a genuine mistake before it shipped. My first draft documented:

```bash
python main.py --repo . --list-resumable
python main.py --repo . --resume <run_id>
```

Neither flag exists on `main` — the resume feature is still an open PR. Documenting a flag that is not there is worse than documenting nothing, because it sends people looking for a bug in their setup. That block now covers `--rollback`, which does exist.

The remaining six — `--repo`, `--task`, `--context-only`, `--verbose`, `--max-cost`, `--rollback` — are each verified present in `--help`, and all ten runner names are verified against `ALLOWED_RUNNERS`.

## What it covers

Setup: missing API key, missing dependency, missing `--repo`.

Sandbox: Docker installed but not running, including why a presence check passes while the daemon does not answer, plus the Linux `docker` group fix and the `strict=True` option. And the case where tests appear to fail but the runner itself is missing.

Debugging a run that will not converge: `--context-only` to see which files were selected without spending anything, `--verbose` to see the exact prompt and reply. Both point at checking what the model saw before blaming the model.

Cost: `--max-cost`, and the note that `--plan-first` costs an extra call.

Two things that are not bugs but cost people time anyway: `python -m pytest` from the repository root fails to collect, because three files share the basename `test_utils.py` with no `__init__.py` and no pytest config — the fix is to run targeted paths. And non-ASCII output looking mangled on Windows, because `read_text()` defaults to cp1252.

One Windows-specific note on PowerShell mangling a multi-line `python -c` via the `>>` continuation prompt, with the here-string workaround.

## Placed before "Failure Cases & Mitigations"

The existing table is a design document — it explains what the system does about each failure class internally. This section is for someone whose run just stopped and who wants to know why. Different audience, so it sits above rather than merging into it.

## Verified

- every error message reproduced directly rather than recalled
- every documented flag confirmed against `python main.py --help`
- every runner name confirmed against `ALLOWED_RUNNERS`
- `npx prettier --check README.md` clean
- built on current `main` after #186 and #188

Documentation only — no code changes.