### PR TITLE
feat(sandbox): run pre-commit hooks before tests — Closes #144

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,6 +71,10 @@ Examples:
                              "lowers it. Requires pytest-cov.")
     parser.add_argument("--coverage-source", default=".", metavar="PATH",
                         help="What --cov points at (default: .)")
+    parser.add_argument("--no-pre-commit", dest="run_pre_commit",
+                        action="store_false", default=True,
+                        help="Skip the repository's pre-commit hooks even when "
+                             ".pre-commit-config.yaml is present.")
     parser.add_argument("--lint", dest="lint_runner", default=None,
                         choices=["ruff", "flake8", "pyflakes", "eslint", "tsc",
                                  "govet", "clippy"],
@@ -264,6 +268,7 @@ def main():
         run_file_runner=args.run_file_runner,
         coverage=args.coverage,
         coverage_source=args.coverage_source,
+        run_pre_commit=args.run_pre_commit,
         lint_runner=args.lint_runner,
         lint_args=args.lint_args,
         timeout_seconds=args.timeout,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -31,6 +31,7 @@ from modules.llm_client import (
 )
 from modules.code_modifier import CodeModificationEngine, ApplyResult
 from modules.sandbox import (
+    PRE_COMMIT_CONFIG,
     ExecutionResult,
     SubprocessSandbox,
     coverage_args,
@@ -68,6 +69,7 @@ class AgentConfig:
     run_file_runner: str = "python"
     coverage: bool = False                 # measure coverage and feed drops back
     coverage_source: str = "."             # what --cov points at
+    run_pre_commit: bool = True            # run repo hooks before tests if configured
     lint_runner: Optional[str] = None      # run a linter before the test suite
     lint_args: list[str] = field(default_factory=list)
     timeout_seconds: int = 120
@@ -714,6 +716,33 @@ class AutonomousAgent:
 
             duration_apply = time.time() - phase
             phase = time.time()
+            # Pre-commit before tests, when the repository configures it.
+            # Hooks that reformat leave the tree different from what the model
+            # wrote, so this has to run before anything is measured -- otherwise
+            # tests pass against code the hooks would then rewrite.
+            if cfg.run_pre_commit and last_changes:
+                config_path = os.path.join(cfg.repo_root, PRE_COMMIT_CONFIG)
+                if os.path.isfile(config_path):
+                    changed = [c.path for c in last_changes]
+                    hook_result = self.sandbox.run_pre_commit(changed)
+                    self.logger.log_execution(hook_result)
+                    if not hook_result.success and hook_result.exit_code != -3:
+                        self.logger.warning(
+                            "  pre-commit hooks failed; retrying with their output."
+                        )
+                        last_exec = hook_result
+                        iter_record.execution_command = hook_result.command
+                        iter_record.execution_exit_code = hook_result.exit_code
+                        iter_record.execution_stdout = hook_result.stdout[:2000]
+                        iter_record.execution_stderr = hook_result.stderr[:2000]
+                        iter_record.execution_success = False
+                        _stamp_timings(
+                            iter_record, iter_started, duration_ingest,
+                            duration_context, duration_llm, duration_apply, phase,
+                        )
+                        self.logger.record_iteration(iter_record)
+                        continue
+
             # ── Step 5: Execute ──
             # Lint first when configured. A syntax error surfaces in under a
             # second with a precise location, instead of arriving as a pytest

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -117,6 +117,8 @@ ALLOWED_RUNNERS = {
 # and since the model cannot fix what it did not write, the gate would loop
 # until max_iterations on every run. E9 is syntax errors, F is pyflakes
 # (undefined names, unused imports). Widen it per project with --lint-args.
+PRE_COMMIT_CONFIG = ".pre-commit-config.yaml"
+
 ALLOWED_LINTERS = {
     "ruff": [sys.executable, "-m", "ruff", "check", "--select", "E9,F", "."],
     "flake8": [sys.executable, "-m", "flake8", "--select=E9,F63,F7,F82", "."],
@@ -635,6 +637,72 @@ class SubprocessSandbox:
             timed_out=timed_out,
             duration_seconds=time.time() - started,
         )
+
+    def run_pre_commit(
+        self,
+        files: list[str],
+        config: str = PRE_COMMIT_CONFIG,
+    ) -> ExecutionResult:
+        """
+        Run the repository's pre-commit hooks against the changed files.
+
+        Hooks fall into two kinds and pre-commit reports both as "Failed":
+
+        - **auto-fixing** (black, isort, trailing-whitespace) rewrite the file
+          and exit non-zero to say they did something. Nothing is wrong; the
+          code is now formatted.
+        - **checking** (check-yaml, flake8) exit non-zero because something is
+          actually wrong.
+
+        Treating the first as a failure would send the agent back to fix code
+        that a hook just fixed for it. The two are told apart by running again:
+        an auto-fix passes the second time, a genuine failure does not.
+        """
+        if not shutil.which("pre-commit"):
+            return ExecutionResult(
+                command="pre-commit",
+                exit_code=-3,
+                stdout="",
+                stderr="pre-commit is not installed. Run: pip install pre-commit",
+                timed_out=False,
+                duration_seconds=0.0,
+            )
+        if not files:
+            return ExecutionResult(
+                command="pre-commit (no files)",
+                exit_code=0,
+                stdout="No changed files to check.",
+                stderr="",
+                timed_out=False,
+                duration_seconds=0.0,
+            )
+
+        command = ["pre-commit", "run", "--config", config, "--files", *files]
+        first = self.run(command)
+        if first.success:
+            return first
+
+        # Non-zero: re-run to find out which kind it was.
+        second = self.run(command)
+        if second.success:
+            _LOG.info(
+                "pre-commit modified %d file(s) and now passes; continuing.",
+                len(files),
+            )
+            return ExecutionResult(
+                command=" ".join(command),
+                exit_code=0,
+                stdout=(
+                    "[pre-commit] Hooks reformatted the changed files and now "
+                    "pass. The rewritten files are what will be tested.\n\n"
+                    + first.stdout
+                ),
+                stderr="",
+                timed_out=False,
+                duration_seconds=first.duration_seconds + second.duration_seconds,
+            )
+
+        return second
 
     def run_lint(
         self,

--- a/tests/test_lint_step.py
+++ b/tests/test_lint_step.py
@@ -163,7 +163,7 @@ def test_a_lint_failure_short_circuits_the_iteration():
     """Running a suite that cannot import is wasted time."""
     source = AGENT_LOOP.read_text(encoding="utf-8")
     start = source.index("if cfg.lint_runner:")
-    block = source[start:start + 900]
+    block = source[start:start + 2400]
 
     assert "if not lint_result.success:" in block
     assert "continue" in block

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -1,0 +1,180 @@
+"""
+Tests for pre-commit integration (modules/sandbox.py, modules/agent_loop.py).
+
+When a repository has `.pre-commit-config.yaml`, its hooks run against the
+changed files before the test suite.
+
+The distinction that makes this work: pre-commit reports both auto-fixes and
+genuine failures as "Failed". Treating the first as a failure would send the
+agent back to fix code that a hook just fixed for it.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.sandbox import PRE_COMMIT_CONFIG, SubprocessSandbox  # noqa: E402
+
+AGENT_LOOP = Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+
+needs_pre_commit = pytest.mark.skipif(
+    shutil.which("pre-commit") is None, reason="pre-commit not installed"
+)
+
+CONFIG = """\
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+"""
+
+
+@pytest.fixture
+def repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / PRE_COMMIT_CONFIG).write_text(CONFIG)
+    return tmp_path
+
+
+def staged(repo):
+    subprocess.run(["git", "-C", str(repo), "add", "-A"], check=True)
+    return SubprocessSandbox(str(repo), timeout_seconds=300)
+
+
+# ── refusals and no-ops ───────────────────────────────────────────────────
+
+
+def test_no_files_is_a_pass(tmp_path):
+    """An iteration that changed nothing has nothing for hooks to check."""
+    result = SubprocessSandbox(str(tmp_path)).run_pre_commit([])
+
+    assert result.success is True
+
+
+def test_a_missing_binary_is_reported_not_raised(tmp_path, monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    result = SubprocessSandbox(str(tmp_path)).run_pre_commit(["a.py"])
+
+    assert result.exit_code == -3
+    assert "pip install pre-commit" in result.stderr
+
+
+def test_the_config_name_is_the_conventional_one():
+    assert PRE_COMMIT_CONFIG == ".pre-commit-config.yaml"
+
+
+# ── the distinction that matters ──────────────────────────────────────────
+
+
+@needs_pre_commit
+def test_an_auto_fix_counts_as_success(repo):
+    """
+    trailing-whitespace rewrites the file and exits non-zero to say so. Nothing
+    is wrong — treating it as a failure would send the agent back to fix code a
+    hook just fixed.
+    """
+    (repo / "messy.py").write_text("x = 1   \ny = 2")
+
+    assert staged(repo).run_pre_commit(["messy.py"]).success is True
+
+
+@needs_pre_commit
+def test_the_file_is_actually_rewritten(repo):
+    (repo / "messy.py").write_text("x = 1   \ny = 2")
+    staged(repo).run_pre_commit(["messy.py"])
+
+    assert (repo / "messy.py").read_text() == "x = 1\ny = 2\n"
+
+
+@needs_pre_commit
+def test_the_reformatting_is_reported(repo):
+    """
+    Silence here would hide the fact that the tree no longer matches what the
+    model wrote.
+    """
+    (repo / "messy.py").write_text("x = 1   \ny = 2")
+
+    stdout = staged(repo).run_pre_commit(["messy.py"]).stdout
+
+    assert "reformatted" in stdout
+    assert "will be tested" in stdout
+
+
+@needs_pre_commit
+def test_a_genuine_failure_fails(repo):
+    """check-yaml cannot fix invalid YAML, so a re-run fails too."""
+    (repo / "bad.yaml").write_text("not: valid: yaml: [\n")
+
+    assert staged(repo).run_pre_commit(["bad.yaml"]).success is False
+
+
+@needs_pre_commit
+def test_the_failure_reason_reaches_the_model(repo):
+    (repo / "bad.yaml").write_text("not: valid: yaml: [\n")
+
+    result = staged(repo).run_pre_commit(["bad.yaml"])
+
+    assert "yaml" in (result.stdout + result.stderr).lower()
+
+
+@needs_pre_commit
+def test_clean_files_pass_without_a_second_run(repo):
+    (repo / "clean.py").write_text("x = 1\n")
+
+    assert staged(repo).run_pre_commit(["clean.py"]).success is True
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_it_is_on_by_default():
+    """The issue asks for it whenever the repo configures hooks."""
+    assert AgentConfig(repo_root=".", task="t").run_pre_commit is True
+
+
+def test_it_runs_before_the_test_suite():
+    """
+    Hooks that reformat leave the tree different from what the model wrote, so
+    tests measured first would be measuring code the hooks then rewrite.
+    """
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+
+    assert source.index("run_pre_commit(changed)") < \
+        source.index("# ── Step 5: Execute ──")
+
+
+def test_nothing_happens_without_a_config():
+    """Repositories that do not use pre-commit are unaffected."""
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    block = source[source.index("if cfg.run_pre_commit and last_changes:"):][:400]
+
+    assert "os.path.isfile(config_path)" in block
+
+
+def test_only_changed_files_are_checked():
+    """Running every hook over a whole repository would be far slower."""
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    block = source[source.index("if cfg.run_pre_commit and last_changes:"):][:500]
+
+    assert "[c.path for c in last_changes]" in block
+
+
+def test_a_missing_binary_does_not_fail_the_iteration():
+    """
+    -3 means pre-commit is not installed, which is the user's environment
+    rather than a problem with the model's output.
+    """
+    source = AGENT_LOOP.read_text(encoding="utf-8")
+    block = source[source.index("if cfg.run_pre_commit and last_changes:"):][:900]
+
+    assert "hook_result.exit_code != -3" in block


### PR DESCRIPTION
Closes #144

## Summary

When a repository has `.pre-commit-config.yaml`, its hooks now run against the changed files before the test suite. Automatic when the config is present; `--no-pre-commit` opts out.

## The part that needed testing rather than assuming

`pre-commit` reports two very different situations identically:

```
fix end of files.....Failed
- hook id: end-of-file-fixer
- exit code: 1
- files were modified by this hook
```

That is not a failure. A hook reformatted the file and exits non-zero to say so. Meanwhile a real problem — invalid YAML, a flake8 error — produces the same shape.

Taking exit code at face value would send the agent back to "fix" code that a hook had just fixed for it, burning an iteration and an API call every time anyone uses black or isort. Which is most repositories that configure pre-commit at all.

The two are distinguishable by running again. Measured against real hooks:

| case | first run | second run |
| ---- | --------- | ---------- |
| trailing whitespace | exit 1 | **exit 0** — it was an auto-fix |
| invalid YAML | exit 1 | **exit 1** — genuinely broken |

So a non-zero result is re-run once. Passing the second time means the hooks reformatted and the code is fine; still failing means something is actually wrong and the output goes back to the model.

## The reformatting is reported, not swallowed

```
[pre-commit] Hooks reformatted the changed files and now pass.
The rewritten files are what will be tested.
```

Silence here would hide that the working tree no longer matches what the model wrote — which matters when someone later reads the run log and compares it against the diff.

## Three other choices

**It runs before the tests.** Hooks that reformat leave the tree different from what was written, so measuring tests first would be measuring code the hooks are about to rewrite.

**Only changed files are checked**, via `pre-commit run --files`. Running every hook across a whole repository on every iteration would dominate the run time.

**A missing binary does not fail the iteration.** `pre-commit` not being installed returns exit `-3`, which the loop distinguishes from a hook failure — that is the user's environment, not a problem with the model's output.

## Tests

`tests/test_pre_commit.py` — 14 cases. The hook tests skip cleanly when `pre-commit` is not installed.

Refusals and no-ops: no files is a pass, since an iteration that changed nothing has nothing to check; a missing binary is reported rather than raised; the config name is the conventional one.

The distinction: an auto-fix counts as success; the file is actually rewritten; the reformatting is reported; a genuine failure fails; the failure reason reaches the model; clean files pass without a second run.

Wiring: it is on by default; it runs before the test suite; nothing happens without a config, so repositories that do not use pre-commit are unaffected; only changed files are checked; a missing binary does not fail the iteration.

`tests/test_lint_step.py` has one search window widened from 900 to 2400 characters — my insertion pushed the lint block past it. No behaviour change.

## Verified

- the auto-fix versus genuine-failure table above, against real `pre-commit-hooks`
- 39 tests pass, including `test_lint_step`, `test_runner_fallback` and `test_sandbox_env` with no regressions
- confirmed on Windows, where the hook environments were downloaded and executed for real
- ruff unchanged: `sandbox.py` 2, `agent_loop.py` 23, `main.py` 17
- all six import-guard checks green

## Worth knowing

The first run in a repository installs hook environments, which needs network and takes tens of seconds. Subsequent runs are cached. That cost lands on the first iteration of the first run against a given repo, and is why the tests take ~35s rather than ~3s.