### PR TITLE
perf(context): bound import scanning and precompile patterns — Closes #147

### DIFF
--- a/modules/context_builder.py
+++ b/modules/context_builder.py
@@ -201,6 +201,43 @@ def _extract_keywords(task: str) -> list[str]:
     return [token for token in tokens if token not in stopwords and len(token) > 2]
 
 
+# Compiled once at import rather than on every file. Python caches compiled
+# patterns internally, but the cache is keyed on the pattern string and still
+# costs a lookup per call -- and scoring runs these three against every file in
+# the repository, on every iteration.
+IMPORT_PATTERNS = [
+    re.compile(r"^import\s+(\w+)", re.MULTILINE),
+    re.compile(r"^from\s+(\w+)", re.MULTILINE),
+    re.compile(r"""require\(['"]([^'"]+)['"]""", re.MULTILINE),
+]
+
+# Imports appear at the top of a file by convention in every language this
+# scores. Scanning the whole of a 300KB minified bundle for `^import` finds
+# nothing and costs the most of any single step -- and on minified output there
+# are no line starts at all, so re.MULTILINE scans the entire blob for anchors
+# that cannot exist.
+IMPORT_SCAN_CHARS = 8_000
+
+# Languages with no import syntax worth scanning for.
+NON_CODE_LANGUAGES = frozenset({
+    "json", "yaml", "toml", "xml", "markdown", "text", "css", "scss",
+    "ini", "config", "env", "sql", "unknown",
+})
+
+
+def _extract_imports(content: str, language: str) -> set[str]:
+    """Module names imported near the top of a file."""
+    if language in NON_CODE_LANGUAGES:
+        return set()
+
+    head = content[:IMPORT_SCAN_CHARS]
+    modules: set[str] = set()
+    for pattern in IMPORT_PATTERNS:
+        for match in pattern.finditer(head):
+            modules.add(match.group(1).lower().split(".")[0])
+    return modules
+
+
 def _score_file(record: FileRecord, keywords: list[str], task: str) -> ScoredFile:
     score = 0.0
     reasons = []
@@ -250,15 +287,7 @@ def _score_file(record: FileRecord, keywords: list[str], task: str) -> ScoredFil
     elif is_test:
         score -= 3
 
-    import_patterns = [
-        r"^import\s+(\w+)",
-        r"^from\s+(\w+)",
-        r"require\(['\"]([^'\"]+)['\"]",
-    ]
-    imported_modules: set[str] = set()
-    for pattern in import_patterns:
-        for match in re.finditer(pattern, record.content, re.MULTILINE):
-            imported_modules.add(match.group(1).lower().split(".")[0])
+    imported_modules = _extract_imports(record.content, record.language)
 
     import_hits = sum(1 for keyword in keywords if keyword in imported_modules)
     if import_hits:

--- a/tests/test_scoring_performance.py
+++ b/tests/test_scoring_performance.py
@@ -1,0 +1,181 @@
+"""
+Tests for context scoring performance (modules/context_builder.py).
+
+`_score_file` runs against every file in the repository on every iteration, and
+the import-extraction regexes dominated it: 4.5ms of 6.3ms on a 320KB minified
+bundle. re.MULTILINE on a single enormous line scans the whole blob looking for
+line anchors that cannot exist.
+
+The optimisation must not change which files get selected, so most of what
+follows is about equivalence rather than speed.
+"""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.context_builder import (  # noqa: E402
+    IMPORT_PATTERNS,
+    IMPORT_SCAN_CHARS,
+    NON_CODE_LANGUAGES,
+    _extract_imports,
+    _score_file,
+    build_context,
+)
+from modules.repo_ingestion import FileRecord, ingest_repository  # noqa: E402
+
+
+def record(content, language="python", path="mod.py"):
+    return FileRecord(
+        path=path, abs_path=f"/{path}", content=content, size=len(content),
+        extension=Path(path).suffix, language=language, checksum="x",
+    )
+
+
+# ── imports are still found ───────────────────────────────────────────────
+
+
+def test_python_imports_are_found():
+    found = _extract_imports("import os\nfrom pathlib import Path\nimport requests\n", "python")
+
+    assert found == {"os", "pathlib", "requests"}
+
+
+def test_javascript_requires_are_found():
+    found = _extract_imports("const fs = require('fs');\nvar _ = require(\"lodash\");\n", "javascript")
+
+    assert found == {"fs", "lodash"}
+
+
+def test_dotted_imports_keep_only_the_root():
+    assert _extract_imports("import os.path\n", "python") == {"os"}
+
+
+def test_imports_after_a_comment_are_found():
+    assert _extract_imports("# header\n\nimport numpy as np\n", "python") == {"numpy"}
+
+
+def test_an_indented_import_is_not_matched():
+    """The patterns are line-anchored; a function-local import is not a signal."""
+    assert _extract_imports("def f():\n    import os\n", "python") == set()
+
+
+# ── the scan is bounded ───────────────────────────────────────────────────
+
+
+def test_the_scan_is_limited_to_the_head():
+    """
+    Imports are at the top by convention in every language scored here. The
+    bound is what makes a 300KB file cheap.
+    """
+    assert IMPORT_SCAN_CHARS <= 32_000
+
+
+def test_an_import_beyond_the_bound_is_not_scanned():
+    content = ("# filler\n" * (IMPORT_SCAN_CHARS // 9 + 100)) + "import buried\n"
+
+    assert "buried" not in _extract_imports(content, "python")
+
+
+def test_an_import_within_the_bound_is_found():
+    content = "import early\n" + ("# filler\n" * 500)
+
+    assert "early" in _extract_imports(content, "python")
+
+
+@pytest.mark.parametrize("language", ["json", "markdown", "css", "text", "unknown"])
+def test_non_code_languages_are_skipped_entirely(language):
+    assert _extract_imports("import os\n", language) == set()
+
+
+def test_code_languages_are_not_skipped():
+    assert "python" not in NON_CODE_LANGUAGES
+    assert "javascript" not in NON_CODE_LANGUAGES
+
+
+# ── patterns are compiled once ────────────────────────────────────────────
+
+
+def test_patterns_are_precompiled():
+    """Recompiling per file costs a cache lookup on every file, every iteration."""
+    for pattern in IMPORT_PATTERNS:
+        assert hasattr(pattern, "finditer")
+
+
+def test_all_three_patterns_are_kept():
+    assert len(IMPORT_PATTERNS) == 3
+
+
+# ── behaviour is unchanged ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def corpus(tmp_path):
+    for name in ("parser", "sandbox", "client", "logger"):
+        (tmp_path / f"{name}.py").write_text(
+            f"import os\nimport re\n\ndef {name}_run(x):\n    return x\n" * 20
+        )
+    (tmp_path / "bundle.min.js").write_text("var a=1;" * 20000)
+    (tmp_path / "README.md").write_text("# project\n" * 40)
+    return ingest_repository(str(tmp_path))
+
+
+def test_scoring_still_ranks_the_relevant_file_first(corpus):
+    context = build_context(corpus, "fix the parser bug")
+
+    assert context.files[0].path == "parser.py"
+
+
+def test_a_minified_bundle_is_still_scored_not_skipped(corpus):
+    """Bounding the scan must not remove the file from consideration."""
+    scored = _score_file(record("var a=1;" * 20000, "javascript", "bundle.min.js"), ["a"], "t")
+
+    assert scored.score is not None
+
+
+def test_import_matches_still_raise_the_score():
+    keywords = ["requests"]
+    with_import = _score_file(record("import requests\nx = 1\n"), keywords, "use requests")
+    without = _score_file(record("x = 1\n"), keywords, "use requests")
+
+    assert with_import.score > without.score
+
+
+# ── it is actually faster ─────────────────────────────────────────────────
+
+
+def test_a_minified_file_scores_quickly():
+    """
+    The reported symptom. Generous threshold -- CI machines vary, and the point
+    is catching a regression back to whole-file scanning, not policing ms.
+    """
+    minified = record("var a=1;" * 40000, "javascript", "bundle.min.js")
+    keywords = ["parse", "parser", "function"]
+
+    start = time.perf_counter()
+    for _ in range(10):
+        _score_file(minified, keywords, "fix the parse function")
+    elapsed = (time.perf_counter() - start) / 10
+
+    assert elapsed < 0.05
+
+
+def test_scoring_cost_does_not_scale_with_file_size():
+    """
+    A file 10x larger should not cost 10x, now that the import scan is bounded.
+    """
+    keywords = ["parse"]
+    small = record("import os\n" + "def parse(x):\n    return x\n" * 500)
+    large = record("import os\n" + "def parse(x):\n    return x\n" * 5000)
+
+    def timed(rec):
+        start = time.perf_counter()
+        for _ in range(5):
+            _score_file(rec, keywords, "fix parse")
+        return (time.perf_counter() - start) / 5
+
+    assert timed(large) < timed(small) * 8


### PR DESCRIPTION
Closes #147

## Profiled first

`_score_file` runs against every file in the repository, on every iteration. Before assuming the issue was right about regexes, I measured a 320KB minified bundle:

```
total 6.3ms  |  .count() 1.0ms  |  regex 4.5ms
```

The issue is right. Import extraction is 71% of scoring cost on the file type it names.

## Why it was so expensive

Three patterns run with `re.MULTILINE` over the whole file. On minified output there are no line breaks at all, so `^import` and `^from` can never match — but the engine still scans the entire 320KB looking for line anchors that do not exist.

Three changes, in order of impact:

**The scan is bounded to the first 8,000 characters.** Imports appear at the top of a file by convention in every language scored here — Python, JavaScript, TypeScript, Go, Rust. Scanning further finds nothing and costs the most.

**Non-code languages are skipped entirely.** JSON, Markdown, CSS, YAML, plain text and unknown files have no import syntax worth matching.

**Patterns are compiled once at import.** Python caches compiled patterns internally, but the cache is keyed on the pattern string and still costs a lookup per call — three lookups per file, every file, every iteration.

## Result

```
minified js 320KB    5.73ms -> 1.24ms    4.6x
large python 200KB   4.05ms -> 0.93ms    4.4x
normal python 4KB    0.08ms -> 0.06ms
```

Small files were never the problem and are unchanged.

## Selection is identical

This is the property that actually matters — a faster scorer that picks different files is not an optimisation, it is a behaviour change.

Verified across five tasks on a **fixed corpus** — twelve source files, matching test files, a minified bundle and a README:

```
selection IDENTICAL across 5 tasks
```

My first attempt compared against this repository and showed a difference. That was an artefact: I was scoring the repository containing the file I had just edited, so `context_builder.py`'s own content had changed. Worth mentioning because the first result looked like a regression and was not.

## The bound is a judgement call

8,000 characters is generous for a convention that usually holds within the first few hundred, but it is a real limit and a file with imports below it would lose those signals. Two things make that acceptable:

- import matches are one of several scoring components, worth `4 * hits` alongside path matching, content matching, language priority and entry-point detection. Losing them degrades ranking slightly rather than dropping a file.
- there is a test asserting an import beyond the bound is not scanned, so the behaviour is documented rather than incidental.

Happy to raise the bound if you would rather trade some of the speedup for certainty.

## Tests

`tests/test_scoring_performance.py` — 21 cases.

Imports still found: Python imports; JavaScript `require`; dotted imports keep only the root; imports after a comment; an indented function-local import is correctly **not** matched, since the patterns are line-anchored.

The bound: the scan is limited to the head; an import beyond the bound is not scanned; an import within it is found; five non-code languages are skipped; code languages are not.

Compilation: patterns are precompiled; all three are kept.

Behaviour: scoring still ranks the relevant file first; a minified bundle is still scored rather than skipped; import matches still raise the score.

Speed: a minified file scores quickly; cost does not scale linearly with file size. Both thresholds are deliberately loose — 50ms against a measured 1.2ms, and 8x on the scaling check — because CI machines vary and the point is catching a regression back to whole-file scanning, not policing milliseconds.

## Verified

- the profile and the before/after benchmarks above
- identical selection across five tasks on a fixed corpus
- 21 tests pass, plus `test_ast_outlines` and `test_context_only` with no regressions
- ruff on `modules/context_builder.py` at its baseline of 1 finding
- built on current `main` after #186 and #188