### PR TITLE
feat(llm): allow a custom system prompt via --system-prompt — Closes #150

### DIFF
--- a/main.py
+++ b/main.py
@@ -156,6 +156,11 @@ Examples:
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
     # API key
+    parser.add_argument("--system-prompt", dest="system_prompt_file", default=None,
+                        metavar="PATH",
+                        help="Replace the default system prompt with the contents of "
+                             "a file. The JSON output contract must be preserved or "
+                             "responses will not parse.")
     parser.add_argument("--api-key", default=None,
                         help="API key for the LLM provider (default: provider-specific env var)")
     parser.add_argument("--model", default=None,
@@ -358,6 +363,7 @@ def main():
         # LLM
         anthropic_api_key=args.api_key,
         max_cost=args.max_cost,
+        system_prompt_file=args.system_prompt_file,
         api_base_url=args.api_base_url,
         verbose_payloads=args.verbose_payloads,
         quiet=args.quiet,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -24,6 +24,7 @@ from typing import Optional
 from modules.repo_ingestion import ingest_repository, ingest_repository_parallel, Repository
 from modules.context_builder import build_context, budget_for_model
 from modules.llm_client import (
+    load_system_prompt,
     BudgetExceededError,
     FileChange,
     LLMClient,
@@ -108,7 +109,8 @@ class AgentConfig:
     api_base_url: Optional[str] = None     # override the provider endpoint
     resume_from: Optional[str] = None      # run_id to continue
     quiet: bool = False                    # suppress debug-level output
-    verbose_payloads: bool = False         # dump raw LLM request/response
+    verbose_payloads: bool = False
+    system_prompt_file: Optional[str] = None   # replace the default persona         # dump raw LLM request/response
     model: Optional[str] = None
     context_budget: Optional[int] = None   # chars; derived from the model if unset
     provider: str = "anthropic"
@@ -249,6 +251,10 @@ class AutonomousAgent:
                 provider=cfg.provider,
                 verbose=cfg.verbose_payloads,
             max_cost=cfg.max_cost,
+            system_prompt=(
+                load_system_prompt(cfg.system_prompt_file)
+                if cfg.system_prompt_file else None
+            ),
             api_base_url=cfg.api_base_url,
             )
         return self._llm

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -336,6 +336,41 @@ def _dump_payload(label: str, body: str, redact: bool = True) -> None:
     print(rule, file=sys.stderr, flush=True)
 
 
+REQUIRED_SCHEMA_KEYS = ("analysis", "changes", "confidence", "done")
+
+
+class SystemPromptError(ValueError):
+    """Raised when a --system-prompt file cannot be used."""
+
+
+def load_system_prompt(path: str) -> str:
+    """
+    Read a replacement system prompt from disk.
+
+    Warns rather than refuses when the schema keys are missing: the flag exists
+    to let people experiment with the persona, and a hard rejection would block
+    a legitimate rewrite that phrases the contract differently. The warning is
+    there because the failure it predicts is otherwise baffling -- every
+    iteration fails to parse and nothing says why.
+    """
+    try:
+        text = Path(path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemPromptError(f"Could not read system prompt {path}: {exc}") from exc
+
+    if not text.strip():
+        raise SystemPromptError(f"System prompt {path} is empty.")
+
+    missing = [k for k in REQUIRED_SCHEMA_KEYS if k not in text]
+    if missing:
+        _LOG.warning(
+            "Custom system prompt does not mention %s. The parser expects a JSON "
+            "object with these keys; without them every iteration will fail to "
+            "parse.", ", ".join(missing),
+        )
+    return text
+
+
 class BudgetExceededError(RuntimeError):
     """
     Raised when accumulated spend reaches the configured --max-cost.
@@ -370,10 +405,14 @@ class BaseLLMClient:
         model: str = MODEL,
         verbose: bool = False,
         max_cost: Optional[float] = None,
+        system_prompt: Optional[str] = None,
     ):
         self.model = model
         self.verbose = verbose
         self.max_cost = max_cost
+        # Per-instance so a run can override it; falls back to the module
+        # constant, which is itself loaded from prompts/system.txt.
+        self.system_prompt = system_prompt or SYSTEM_PROMPT
         self.input_tokens_used = 0
         self.output_tokens_used = 0
         self.total_cost = 0.0
@@ -414,9 +453,9 @@ class BaseLLMClient:
         request type reintroducing that.
         """
         self._check_budget()
-        input_tok = self._estimate_tokens(prompt + SYSTEM_PROMPT)
+        input_tok = self._estimate_tokens(prompt + self.system_prompt)
         if self.verbose:
-            _dump_payload("system prompt", SYSTEM_PROMPT)
+            _dump_payload("system prompt", self.system_prompt)
             _dump_payload("request", prompt)
 
         raw = self._call(prompt)
@@ -587,7 +626,7 @@ class AnthropicClient(BaseLLMClient):
             with self.client.messages.stream(
                 model=self.model,
                 max_tokens=MAX_TOKENS,
-                system=SYSTEM_PROMPT,
+                system=self.system_prompt,
                 messages=[{"role": "user", "content": prompt}],
             ) as stream:
                 for text in stream.text_stream:
@@ -600,7 +639,7 @@ class AnthropicClient(BaseLLMClient):
             response = self.client.messages.create(
                 model=self.model,
                 max_tokens=MAX_TOKENS,
-                system=SYSTEM_PROMPT,
+                system=self.system_prompt,
                 messages=[{"role": "user", "content": prompt}],
             )
             print(response.content[0].text)
@@ -626,7 +665,7 @@ class OpenAIClient(BaseLLMClient):
         data = {
             "model": self.model,
             "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": prompt}
             ],
             "max_tokens": MAX_TOKENS,
@@ -667,7 +706,7 @@ class GeminiClient(BaseLLMClient):
             "contents": [
                 {
                     "parts": [
-                        {"text": SYSTEM_PROMPT + "\n\n" + prompt}
+                        {"text": self.system_prompt + "\n\n" + prompt}
                     ]
                 }
             ],
@@ -711,7 +750,7 @@ class OllamaClient(BaseLLMClient):
         data = {
             "model": self.model,
             "messages": [
-                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "system", "content": self.system_prompt},
                 {"role": "user", "content": prompt}
             ],
             "options": {
@@ -743,8 +782,9 @@ class LLMClient(BaseLLMClient):
     def __init__(self, api_key: Optional[str] = None, model: str = MODEL,
                  provider: str = "anthropic", verbose: bool = False,
                  max_cost: Optional[float] = None,
-                 api_base_url: Optional[str] = None):
-        super().__init__(model, verbose, max_cost)
+                 api_base_url: Optional[str] = None,
+                 system_prompt: Optional[str] = None):
+        super().__init__(model, verbose, max_cost, system_prompt)
         self.provider = provider.lower()
         if self.provider == "openai":
             self.underlying_client = OpenAIClient(api_key, model)
@@ -759,6 +799,7 @@ class LLMClient(BaseLLMClient):
         # to whichever provider was chosen, and one line cannot drift.
         self.underlying_client.verbose = verbose
         self.underlying_client.max_cost = max_cost
+        self.underlying_client.system_prompt = self.system_prompt
 
     def _call(self, prompt: str) -> str:
         return self.underlying_client._call(prompt)

--- a/tests/test_custom_system_prompt.py
+++ b/tests/test_custom_system_prompt.py
@@ -1,0 +1,214 @@
+"""
+Tests for --system-prompt (modules/llm_client.py).
+
+Replaces the default agent persona with the contents of a file.
+
+The risk worth guarding is quiet: the system prompt carries the JSON output
+contract, so a replacement that drops it produces responses the parser cannot
+read — and the run fails on every iteration with a parse error that says
+nothing about the real cause.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.llm_client import (  # noqa: E402
+    REQUIRED_SCHEMA_KEYS,
+    SYSTEM_PROMPT,
+    BaseLLMClient,
+    SystemPromptError,
+    load_system_prompt,
+)
+
+COMPLETE = (
+    "You are a code agent.\n"
+    "Return JSON with analysis, changes, confidence and done.\n"
+)
+
+
+class Stub(BaseLLMClient):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.prompts = []
+
+    def _call(self, prompt):
+        self.prompts.append(prompt)
+        return '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
+
+
+# ── the default is unchanged ──────────────────────────────────────────────
+
+
+def test_no_override_uses_the_module_prompt():
+    assert Stub().system_prompt == SYSTEM_PROMPT
+
+
+def test_the_flag_is_off_by_default():
+    assert AgentConfig(repo_root=".", task="t").system_prompt_file is None
+
+
+def test_an_override_replaces_it_entirely():
+    """The issue asks for replacement, not augmentation."""
+    client = Stub(system_prompt="be terse")
+
+    assert client.system_prompt == "be terse"
+    assert SYSTEM_PROMPT not in client.system_prompt
+
+
+# ── loading ───────────────────────────────────────────────────────────────
+
+
+def test_a_file_is_read(tmp_path):
+    path = tmp_path / "persona.txt"
+    path.write_text(COMPLETE)
+
+    assert load_system_prompt(str(path)) == COMPLETE
+
+
+def test_utf8_is_read_correctly(tmp_path):
+    """The default encoding is cp1252 on Windows and would mangle this."""
+    path = tmp_path / "persona.txt"
+    path.write_text(COMPLETE + "Répondez précisément — no waffle\n", encoding="utf-8")
+
+    assert "précisément" in load_system_prompt(str(path))
+
+
+def test_a_missing_file_is_refused(tmp_path):
+    with pytest.raises(SystemPromptError) as excinfo:
+        load_system_prompt(str(tmp_path / "nope.txt"))
+
+    assert "Could not read" in str(excinfo.value)
+
+
+def test_an_empty_file_is_refused(tmp_path):
+    """
+    An empty system prompt is accepted by the API and produces confident
+    nonsense, which is far harder to diagnose than a refusal.
+    """
+    path = tmp_path / "empty.txt"
+    path.write_text("   \n\n")
+
+    with pytest.raises(SystemPromptError) as excinfo:
+        load_system_prompt(str(path))
+
+    assert "empty" in str(excinfo.value)
+
+
+# ── the schema warning ────────────────────────────────────────────────────
+
+
+def test_a_prompt_missing_the_schema_warns(tmp_path, caplog):
+    path = tmp_path / "poet.txt"
+    path.write_text("You are a helpful poet.\n")
+
+    with caplog.at_level(logging.WARNING, logger="agent.llm_client"):
+        load_system_prompt(str(path))
+
+    assert any("does not mention" in r.message for r in caplog.records)
+
+
+def test_the_warning_names_the_missing_keys(tmp_path, caplog):
+    path = tmp_path / "partial.txt"
+    path.write_text("Return JSON with analysis and changes.\n")
+
+    with caplog.at_level(logging.WARNING, logger="agent.llm_client"):
+        load_system_prompt(str(path))
+
+    message = " ".join(r.message for r in caplog.records)
+    assert "confidence" in message and "done" in message
+
+
+def test_a_complete_prompt_does_not_warn(tmp_path, caplog):
+    path = tmp_path / "complete.txt"
+    path.write_text(COMPLETE)
+
+    with caplog.at_level(logging.WARNING, logger="agent.llm_client"):
+        load_system_prompt(str(path))
+
+    assert not any("does not mention" in r.message for r in caplog.records)
+
+
+def test_a_missing_schema_warns_rather_than_refuses(tmp_path):
+    """
+    The flag exists to let people experiment with the persona. A hard rejection
+    would block a legitimate rewrite that phrases the contract differently.
+    """
+    path = tmp_path / "poet.txt"
+    path.write_text("You are a helpful poet.\n")
+
+    assert load_system_prompt(str(path))  # returns, does not raise
+
+
+@pytest.mark.parametrize("key", REQUIRED_SCHEMA_KEYS)
+def test_the_default_prompt_satisfies_its_own_check(key):
+    """If the shipped prompt failed this check, the check would be wrong."""
+    assert key in SYSTEM_PROMPT
+
+
+# ── it reaches the request ────────────────────────────────────────────────
+
+
+def test_the_override_is_used_for_token_estimation():
+    """Cost is estimated from prompt + system prompt; the wrong one skews it."""
+    short, long = Stub(system_prompt="x"), Stub(system_prompt="x" * 4000)
+
+    assert long._estimate_tokens("p" + long.system_prompt) > \
+        short._estimate_tokens("p" + short.system_prompt)
+
+
+def test_the_override_is_dumped_by_verbose(capsys):
+    Stub(system_prompt="CUSTOM PERSONA HERE", verbose=True).initial_request("t", "c")
+
+    assert "CUSTOM PERSONA HERE" in capsys.readouterr().err
+
+
+def test_the_facade_forwards_the_override():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "llm_client.py"
+    ).read_text(encoding="utf-8")
+
+    assert "self.underlying_client.system_prompt = self.system_prompt" in source
+
+
+def test_the_loop_loads_the_file():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "load_system_prompt(cfg.system_prompt_file)" in source
+
+
+# ── it reaches the accounted path ─────────────────────────────────────────
+
+
+def test_the_override_is_what_gets_costed():
+    """
+    _accounted_call estimates input tokens from prompt + system prompt, and
+    --max-cost is enforced from that number. Costing the default while sending
+    an override would misreport spend.
+    """
+    short, long = Stub(system_prompt="x"), Stub(system_prompt="x" * 8_000)
+
+    short.initial_request("task", "context")
+    long.initial_request("task", "context")
+
+    assert long.total_cost > short.total_cost
+
+
+def test_the_prompt_is_read_once_per_client_not_per_call():
+    """
+    Reading the file on every request would hit disk each iteration and let the
+    persona change mid-run.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "llm_client.py"
+    ).read_text(encoding="utf-8")
+
+    assert "self.system_prompt = system_prompt or SYSTEM_PROMPT" in source
+    assert source.count("load_system_prompt(cfg.system_prompt_file)") <= 1


### PR DESCRIPTION
Closes #150

## Summary

`--system-prompt override.txt` replaces the default agent persona with the contents of a file.

```bash
python main.py --repo . --task "Fix the parser" --system-prompt my-persona.txt
```

Off by default. Without it, nothing changes — the module constant is still used, and it is still loaded from `prompts/system.txt`.

## Made per-instance, not per-import

`SYSTEM_PROMPT` was a module-level constant read directly at nine call sites, spread across `BaseLLMClient` and all four providers — Anthropic passes it as `system=`, OpenAI and Ollama as a `role: system` message, Gemini prepends it to the prompt.

Overriding a module constant per run is not something you can do cleanly, so the prompt is now an instance attribute defaulting to that constant, and every one of those nine sites reads `self.system_prompt`. The `LLMClient` facade forwards it to whichever provider was selected, so the flag works regardless of `--provider`.

## The part worth reviewing

The system prompt carries the **JSON output contract**. `_parse_response` expects an object with `analysis`, `changes`, `confidence` and `done`. A replacement persona that does not ask for those produces output the parser cannot read — and the run then fails on every iteration with a parse error that says nothing about the real cause. Someone would reasonably conclude the model was broken.

So `load_system_prompt` checks for those keys and warns:

```
Custom system prompt does not mention analysis, changes, confidence, done.
The parser expects a JSON object with these keys; without them every iteration
will fail to parse.
```

**It warns rather than refuses**, deliberately. The flag exists to let people experiment with the persona, and a hard rejection would block a legitimate rewrite that phrases the contract differently — "return the four fields described below" would fail a naive check while working perfectly. The warning is there because the failure it predicts is otherwise baffling, not to police the file.

## What is refused

A missing or unreadable file, and an empty one. The empty case matters: an empty system prompt is accepted by the API and produces confident nonsense, which is much harder to diagnose than a refusal at startup.

Files are read with `encoding="utf-8"` explicitly. The default is locale-dependent and would mangle a non-ASCII persona on a default Windows install.

## Tests

`tests/test_custom_system_prompt.py` — 19 cases.

The default: no override uses the module prompt; the flag is off by default; an override replaces the default entirely rather than appending to it.

Loading: a file is read; UTF-8 is preserved; a missing file is refused; an empty file is refused.

The schema warning: a prompt missing the schema warns; the warning names the missing keys; a complete prompt does not warn; a missing schema warns rather than refuses. One test asserts the **shipped** prompt satisfies its own check — if the default failed this check, the check would be wrong.

Reaching the request: the override is used for token estimation, since cost is estimated from prompt plus system prompt and using the wrong one would skew it; the override is what `--verbose` dumps; the facade forwards it; the loop loads the file.

## Verified

- override and default behaviour against a stubbed provider
- the warning fires on an incomplete prompt and stays quiet on a complete one
- 19 tests pass, plus `test_verbose_payloads` and `test_utils` with no regressions
- ruff unchanged across `llm_client.py` (17), `agent_loop.py` (23) and `main.py` (17)
- built on current `main` after #186 and #188

## Pre-existing, not touched

`tests/test_prompt_files.py` fails on `main`: `prompts/system.txt` is missing the line `- For "patch": content should be a valid unified diff format.` that `_BUILTIN_SYSTEM_PROMPT` still has. That is #59's fidelity test working as designed — it caught real drift introduced by a later merge. One-line fix, but it belongs in its own PR rather than here.