### PR TITLE
ci: add a smoke run and structural checks to the import guard - Closes #198

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -84,3 +84,67 @@ jobs:
 
           print(f"{len(flags)} CLI flags, no duplicates")
           PY
+
+      - name: Every args.X is registered
+        # main.py referenced args.list_resumable while the flag itself was lost
+        # in a merge. --help still passed, because argparse only fails on a flag
+        # it is asked for -- not on one the code reads and it never declared.
+        run: |
+          python - <<'PY'
+          import re, sys
+
+          source = open("main.py").read()
+          used = set(re.findall(r"args\.(\w+)", source))
+
+          declared = set(
+              re.findall(r'add_argument\([^)]*?dest="(\w+)"', source, re.S)
+          )
+          declared |= {
+              flag.replace("-", "_")
+              for flag in re.findall(r'add_argument\(\s*"--([a-z0-9-]+)"', source)
+          }
+
+          missing = sorted(used - declared)
+          for name in missing:
+              print(f"FAIL args.{name} is read but never registered")
+
+          if missing:
+              sys.exit(1)
+
+          print(f"{len(used)} args references, all registered")
+          PY
+
+      - name: AgentConfig accepts everything main.py passes
+        # main.py passed plan_first and resume_from after both fields were lost
+        # from the dataclass, so every run died with TypeError at construction.
+        run: |
+          python - <<'PY'
+          import dataclasses, re, sys
+
+          from modules.agent_loop import AgentConfig
+
+          fields = {f.name for f in dataclasses.fields(AgentConfig)}
+          source = open("main.py").read()
+          block = source[source.index("config = AgentConfig("):]
+          block = block[: block.index("\n    )")]
+          passed = set(re.findall(r"^\s+(\w+)=", block, re.MULTILINE))
+
+          missing = sorted(passed - fields)
+          for name in missing:
+              print(f"FAIL main.py passes {name}=, AgentConfig has no such field")
+
+          if missing:
+              sys.exit(1)
+
+          print(f"{len(passed)} config arguments, all accepted")
+          PY
+
+      - name: Smoke run
+        # The check the guard was missing. --context-only compiles the context
+        # and returns before any provider call, so this exercises argparse,
+        # config construction, ingestion, context building and the run summary
+        # without an API key and without spending anything.
+        run: |
+          python main.py --repo . --task "smoke" --no-git --context-only > /tmp/smoke.txt
+          tail -5 /tmp/smoke.txt
+          grep -q "No API call was made" /tmp/smoke.txt


### PR DESCRIPTION
Closes #198 

The import guard verifies that every module imports and that `main.py --help` starts. Both of those passed while `main.py` crashed on every real invocation — the failures were at call time, past where an import check reaches.

Three things got through:

```
AttributeError: 'Namespace' object has no attribute 'list_resumable'
TypeError: AgentConfig.__init__() got an unexpected keyword argument 'plan_first'
```

`--help` succeeds in both cases. argparse only fails on a flag it is *asked for*, not on one the code reads and it never declared; and a dataclass only rejects an unknown keyword when something actually constructs it.

## Three steps added

**Every `args.X` is registered.** Cross-checks every `args.something` read in `main.py` against what argparse declares, matching both `--flag-name` and explicit `dest=`.

**`AgentConfig` accepts everything `main.py` passes.** Imports the dataclass, reads the `AgentConfig(...)` call out of `main.py`, and compares the keywords against the real fields.

**Smoke run.** The check that was missing:

```bash
python main.py --repo . --task "smoke" --no-git --context-only
```

`--context-only` compiles the repository context, prints it, and returns before any provider call. So this exercises argparse, config construction, ingestion, context building, outlining and the run summary — with **no API key and no cost**. The step greps for `No API call was made` so a silent early exit cannot pass.

## Verified against the actual bug

Run against the broken tree, each step fails and names the problem:

```
FAIL args.list_resumable is read but never registered
FAIL main.py passes plan_first=, AgentConfig has no such field
smoke run: exit 1
```

Against the repaired tree, all three exit 0. Both checks currently report clean on `main`.

## Why it belongs in this workflow

It is the same question — "does this actually work" — asked one layer deeper, and it has no dependency on the test suite. That matters: nine test files currently fail on `main` for unrelated reasons, so a guard that depended on them would be permanently red and quickly ignored.

The smoke run needs no credentials, makes no network request, and takes a few seconds.

## Honest limit

This catches wiring, not behaviour. A run that reaches the provider and then does the wrong thing still passes, and it always will — that is what the test suite is for. What it guarantees is narrower and worth having on its own: the CLI starts, the config assembles, and the pipeline runs end to end.