### PR TITLE
feat(context): load per-repo rules from .agentcontext — Closes #148

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,11 @@ Examples:
     parser.add_argument("--context-budget", type=int, default=None, metavar="CHARS",
                         help="Characters of repository context to send. Derived "
                              "from the model's context window when not set.")
+    parser.add_argument("--project-rules", dest="project_rules_file",
+                        default=".agentcontext", metavar="PATH",
+                        help="Per-repo rules file, read from the repo root and "
+                             "prepended to every prompt. Pass an empty string to "
+                             "disable.")
     parser.add_argument("--include", nargs="*", default=None,
                         help="Force-include specific file paths in context (relative to repo root)")
 
@@ -282,6 +287,7 @@ def main():
 
         # Context
         force_include_paths=args.include,
+        project_rules_file=args.project_rules_file,
         context_budget=args.context_budget,
 
         # LLM

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -39,6 +39,7 @@ from modules.sandbox import (
 from modules.git_integration import GitIntegration
 from modules.doc_lookup import perform_lookups, render_lookups
 from modules.run_state import check_resumable, clear_state, load_state, save_state
+from modules.project_rules import load_project_rules, render_project_rules
 from modules.logger import AgentLogger, IterationRecord
 from modules.secret_scanner import scan_directory, format_findings
 from modules.token_tracker import TokenTracker
@@ -101,6 +102,7 @@ class AgentConfig:
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
+    project_rules_file: str = ".agentcontext"   # per-repo rules, "" to disable
 
     # Parallel Processing
     parallel: bool = False
@@ -452,6 +454,19 @@ class AutonomousAgent:
             )
             self.logger.log_context([f.path for f in context.files], context.total_chars)
             context_str = context.render()
+
+            # Prepended rather than folded into the file context: when the
+            # budget is tight, files get dropped or outlined, and the project's
+            # own rules should not be the thing that falls out.
+            if cfg.project_rules_file:
+                rules = load_project_rules(cfg.repo_root, cfg.project_rules_file)
+                if rules:
+                    if iteration == 1:
+                        self.logger.info(
+                            f"  Project rules: {cfg.project_rules_file} "
+                            f"({len(rules):,} chars)"
+                        )
+                    context_str = render_project_rules(rules) + "\n\n" + context_str
 
             if cfg.context_only:
                 # Before the LLM call, so this costs nothing. --dry-run already

--- a/modules/project_rules.py
+++ b/modules/project_rules.py
@@ -1,0 +1,89 @@
+"""
+Module: Project rules.
+
+A `.agentcontext` file at the repository root carries instructions that apply to
+every task in that repository — "this project targets Python 3.9, do not use
+match statements", "tests live in spec/ not tests/", "never edit generated/".
+
+These are different from `.repopilot.json`, which sets CLI defaults. That file
+answers "how should the tool be invoked"; this one answers "what should the
+model know before it writes anything".
+
+Kept separate from the file context because the two behave differently under
+pressure: when the character budget is tight, source files get dropped or
+outlined, and the project's own rules should not be the thing that falls out.
+"""
+
+import logging
+import os
+from typing import Optional
+
+_LOG = logging.getLogger("agent.project_rules")
+
+RULES_FILENAME = ".agentcontext"
+
+# Rules are prepended to every prompt, on every iteration, so their cost is paid
+# repeatedly. This is generous for a page of conventions and small enough that
+# a file pasted here by mistake is caught rather than silently billed for.
+MAX_RULES_CHARS = 8_000
+
+
+def rules_path(repo_root: str, filename: str = RULES_FILENAME) -> str:
+    return os.path.join(repo_root, filename)
+
+
+def load_project_rules(
+    repo_root: str,
+    filename: str = RULES_FILENAME,
+) -> Optional[str]:
+    """
+    Read `.agentcontext` from the repository root, or None if there is none.
+
+    Never raises. An unreadable rules file should not stop a run that would
+    otherwise work — the agent simply proceeds without the extra guidance, which
+    is what happens today for every repository that has no such file.
+    """
+    path = rules_path(repo_root, filename)
+    if not os.path.isfile(path):
+        return None
+
+    try:
+        text = open(path, "r", encoding="utf-8", errors="replace").read()
+    except OSError as exc:
+        _LOG.warning("could not read %s: %s", path, exc)
+        return None
+
+    text = text.strip()
+    if not text:
+        _LOG.debug("%s is empty; ignoring", path)
+        return None
+
+    if len(text) > MAX_RULES_CHARS:
+        _LOG.warning(
+            "%s is %d chars; using the first %d. Rules are sent on every "
+            "iteration, so a long file is paid for repeatedly.",
+            path, len(text), MAX_RULES_CHARS,
+        )
+        text = text[:MAX_RULES_CHARS].rstrip()
+
+    return text
+
+
+def render_project_rules(rules: Optional[str]) -> str:
+    """
+    Wrap the rules for inclusion in a prompt.
+
+    Tagged like the file blocks the context already emits, so the model sees a
+    consistent structure, and labelled as rules rather than as content — the
+    distinction matters when a rule says "never edit generated/" and the model
+    is otherwise free to treat everything it receives as material to change.
+    """
+    if not rules:
+        return ""
+    return (
+        "<project_rules>\n"
+        "These rules come from the repository and apply to every task in it. "
+        "Follow them unless the task explicitly says otherwise.\n\n"
+        f"{rules}\n"
+        "</project_rules>"
+    )

--- a/tests/test_project_rules.py
+++ b/tests/test_project_rules.py
@@ -1,0 +1,189 @@
+"""
+Tests for `.agentcontext` (modules/project_rules.py).
+
+A repository can carry rules that apply to every task in it — a language
+version to stay within, a directory never to touch, a test layout that differs
+from the default.
+
+Distinct from `.repopilot.json`, which sets CLI defaults: that file answers
+"how should the tool be invoked", this one answers "what should the model know
+before it writes anything".
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.project_rules import (  # noqa: E402
+    MAX_RULES_CHARS,
+    RULES_FILENAME,
+    load_project_rules,
+    render_project_rules,
+    rules_path,
+)
+
+RULES = (
+    "- This project targets Python 3.9. Do not use match statements.\n"
+    "- Tests live in spec/, not tests/.\n"
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    (tmp_path / RULES_FILENAME).write_text(RULES, encoding="utf-8")
+    return tmp_path
+
+
+# ── loading ───────────────────────────────────────────────────────────────
+
+
+def test_rules_are_read_from_the_repo_root(repo):
+    assert load_project_rules(str(repo)) == RULES.strip()
+
+
+def test_no_file_means_no_rules(tmp_path):
+    """Every repository without one must behave exactly as it does today."""
+    assert load_project_rules(str(tmp_path)) is None
+
+
+def test_an_empty_file_means_no_rules(tmp_path):
+    (tmp_path / RULES_FILENAME).write_text("\n\n   \n")
+
+    assert load_project_rules(str(tmp_path)) is None
+
+
+def test_a_directory_in_place_of_the_file_is_ignored(tmp_path):
+    (tmp_path / RULES_FILENAME).mkdir()
+
+    assert load_project_rules(str(tmp_path)) is None
+
+
+def test_an_unreadable_file_does_not_raise(tmp_path, monkeypatch):
+    """
+    A broken rules file must not stop a run that would otherwise work — the
+    agent proceeds without the guidance, which is today's behaviour anyway.
+    """
+    (tmp_path / RULES_FILENAME).write_text(RULES)
+
+    def explode(*args, **kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr("builtins.open", explode)
+
+    assert load_project_rules(str(tmp_path)) is None
+
+
+def test_utf8_is_read_correctly(tmp_path):
+    """The default encoding is cp1252 on Windows and would mangle this."""
+    (tmp_path / RULES_FILENAME).write_text("- Répondez précisément — no waffle\n",
+                                           encoding="utf-8")
+
+    assert "précisément" in load_project_rules(str(tmp_path))
+
+
+def test_undecodable_bytes_do_not_raise(tmp_path):
+    (tmp_path / RULES_FILENAME).write_bytes(b"- rule \xff\xfe invalid\n")
+
+    assert load_project_rules(str(tmp_path)) is not None
+
+
+def test_a_custom_filename_is_honoured(tmp_path):
+    (tmp_path / "RULES.md").write_text(RULES)
+
+    assert load_project_rules(str(tmp_path), "RULES.md") == RULES.strip()
+
+
+def test_the_path_is_built_from_the_repo_root(tmp_path):
+    assert rules_path(str(tmp_path)).endswith(RULES_FILENAME)
+
+
+# ── the size cap ──────────────────────────────────────────────────────────
+
+
+def test_a_long_file_is_truncated(tmp_path):
+    """
+    Rules are sent on every iteration, so their cost is paid repeatedly. The cap
+    catches a file pasted here by mistake rather than being billed for it.
+    """
+    (tmp_path / RULES_FILENAME).write_text("- rule\n" * (MAX_RULES_CHARS // 7 + 500))
+
+    assert len(load_project_rules(str(tmp_path))) <= MAX_RULES_CHARS
+
+
+def test_a_normal_file_is_not_truncated(repo):
+    assert load_project_rules(str(repo)) == RULES.strip()
+
+
+def test_the_cap_is_generous_enough_for_real_rules():
+    assert MAX_RULES_CHARS >= 4_000
+
+
+# ── rendering ─────────────────────────────────────────────────────────────
+
+
+def test_rules_are_tagged():
+    """Matches the <file> blocks the context already emits."""
+    rendered = render_project_rules(RULES)
+
+    assert rendered.startswith("<project_rules>")
+    assert rendered.endswith("</project_rules>")
+
+
+def test_the_rules_text_survives_rendering():
+    assert "Python 3.9" in render_project_rules(RULES)
+
+
+def test_the_block_says_these_are_rules_not_content():
+    """
+    Without this the model may treat the block as material to edit — which
+    matters most when a rule says never to touch something.
+    """
+    rendered = render_project_rules(RULES)
+
+    assert "rules" in rendered.lower()
+    assert "apply to every task" in rendered
+
+
+def test_nothing_renders_without_rules():
+    assert render_project_rules(None) == ""
+    assert render_project_rules("") == ""
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_default_filename_is_agentcontext():
+    assert AgentConfig(repo_root=".", task="t").project_rules_file == ".agentcontext"
+
+
+def test_rules_are_prepended_not_appended():
+    """
+    When the budget is tight, files get dropped or outlined. Putting the rules
+    first keeps them out of what gets squeezed.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'render_project_rules(rules) + "\\n\\n" + context_str' in source
+
+
+def test_rules_are_read_after_the_context_is_built():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert source.index("context_str = context.render()") < \
+        source.index("load_project_rules(cfg.repo_root")
+
+
+def test_an_empty_setting_disables_the_feature():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "if cfg.project_rules_file:" in source


### PR DESCRIPTION
Closes #148

## Summary

A `.agentcontext` file at the repository root carries instructions that apply to every task in that repository. It is read on each iteration and prepended to the prompt.

```
- This project targets Python 3.9. Do not use match statements or | unions.
- Tests live in spec/, not tests/.
- Never edit anything under generated/.
```

Verified against a real repository:

```
Project rules: .agentcontext (150 chars)
<project_rules>
These rules come from the repository and apply to every task in it. Follow them
unless the task explicitly says otherwise.

- This project targets Python 3.9. Do not use match statements or | unions.
...
</project_rules>
```

## Not the same thing as `.repopilot.json`

Worth separating, since both sit at the repo root. `.repopilot.json` sets CLI defaults — it answers "how should the tool be invoked". This answers "what should the model know before it writes anything". A rule like *never edit generated/* is not a CLI default, and a `--provider` setting is not something to put in a prompt.

## Prepended, not merged into the file context

The rules go in front of the `<file>` blocks rather than being folded in among them, and that placement is deliberate.

When the character budget is tight — which is exactly when a small-window model is in use, per #149 — files get dropped or reduced to signature outlines. The project's own rules should not be the thing that falls out of a full context window. Keeping them outside the budgeted section means they survive.

## The block says these are rules, not content

```
<project_rules>
These rules come from the repository and apply to every task in it. Follow them
unless the task explicitly says otherwise.
```

Everything else the model receives is material it may edit. Without the framing, a block of text arriving alongside the file contents can reasonably be read as more of the same — which matters most for a rule like "never edit generated/", where the failure mode is the model editing the very thing it was told to leave alone.

The tag matches the `<file path=...>` blocks the context already emits, so the structure is consistent.

## Failing softly

`load_project_rules` never raises. A missing file, an empty file, a directory in place of the file, an unreadable file, or undecodable bytes all return `None`, and the run proceeds exactly as it does today for every repository without one. A broken rules file should not stop a run that would otherwise work.

Read with `encoding="utf-8"` and `errors="replace"` — the default is cp1252 on a default Windows install and would mangle a non-ASCII rules file.

## The size cap

8,000 characters, truncated with a warning above that. Rules are sent on **every iteration**, so their cost is paid repeatedly — a file pasted here by mistake would be billed for on every call of every run. The cap is generous for a page of conventions and small enough to catch that mistake.

`--project-rules PATH` points at a different filename; an empty string disables the feature entirely.

## Tests

`tests/test_project_rules.py` — 20 cases.

Loading: rules are read from the repo root; no file means no rules, so unaffected repositories behave exactly as before; an empty file, a directory in place of the file, and an unreadable file all yield nothing without raising; UTF-8 is preserved; undecodable bytes do not raise; a custom filename is honoured.

The cap: a long file is truncated; a normal file is not; the cap is generous enough for real rules.

Rendering: rules are tagged; the text survives; the block states that these are rules rather than content; nothing renders without rules.

Wiring: the default filename is `.agentcontext`; rules are prepended rather than appended; they are read after the context is built; an empty setting disables the feature.

## Verified

- the rendered output above, from a real `--context-only` run
- 20 tests pass, plus `test_context_only` and `test_ast_outlines` with no regressions
- all six import-guard checks green
- ruff clean on the new module
- built on current `main` after the seven-PR merge, touching `agent_loop.py` (+15) and `main.py` (+6) plus two new files