### PR TITLE
fix(ingestion): read in batches so memory tracks the budget, not the repo — Closes #145

### DIFF
--- a/modules/repo_ingestion.py
+++ b/modules/repo_ingestion.py
@@ -54,6 +54,10 @@ SECRET_FILE_PATTERNS = (
 MAX_FILE_SIZE_BYTES = 512 * 1024  # 512 KB per file
 MAX_TOTAL_BYTES = 8 * 1024 * 1024  # 8 MB total repo budget
 
+# Files read concurrently per batch. Caps peak memory at roughly one batch of
+# file contents instead of the whole repository.
+READ_BATCH_SIZE = 64
+
 SECRET_PATTERNS = [
     re.compile(r"sk-ant-[a-zA-Z0-9_-]{40,}"), # Anthropic API Key
     re.compile(r"sk-[a-zA-Z0-9]{48}"),         # OpenAI API Key
@@ -300,35 +304,54 @@ def ingest_repository(repo_root: str) -> Repository:
             return None
         return content, abs_path, len(content.encode("utf-8"))
 
-    # Parallel file reading
+    # Read in bounded batches rather than submitting every candidate at once.
+    #
+    # Submitting all of them holds the entire repository in memory before the
+    # budget is ever consulted -- a 141 MB checkout peaked at 166 MB RSS to keep
+    # the 8 MB the budget allows, and that scales with the repository rather
+    # than with the budget. Batching caps the excess at one batch, and the
+    # budget check now stops the walk instead of reading the remainder and
+    # discarding it.
     with ThreadPoolExecutor() as executor:
-        futures = {executor.submit(_process_file, abs_p, rel_p): rel_p for abs_p, rel_p in candidates}
-        for future in futures:
-            rel_p = futures[future]
-            res = future.result()
-            if res is None:
-                repo.skipped.append(rel_p)
-                continue
-            content, abs_path, size = res
+        for start in range(0, len(candidates), READ_BATCH_SIZE):
+            if repo.total_bytes >= MAX_TOTAL_BYTES:
+                repo.skipped.extend(
+                    f"{rel} (repo budget exhausted)"
+                    for _, rel in candidates[start:]
+                )
+                break
 
-            if repo.total_bytes + size > MAX_TOTAL_BYTES:
-                repo.skipped.append(f"{rel_p} (repo budget exhausted)")
-                continue
+            batch = candidates[start:start + READ_BATCH_SIZE]
+            futures = {
+                executor.submit(_process_file, abs_p, rel_p): rel_p
+                for abs_p, rel_p in batch
+            }
+            for future in futures:
+                rel_p = futures[future]
+                res = future.result()
+                if res is None:
+                    repo.skipped.append(rel_p)
+                    continue
+                content, abs_path, size = res
 
-            ext = Path(abs_path).suffix.lower()
-            checksum = hashlib.sha256(content.encode()).hexdigest()[:16]
+                if repo.total_bytes + size > MAX_TOTAL_BYTES:
+                    repo.skipped.append(f"{rel_p} (repo budget exhausted)")
+                    continue
 
-            record = FileRecord(
-                path=rel_p,
-                abs_path=abs_path,
-                content=content,
-                size=size,
-                extension=ext,
-                language=infer_language(abs_path),
-                checksum=checksum,
-            )
-            repo.files.append(record)
-            repo.total_bytes += size
+                ext = Path(abs_path).suffix.lower()
+                checksum = hashlib.sha256(content.encode()).hexdigest()[:16]
+
+                record = FileRecord(
+                    path=rel_p,
+                    abs_path=abs_path,
+                    content=content,
+                    size=size,
+                    extension=ext,
+                    language=infer_language(abs_path),
+                    checksum=checksum,
+                )
+                repo.files.append(record)
+                repo.total_bytes += size
 
     return repo
 

--- a/tests/test_ingestion_memory.py
+++ b/tests/test_ingestion_memory.py
@@ -1,0 +1,135 @@
+"""
+Tests for bounded ingestion memory (modules/repo_ingestion.py).
+
+Ingestion submitted every candidate file to the thread pool at once, so the
+whole repository was read into memory before the size budget was consulted. A
+141 MB checkout peaked at 166 MB RSS to keep the 8 MB the budget allows — the
+cost scaled with the repository rather than with the budget.
+
+Reading in batches, and stopping the walk once the budget is full, caps that at
+roughly one batch.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.repo_ingestion import (  # noqa: E402
+    MAX_TOTAL_BYTES,
+    READ_BATCH_SIZE,
+    ingest_repository,
+)
+
+
+def corpus(tmp_path, count, kb_each):
+    body = "x = 1\n" * (kb_each * 1024 // 6)
+    for i in range(count):
+        (tmp_path / f"mod_{i:04d}.py").write_text(f"# {i}\n{body}")
+    return tmp_path
+
+
+# ── the batch bound ───────────────────────────────────────────────────────
+
+
+def test_the_batch_size_is_bounded():
+    """
+    Unbounded is what caused the spike. The value only needs to be small
+    relative to a large repository, not tuned.
+    """
+    assert 0 < READ_BATCH_SIZE <= 256
+
+
+def test_reads_happen_in_batches():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "repo_ingestion.py"
+    ).read_text(encoding="utf-8")
+
+    assert "range(0, len(candidates), READ_BATCH_SIZE)" in source
+
+
+def test_the_walk_stops_once_the_budget_is_full():
+    """
+    Without this the remaining files are read and then discarded, which is the
+    memory cost the batching is there to avoid.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "repo_ingestion.py"
+    ).read_text(encoding="utf-8")
+    block = source[source.index("for start in range(0, len(candidates)"):][:600]
+
+    assert "if repo.total_bytes >= MAX_TOTAL_BYTES:" in block
+    assert "break" in block
+
+
+# ── behaviour is unchanged ────────────────────────────────────────────────
+
+
+def test_a_small_repo_is_fully_ingested(tmp_path):
+    corpus(tmp_path, count=5, kb_each=1)
+
+    assert len(ingest_repository(str(tmp_path)).files) == 5
+
+
+def test_a_repo_spanning_several_batches_is_fully_ingested(tmp_path):
+    """The batching must not drop files that fit within the budget."""
+    corpus(tmp_path, count=READ_BATCH_SIZE * 2 + 7, kb_each=1)
+
+    repo = ingest_repository(str(tmp_path))
+
+    assert len(repo.files) == READ_BATCH_SIZE * 2 + 7
+    assert repo.skipped == []
+
+
+def test_file_contents_are_intact(tmp_path):
+    (tmp_path / "one.py").write_text("def hello():\n    return 'world'\n")
+
+    record = ingest_repository(str(tmp_path)).files[0]
+
+    assert record.content == "def hello():\n    return 'world'\n"
+
+
+def test_metadata_is_still_populated(tmp_path):
+    (tmp_path / "one.py").write_text("x = 1\n")
+
+    record = ingest_repository(str(tmp_path)).files[0]
+
+    assert record.language == "python"
+    assert record.checksum
+    assert record.size > 0
+
+
+# ── the budget still holds ────────────────────────────────────────────────
+
+
+def test_the_budget_is_respected(tmp_path):
+    corpus(tmp_path, count=60, kb_each=256)   # ~15 MB, budget is 8 MB
+
+    repo = ingest_repository(str(tmp_path))
+
+    assert repo.total_bytes <= MAX_TOTAL_BYTES
+
+
+def test_files_beyond_the_budget_are_recorded_as_skipped(tmp_path):
+    corpus(tmp_path, count=60, kb_each=256)
+
+    repo = ingest_repository(str(tmp_path))
+
+    assert repo.skipped
+    assert any("budget exhausted" in entry for entry in repo.skipped)
+
+
+def test_every_candidate_is_accounted_for(tmp_path):
+    """Kept plus skipped should equal what was found — nothing vanishes."""
+    corpus(tmp_path, count=60, kb_each=256)
+
+    repo = ingest_repository(str(tmp_path))
+
+    assert len(repo.files) + len(repo.skipped) == 60
+
+
+def test_an_empty_repo_yields_nothing(tmp_path):
+    repo = ingest_repository(str(tmp_path))
+
+    assert repo.files == []
+    assert repo.skipped == []


### PR DESCRIPTION
Closes #145

## The reported symptom is not reproducible

The issue says `demo_run.py` crashes on a huge repo and suggests enforcing a size limit or a shallow clone. Three things do not hold:

- `demo_run.py` does not clone anything. It takes a local path.
- Size limits already exist — `MAX_FILE_SIZE_BYTES = 512 KB` per file and `MAX_TOTAL_BYTES = 8 MB` per repository.
- It does not crash. A 3000-file, 12 MB repository ingests in 0.16s: 2421 files kept, 579 skipped.

I could have closed it there. Measuring it properly turned up a real defect that the issue did not describe, and which is very likely what whoever filed it actually hit.

## The real problem

Ingestion submits **every** candidate to the thread pool in one go:

```python
futures = {executor.submit(_process_file, abs_p, rel_p): rel_p for abs_p, rel_p in candidates}
```

`_process_file` reads the whole file. So the entire repository is loaded into memory *before* the budget is ever consulted, and only then are files discarded:

```
repo on disk : 141 MB
kept         : 22 files, 8.1 MB   (the budget)
skipped      : 378 files
peak RSS     : 166 MB
```

166 MB of memory to retain 8 MB. The cost scales with the repository rather than with the budget, so a large monorepo exhausts memory regardless of how small the budget is. That is an OOM, not a crash with a useful traceback — which fits the issue's description better than the size limit it proposed.

There was also no early exit: once the budget filled, the remaining files were still read and then thrown away.

## The fix

Read in batches of 64, and stop the walk once the budget is full.

```
peak RSS : 166 MB -> 55 MB
```

Peak memory is now bounded by one batch of file contents rather than by the repository. The budget, the per-file cap, and the ordering are all unchanged.

## Output is identical

The property that matters. Compared before and after across four corpora — a small fixed corpus, a rules repo, a 3000-file 12 MB repo, and the 141 MB one:

```
IDENTICAL across 4 corpora, including the 141 MB one
```

Same file count, same byte total, same skipped count, same file list.

## Tests

`tests/test_ingestion_memory.py` — 11 cases.

The bound: the batch size is bounded; reads happen in batches; the walk stops once the budget is full.

Unchanged behaviour: a small repo is fully ingested; a repo spanning several batches is fully ingested with nothing skipped — the batching must not drop files that fit; file contents are intact; metadata is still populated.

The budget: it is respected; files beyond it are recorded as skipped; every candidate is accounted for, so kept plus skipped equals what was found and nothing vanishes silently; an empty repo yields nothing.

## Verified

- the memory measurements above, via `resource.getrusage`
- identical output across four corpora
- 11 tests pass, plus `test_repo_ingestion_gitignore`, `test_utils` and `test_context_only` — 45 in total, no regressions
- all six import-guard checks green
- ruff on `modules/repo_ingestion.py`: 12 findings before, 11 after

## One process note

My first attempt reindented the loop body programmatically and silently corrupted it — the result kept 400 files at 2.6 MB instead of 22 at 8.1 MB, which looks plausible until you compare it. The corpus comparison caught it; I reverted and replaced the block explicitly rather than transforming it. Worth mentioning because the broken version passed a casual glance.

## Not addressed

The issue's suggestion of a shallow clone does not apply, since nothing here clones. If cloning is wanted as a feature — pointing the agent at a URL rather than a path — that is a separate piece of work and `--depth 1` would belong in it.

`ingest_repository_parallel` has the same unbounded-submit shape and is not touched here. It is a separate entry point with its own reader, and changing both in one PR would make this diff harder to check. Happy to follow up.