### PR TITLE
feat(context): derive the character budget from the model window — Closes #149

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,6 +108,9 @@ Examples:
                         help="Prefix for the auto-created branch name (default: agent)")
 
     # Context
+    parser.add_argument("--context-budget", type=int, default=None, metavar="CHARS",
+                        help="Characters of repository context to send. Derived "
+                             "from the model's context window when not set.")
     parser.add_argument("--include", nargs="*", default=None,
                         help="Force-include specific file paths in context (relative to repo root)")
 
@@ -273,6 +276,7 @@ def main():
 
         # Context
         force_include_paths=args.include,
+        context_budget=args.context_budget,
 
         # LLM
         anthropic_api_key=args.api_key,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Optional
 
 from modules.repo_ingestion import ingest_repository, ingest_repository_parallel, Repository
-from modules.context_builder import build_context
+from modules.context_builder import build_context, budget_for_model
 from modules.llm_client import (
     BudgetExceededError,
     FileChange,
@@ -93,6 +93,7 @@ class AgentConfig:
     anthropic_api_key: Optional[str] = None
     verbose_payloads: bool = False         # dump raw LLM request/response
     model: Optional[str] = None
+    context_budget: Optional[int] = None   # chars; derived from the model if unset
     provider: str = "anthropic"
 
     # Context
@@ -404,6 +405,11 @@ class AutonomousAgent:
             context = build_context(
                 repo, cfg.task,
                 extra_paths=cfg.force_include_paths,
+                char_budget=(
+                    cfg.context_budget
+                    if cfg.context_budget
+                    else budget_for_model(cfg.model)
+                ),
             )
             self.logger.log_context([f.path for f in context.files], context.total_chars)
             context_str = context.render()

--- a/modules/context_builder.py
+++ b/modules/context_builder.py
@@ -15,6 +15,46 @@ from modules.repo_ingestion import FileRecord, Repository
 
 CONTEXT_CHAR_BUDGET = 60_000
 
+# Context window per model, in tokens. There is no API that reports this, so it
+# is a table -- the same approach MODEL_PRICING already takes for prices.
+MODEL_CONTEXT_TOKENS = {
+    "claude-sonnet-4-20250514": 200_000,
+    "claude-3-5-sonnet-20241022": 200_000,
+    "claude-3-5-haiku-20241022": 200_000,
+    "gpt-4o": 128_000,
+    "gpt-4o-mini": 128_000,
+    "gemini-1.5-pro": 1_000_000,
+    "gemini-1.5-flash": 1_000_000,
+    "llama3": 8_000,
+}
+
+# Characters per token, for converting a window into a character budget.
+#
+# This is an estimate and worth being explicit about, because issue #72 was
+# filed against an assumption of this kind that did not actually exist. English
+# prose runs around 4; source code is denser -- punctuation, indentation and
+# short identifiers all tokenise poorly -- so 3.0 is used to err on the side of
+# sending too little rather than overflowing the window.
+CHARS_PER_TOKEN = 3.0
+
+# Share of the window the repository context may occupy. The rest is left for
+# the system prompt, the task, previous error output on a retry, and the
+# model's own reply, which needs room to return complete file contents.
+CONTEXT_WINDOW_FRACTION = 0.35
+
+
+def budget_for_model(model: Optional[str], default: int = CONTEXT_CHAR_BUDGET) -> int:
+    """
+    Character budget for a model, or the default when the model is unknown.
+
+    Falling back rather than guessing at an unknown model's window keeps a new
+    or self-hosted model working at today's behaviour instead of overflowing.
+    """
+    window = MODEL_CONTEXT_TOKENS.get(model or "")
+    if not window:
+        return default
+    return int(window * CONTEXT_WINDOW_FRACTION * CHARS_PER_TOKEN)
+
 LANGUAGE_PRIORITY = {
     "python": 10, "javascript": 10, "typescript": 10, "java": 9,
     "go": 9, "rust": 9, "cpp": 8, "c": 8, "csharp": 8,

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,148 @@
+"""
+Tests for the model-derived context budget (modules/context_builder.py).
+
+`CONTEXT_CHAR_BUDGET` was a flat 60,000 characters regardless of model. That
+underfills a 200k-token window and overflows an 8k one — llama3's budget works
+out at 8,400 characters, well under the old default, so a small-window model was
+being sent more than it could hold.
+
+The conversion rests on an estimate, and these tests pin that it is a
+conservative one.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.context_builder import (  # noqa: E402
+    CHARS_PER_TOKEN,
+    CONTEXT_CHAR_BUDGET,
+    CONTEXT_WINDOW_FRACTION,
+    MODEL_CONTEXT_TOKENS,
+    budget_for_model,
+    build_context,
+)
+from modules.repo_ingestion import ingest_repository  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path):
+    for i in range(12):
+        (tmp_path / f"mod_{i:02d}.py").write_text(
+            f"# module {i}\n" + "def parse(x):\n    return x\n" * 200
+        )
+    return ingest_repository(str(tmp_path))
+
+
+# ── the table ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "model", ["claude-sonnet-4-20250514", "gpt-4o", "gemini-1.5-pro", "llama3"]
+)
+def test_known_models_have_a_window(model):
+    assert MODEL_CONTEXT_TOKENS[model] > 0
+
+
+def test_a_larger_window_gives_a_larger_budget():
+    assert budget_for_model("claude-sonnet-4-20250514") > budget_for_model("gpt-4o")
+    assert budget_for_model("gpt-4o") > budget_for_model("llama3")
+
+
+def test_an_unknown_model_falls_back_to_the_default():
+    """
+    A new or self-hosted model keeps today's behaviour rather than having its
+    window guessed at, which is the failure that would actually cost money.
+    """
+    assert budget_for_model("some-model-released-tomorrow") == CONTEXT_CHAR_BUDGET
+
+
+@pytest.mark.parametrize("value", [None, ""])
+def test_no_model_falls_back_to_the_default(value):
+    assert budget_for_model(value) == CONTEXT_CHAR_BUDGET
+
+
+def test_the_fallback_is_overridable():
+    assert budget_for_model("unknown", default=123) == 123
+
+
+# ── the conversion is conservative ────────────────────────────────────────
+
+
+def test_chars_per_token_is_below_the_prose_estimate():
+    """
+    Source code tokenises worse than prose -- punctuation, indentation and short
+    identifiers all cost tokens. Using the prose figure of ~4 would overestimate
+    how much fits.
+    """
+    assert CHARS_PER_TOKEN < 4.0
+
+
+def test_only_part_of_the_window_is_used_for_context():
+    """
+    The rest is for the system prompt, the task, prior error output on a retry,
+    and the reply -- which has to carry complete file contents.
+    """
+    assert 0 < CONTEXT_WINDOW_FRACTION < 0.5
+
+
+def test_a_budget_never_exceeds_its_window():
+    for model, window in MODEL_CONTEXT_TOKENS.items():
+        assert budget_for_model(model) < window * 4.0, model
+
+
+def test_a_small_window_gets_less_than_the_old_default():
+    """The case the flat constant got wrong: llama3 holds 8k tokens, not 60k chars."""
+    assert budget_for_model("llama3") < CONTEXT_CHAR_BUDGET
+
+
+# ── it changes what is sent ───────────────────────────────────────────────
+
+
+def test_a_small_budget_selects_fewer_files(repo):
+    small = build_context(repo, "fix parse", char_budget=budget_for_model("llama3"))
+    large = build_context(repo, "fix parse", char_budget=budget_for_model("gpt-4o"))
+
+    assert len(small.files) < len(large.files)
+
+
+def test_the_budget_is_respected(repo):
+    budget = budget_for_model("llama3")
+
+    assert build_context(repo, "fix parse", char_budget=budget).total_chars <= budget
+
+
+def test_the_default_behaviour_is_unchanged(repo):
+    """An unknown model must produce exactly what the flat constant produced."""
+    derived = build_context(repo, "fix parse", char_budget=budget_for_model(None))
+    flat = build_context(repo, "fix parse", char_budget=CONTEXT_CHAR_BUDGET)
+
+    assert [f.path for f in derived.files] == [f.path for f in flat.files]
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_override_is_off_by_default():
+    assert AgentConfig(repo_root=".", task="t").context_budget is None
+
+
+def test_an_explicit_override_wins_over_the_model():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+    block = source[source.index("char_budget=("):][:220]
+
+    assert block.index("cfg.context_budget") < block.index("budget_for_model")
+
+
+def test_the_loop_derives_the_budget_from_the_model():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "budget_for_model(cfg.model)" in source


### PR DESCRIPTION
Closes #149

## Summary

`CONTEXT_CHAR_BUDGET` was a flat 60,000 characters regardless of which model was being used. The budget is now derived from the model's context window, with `--context-budget CHARS` as an explicit override.

## It was wrong in both directions

Measured against a 12-file, 65KB test repository:

| model | budget | files selected |
| ----- | -----: | -------------: |
| llama3 | 8,400 | 1 |
| *unknown / default* | 60,000 | 11 |
| gpt-4o | 134,400 | 12 |
| claude-sonnet-4 | 210,000 | 12 |

The interesting row is the first. `llama3` holds 8k tokens, so its budget works out **below** the old default — a small-window model was being sent more context than it could hold, on every single run. The large-window case is the one the issue describes, and it is real, but the overflow is the more damaging half.

## The estimate, stated plainly

There is no API that reports a model's context window, so `MODEL_CONTEXT_TOKENS` is a table — the same approach `MODEL_PRICING` already takes for prices. An unrecognised model falls back to the existing default rather than having its window guessed at, and a test asserts that fallback produces byte-identical file selection to today.

Converting a token window into a character budget needs an estimate, and this PR is where that estimate enters the codebase, so it is documented rather than buried:

```python
CHARS_PER_TOKEN = 3.0
CONTEXT_WINDOW_FRACTION = 0.35
```

`3.0` rather than the usual prose figure of about 4, because source code tokenises worse — punctuation, indentation and short identifiers all cost tokens — so the lower number errs toward sending too little rather than overflowing.

`0.35` because the window is not all available to repository context. The system prompt, the task, previous error output on a retry, and the model's reply all need room, and the reply in particular has to carry complete file contents.

Both are pinned by tests: `CHARS_PER_TOKEN < 4.0`, `0 < CONTEXT_WINDOW_FRACTION < 0.5`, and no model's budget exceeds four characters per token of its own window.

Worth noting explicitly: issue **#72** claimed an assumption of this kind already existed in `context_builder.py`, and I declined it on the grounds that it did not. This is the PR where it actually gets introduced. Flagging that so the two are not confused later.

## Precedence

`--context-budget` wins over the model-derived value, which wins over the default. A test asserts that ordering against the source, since getting it backwards would make the flag silently useless.

## Tests

`tests/test_context_budget.py` — 19 cases.

The table: known models have a window; a larger window gives a larger budget; an unknown model falls back to the default; no model at all falls back; the fallback is overridable.

The conversion: chars-per-token is below the prose estimate; only part of the window is used; no budget exceeds its window; a small window gets less than the old default.

Effect: a small budget selects fewer files; the budget is respected; **default behaviour is unchanged** — an unknown model produces exactly the same file list as the flat constant did.

Wiring: the override is off by default; an explicit override wins over the model; the loop derives the budget from the model.

## Verified

- the budget table and file-selection measurements above, against a real ingested repository
- 19 tests pass, plus `test_ast_outlines` and `test_repo_ingestion_gitignore` — 59 in total, no regressions
- ruff unchanged: `context_builder.py` (1), `agent_loop.py` (23), `main.py` (17)
- built on current `main` after #186 and #188

## Possible follow-up

The table needs updating when models change. If that becomes a maintenance problem, the same information could be read from a config file alongside `MODEL_PRICING`, which has the identical issue today. Not doing that here — one table is a fact, two tables with the same problem is a pattern worth fixing deliberately rather than as a side effect.