### PR TITLE
refactor(sandbox): add a Sandbox base class so backends cannot diverge — Closes #68

### DIFF
--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -16,6 +16,7 @@ import re
 import shlex
 import shutil
 import subprocess
+from abc import ABC, abstractmethod
 import time
 import sys
 import uuid
@@ -473,90 +474,33 @@ def _register_atexit_once() -> None:
         _ATEXIT_REGISTERED = True
 
 
-class SubprocessSandbox:
+class Sandbox(ABC):
     """
-    Subprocess-based sandbox (no Docker required).
-    Suitable for trusted local repos. For untrusted code, use DockerSandbox.
+    What every execution backend must provide.
+
+    `SubprocessSandbox` and `DockerSandbox` were unrelated classes that happened
+    to share some method names, and they had already drifted: `DockerSandbox`
+    was missing `run`, `run_file`, `run_lint` and `run_pre_commit` entirely, so
+    `--lint`, `--run-file` or a repository's pre-commit hooks raised
+    AttributeError against it rather than doing anything. Nothing detected that,
+    because nothing required the two to agree.
+
+    Subclasses implement `run`. Everything else is expressed in terms of it, so
+    a new backend -- Firecracker, a remote executor -- gets the whole surface by
+    implementing one method, and one that forgets it cannot be instantiated.
     """
 
-    def __init__(
-        self,
-        working_dir: str,
-        timeout_seconds: int = 60,
-        max_output_bytes: int = 1024 * 1024,
-    ):
-        self.working_dir = os.path.abspath(working_dir)
-        self.timeout = timeout_seconds
-        self.max_output_bytes = max_output_bytes
+    working_dir: str
+    timeout: int
 
+    @abstractmethod
     def run(
         self,
         command: list[str],
         env: Optional[dict] = None,
         stdin_data: Optional[str] = None,
     ) -> ExecutionResult:
-        """Run an arbitrary command list in the working dir sandbox."""
-        import time
-
-        safe_env = _build_safe_env(env)
-        cmd_str = shlex.join(command)
-        start = time.monotonic()
-
-        try:
-            proc = subprocess.run(
-                command,
-                cwd=self.working_dir,
-                env=safe_env,
-                input=stdin_data,
-                capture_output=True,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-                timeout=self.timeout,
-            )
-            elapsed = time.monotonic() - start
-
-            return ExecutionResult(
-                command=cmd_str,
-                exit_code=proc.returncode,
-                stdout=proc.stdout[:self.max_output_bytes],
-                stderr=proc.stderr[:self.max_output_bytes],
-                timed_out=False,
-                duration_seconds=elapsed,
-            )
-
-        except subprocess.TimeoutExpired as exc:
-            elapsed = time.monotonic() - start
-            return ExecutionResult(
-                command=cmd_str,
-                exit_code=-1,
-                stdout=_coerce_output(exc.stdout)[:self.max_output_bytes],
-                stderr=_coerce_output(exc.stderr)[:self.max_output_bytes],
-                timed_out=True,
-                duration_seconds=elapsed,
-            )
-
-        except FileNotFoundError:
-            elapsed = time.monotonic() - start
-            return ExecutionResult(
-                command=cmd_str,
-                exit_code=127,
-                stdout="",
-                stderr=f"Command not found: {command[0]}",
-                timed_out=False,
-                duration_seconds=elapsed,
-            )
-
-        except Exception as exc:
-            elapsed = time.monotonic() - start
-            return ExecutionResult(
-                command=cmd_str,
-                exit_code=-2,
-                stdout="",
-                stderr=f"Sandbox error: {exc}",
-                timed_out=False,
-                duration_seconds=elapsed,
-            )
+        """Execute a command list in the sandbox and capture its result."""
 
     def run_tests(self, runner: str = "pytest", extra_args: Optional[list[str]] = None) -> ExecutionResult:
         """Run the project's test suite using a named runner."""
@@ -757,6 +701,93 @@ class SubprocessSandbox:
         return self.run(cmd + [abs_path])
 
 
+class SubprocessSandbox(Sandbox):
+    """
+    Subprocess-based sandbox (no Docker required).
+    Suitable for trusted local repos. For untrusted code, use DockerSandbox.
+    """
+
+    def __init__(
+        self,
+        working_dir: str,
+        timeout_seconds: int = 60,
+        max_output_bytes: int = 1024 * 1024,
+    ):
+        self.working_dir = os.path.abspath(working_dir)
+        self.timeout = timeout_seconds
+        self.max_output_bytes = max_output_bytes
+
+    def run(
+        self,
+        command: list[str],
+        env: Optional[dict] = None,
+        stdin_data: Optional[str] = None,
+    ) -> ExecutionResult:
+        """Run an arbitrary command list in the working dir sandbox."""
+        import time
+
+        safe_env = _build_safe_env(env)
+        cmd_str = shlex.join(command)
+        start = time.monotonic()
+
+        try:
+            proc = subprocess.run(
+                command,
+                cwd=self.working_dir,
+                env=safe_env,
+                input=stdin_data,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=self.timeout,
+            )
+            elapsed = time.monotonic() - start
+
+            return ExecutionResult(
+                command=cmd_str,
+                exit_code=proc.returncode,
+                stdout=proc.stdout[:self.max_output_bytes],
+                stderr=proc.stderr[:self.max_output_bytes],
+                timed_out=False,
+                duration_seconds=elapsed,
+            )
+
+        except subprocess.TimeoutExpired as exc:
+            elapsed = time.monotonic() - start
+            return ExecutionResult(
+                command=cmd_str,
+                exit_code=-1,
+                stdout=_coerce_output(exc.stdout)[:self.max_output_bytes],
+                stderr=_coerce_output(exc.stderr)[:self.max_output_bytes],
+                timed_out=True,
+                duration_seconds=elapsed,
+            )
+
+        except FileNotFoundError:
+            elapsed = time.monotonic() - start
+            return ExecutionResult(
+                command=cmd_str,
+                exit_code=127,
+                stdout="",
+                stderr=f"Command not found: {command[0]}",
+                timed_out=False,
+                duration_seconds=elapsed,
+            )
+
+        except Exception as exc:
+            elapsed = time.monotonic() - start
+            return ExecutionResult(
+                command=cmd_str,
+                exit_code=-2,
+                stdout="",
+                stderr=f"Sandbox error: {exc}",
+                timed_out=False,
+                duration_seconds=elapsed,
+            )
+
+
+
 def _docker_user_flags() -> list[str]:
     """
     Run the container as the invoking user, on platforms where that means
@@ -779,7 +810,7 @@ def _docker_user_flags() -> list[str]:
     return ["--user", f"{getuid()}:{getgid()}"]
 
 
-class DockerSandbox:
+class DockerSandbox(Sandbox):
     """
     Docker-based sandbox for untrusted code.
     Falls back to SubprocessSandbox if Docker is unavailable.
@@ -857,7 +888,20 @@ class DockerSandbox:
         ]
         return cmd
 
-    def run_tests(self, runner: str = "pytest", extra_args: Optional[list[str]] = None) -> ExecutionResult:
+    def run(
+        self,
+        command: list[str],
+        env: Optional[dict] = None,
+        stdin_data: Optional[str] = None,
+    ) -> ExecutionResult:
+        """
+        Run an arbitrary command inside a container.
+
+        The container lifecycle previously lived inside run_tests, so Docker
+        could only ever run a test suite. Lifting it here is what gives the
+        inherited run_lint, run_file and run_pre_commit containerisation --
+        before, none of those methods existed on this class at all.
+        """
         if not self._docker_available:
             reason = (
                 "Docker is unavailable (no CLI on PATH, or no daemon answering). "
@@ -868,23 +912,21 @@ class DockerSandbox:
                 raise SandboxUnavailableError(reason)
 
             _LOG.warning("DockerSandbox: %s Falling back to SubprocessSandbox.", reason)
-            sb = SubprocessSandbox(self.working_dir, self.timeout)
-            result = sb.run_tests(runner, extra_args)
+            result = SubprocessSandbox(self.working_dir, self.timeout).run(
+                command, env, stdin_data
+            )
             result.sandbox = SANDBOX_SUBPROCESS_FALLBACK
             return result
 
-        runner_cmd = DOCKER_RUNNERS.get(runner) or ["python", "-m", "pytest"]
-        inner_cmd = runner_cmd + (extra_args or [])
         name = _new_container_name()
-        docker_cmd = self._build_docker_command(inner_cmd, name)
-
-        sb = SubprocessSandbox(self.working_dir, self.timeout)
+        docker_cmd = self._build_docker_command(command, name)
+        host = SubprocessSandbox(self.working_dir, self.timeout)
 
         _register_atexit_once()
         _ACTIVE_CONTAINERS.add(name)
         self._containers.add(name)
         try:
-            result = sb.run(docker_cmd)
+            result = host.run(docker_cmd, env, stdin_data)
             result.sandbox = SANDBOX_DOCKER
         except BaseException:
             # KeyboardInterrupt and SystemExit reach here; the CLI is gone but
@@ -896,16 +938,24 @@ class DockerSandbox:
             self._containers.discard(name)
 
         if result.timed_out:
-            # subprocess.run kills the docker CLI with SIGKILL on timeout. That
-            # signal cannot be caught or proxied, so the container keeps running
-            # -- still holding its memory and CPU reservation -- and `--rm` will
-            # not fire because the container never exits. Remove it explicitly.
-            _LOG.warning(
-                "DockerSandbox: run timed out; force-removing container %s", name
-            )
+            # subprocess.run kills the docker CLI with SIGKILL on timeout, which
+            # leaves the container running. --rm does not cover this.
             _force_remove_container(name)
 
         return result
+
+    def run_tests(
+        self, runner: str = "pytest", extra_args: Optional[list[str]] = None
+    ) -> ExecutionResult:
+        """
+        Overridden because DOCKER_RUNNERS names the interpreter inside the image
+        (`python`), not the one running the agent (`sys.executable`).
+        """
+        if not self._docker_available and not self.strict:
+            return super().run_tests(runner, extra_args)
+
+        runner_cmd = DOCKER_RUNNERS.get(runner) or ["python", "-m", "pytest"]
+        return self.run(runner_cmd + (extra_args or []))
 
     # ── cleanup surface ───────────────────────────────────────────────
 

--- a/tests/test_docker_cleanup.py
+++ b/tests/test_docker_cleanup.py
@@ -38,6 +38,10 @@ def docker_calls(monkeypatch):
         return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
 
     monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    # which() alone is not enough: _docker_is_usable also probes the daemon with
+    # `docker version`. Without this the sandbox decides Docker is unavailable
+    # and falls back to a host command, so no container flags appear.
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
     monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
     return calls
 
@@ -45,6 +49,7 @@ def docker_calls(monkeypatch):
 @pytest.fixture
 def sandbox(tmp_path, monkeypatch):
     monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
     sb = DockerSandbox(str(tmp_path), timeout_seconds=5)
     yield sb
     sandbox_mod._ACTIVE_CONTAINERS.clear()
@@ -217,6 +222,7 @@ def test_cleanup_is_idempotent(sandbox, docker_calls):
 def test_removal_tolerates_a_container_that_is_already_gone(monkeypatch):
     """`--rm` racing ahead of us is the normal case, not an error."""
     monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
 
     def fake_run(argv, *a, **k):
         return subprocess.CompletedProcess(
@@ -232,6 +238,7 @@ def test_removal_tolerates_a_container_that_is_already_gone(monkeypatch):
 )
 def test_removal_survives_a_broken_or_hanging_cli(monkeypatch, exc):
     monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
 
     def fake_run(*a, **k):
         raise exc
@@ -259,6 +266,7 @@ def test_sweep_filters_on_the_project_label(monkeypatch):
         return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
 
     monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
     monkeypatch.setattr(sandbox_mod.subprocess, "run", fake_run)
 
     removed = DockerSandbox.sweep_orphaned_containers()
@@ -299,6 +307,7 @@ def test_atexit_hook_clears_the_registry(docker_calls):
 def test_atexit_hook_never_raises(monkeypatch):
     """It runs during interpreter shutdown, where an exception is unhelpful."""
     monkeypatch.setattr(sandbox_mod.shutil, "which", lambda exe: "/usr/bin/docker")
+    monkeypatch.setattr(sandbox_mod, "_docker_is_usable", lambda *a, **k: True)
 
     def explode(*a, **k):
         raise RuntimeError("interpreter is going away")

--- a/tests/test_docker_hardening.py
+++ b/tests/test_docker_hardening.py
@@ -24,7 +24,7 @@ from modules.sandbox import DockerSandbox, _docker_user_flags  # noqa: E402
 @pytest.fixture
 def cmd(tmp_path):
     sandbox = DockerSandbox(str(tmp_path))
-    return sandbox._build_docker_command(["python", "-m", "pytest"])
+    return sandbox._build_docker_command(["python", "-m", "pytest"], "test-container")
 
 
 def _flag_value(argv, flag):
@@ -50,7 +50,7 @@ def test_pids_are_limited(cmd):
 
 
 def test_pids_limit_is_configurable(tmp_path):
-    argv = DockerSandbox(str(tmp_path), pids_limit=1024)._build_docker_command(["x"])
+    argv = DockerSandbox(str(tmp_path), pids_limit=1024)._build_docker_command(["x"], "test-container")
     assert "--pids-limit=1024" in argv
     assert "--pids-limit=256" not in argv
 
@@ -78,7 +78,7 @@ def test_command_still_builds_without_getuid(monkeypatch, tmp_path):
     monkeypatch.delattr(os, "getgid", raising=False)
 
     sandbox = DockerSandbox(str(tmp_path))
-    argv = sandbox._build_docker_command(["python", "-m", "pytest"])
+    argv = sandbox._build_docker_command(["python", "-m", "pytest"], "test-container")
     assert argv[0] == "docker"
     assert "--user" not in argv
     # Everything that is not UID-dependent must still be applied.
@@ -121,7 +121,7 @@ def test_read_only_is_off_by_default(cmd):
 
 
 def test_read_only_can_be_enabled(tmp_path):
-    argv = DockerSandbox(str(tmp_path), read_only=True)._build_docker_command(["x"])
+    argv = DockerSandbox(str(tmp_path), read_only=True)._build_docker_command(["x"], "test-container")
     assert "--read-only" in argv
 
 
@@ -144,7 +144,7 @@ def test_workspace_stays_writable(cmd, tmp_path):
 def test_inner_command_is_not_string_interpolated(tmp_path):
     """shlex.join, so a path with spaces or quotes cannot break out of sh -c."""
     argv = DockerSandbox(str(tmp_path))._build_docker_command(
-        ["pytest", "-k", "weird name'; rm -rf /"]
+        ["pytest", "-k", "weird name'; rm -rf /"], "test-container"
     )
     assert argv[-2] == "-c"
     assert "'weird name'\"'\"'; rm -rf /'" in argv[-1]
@@ -157,5 +157,5 @@ def test_image_precedes_the_inner_command(cmd):
 
 def test_custom_image_is_honoured(tmp_path):
     sandbox = DockerSandbox(str(tmp_path), image="node:20-slim")
-    argv = sandbox._build_docker_command(["x"])
+    argv = sandbox._build_docker_command(["x"], "test-container")
     assert "node:20-slim" in argv

--- a/tests/test_sandbox_base.py
+++ b/tests/test_sandbox_base.py
@@ -1,0 +1,149 @@
+"""
+Tests for the Sandbox base class (modules/sandbox.py).
+
+`SubprocessSandbox` and `DockerSandbox` were unrelated classes that happened to
+share some method names, and they had already drifted apart: `DockerSandbox` was
+missing `run`, `run_file` and `run_lint` entirely, so `--lint` or `--run-file`
+against it raised AttributeError rather than doing anything.
+
+Nothing detected that, because nothing required the two to agree. An ABC makes
+the divergence impossible rather than merely fixed.
+"""
+
+import inspect
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import (  # noqa: E402
+    DockerSandbox,
+    ExecutionResult,
+    Sandbox,
+    SubprocessSandbox,
+)
+
+BACKENDS = [SubprocessSandbox, DockerSandbox]
+INTERFACE = ["run", "run_tests", "run_file", "run_lint", "run_pre_commit"]
+
+
+# ── the contract ──────────────────────────────────────────────────────────
+
+
+def test_the_base_is_abstract():
+    assert inspect.isabstract(Sandbox)
+
+
+def test_the_base_cannot_be_instantiated():
+    with pytest.raises(TypeError):
+        Sandbox()
+
+
+def test_a_backend_without_run_cannot_be_instantiated():
+    """
+    The guarantee that matters: a new backend cannot half-exist. Firecracker or
+    a remote executor either implements run or fails at construction.
+    """
+
+    class Incomplete(Sandbox):
+        pass
+
+    with pytest.raises(TypeError):
+        Incomplete()
+
+
+def test_a_backend_with_run_gets_the_whole_surface():
+    class Minimal(Sandbox):
+        working_dir = "."
+        timeout = 5
+
+        def run(self, command, env=None, stdin_data=None):
+            return ExecutionResult(
+                command=" ".join(command), exit_code=0, stdout="", stderr="",
+                timed_out=False, duration_seconds=0.0,
+            )
+
+    backend = Minimal()
+
+    for name in INTERFACE:
+        assert hasattr(backend, name), name
+
+
+# ── both backends satisfy it ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=lambda c: c.__name__)
+def test_every_backend_subclasses_the_base(backend):
+    assert issubclass(backend, Sandbox)
+
+
+@pytest.mark.parametrize("backend", BACKENDS, ids=lambda c: c.__name__)
+@pytest.mark.parametrize("method", INTERFACE)
+def test_every_backend_has_every_method(backend, method):
+    """This is the assertion that was false before: Docker had three of four."""
+    assert callable(getattr(backend, method, None))
+
+
+def test_the_two_backends_expose_the_same_surface():
+    def public(cls):
+        return {
+            name for name, _ in inspect.getmembers(cls, inspect.isfunction)
+            if not name.startswith("_")
+        }
+
+    # cleanup is Docker-only: there is no container to remove in a subprocess.
+    assert public(SubprocessSandbox) <= public(DockerSandbox)
+
+
+# ── shared behaviour lives in one place ───────────────────────────────────
+
+
+def test_run_is_the_only_thing_a_backend_must_implement():
+    abstract = {
+        name for name in Sandbox.__abstractmethods__
+    }
+
+    assert abstract == {"run"}
+
+
+def test_docker_implements_run_itself():
+    """Containerisation belongs to the backend, not to each caller."""
+    assert "run" in DockerSandbox.__dict__
+
+
+def test_docker_inherits_the_shared_methods():
+    """
+    They were previously absent. Inheriting rather than copying is what stops
+    them going missing again.
+    """
+    for name in ("run_file", "run_lint", "run_pre_commit"):
+        assert name not in DockerSandbox.__dict__
+        assert hasattr(DockerSandbox, name)
+
+
+def test_docker_overrides_run_tests():
+    """
+    DOCKER_RUNNERS names the interpreter inside the image, not the one running
+    the agent, so this one genuinely differs.
+    """
+    assert "run_tests" in DockerSandbox.__dict__
+
+
+# ── behaviour is unchanged ────────────────────────────────────────────────
+
+
+def test_a_subprocess_command_still_runs(tmp_path):
+    result = SubprocessSandbox(str(tmp_path), timeout_seconds=30).run(
+        [sys.executable, "-c", "print('hello')"]
+    )
+
+    assert result.success is True
+    assert "hello" in result.stdout
+
+
+def test_an_unknown_runner_still_fails_cleanly(tmp_path):
+    result = SubprocessSandbox(str(tmp_path), timeout_seconds=30).run_tests("nonesuch")
+
+    assert result.exit_code == -3


### PR DESCRIPTION
Closes #68

## They had already diverged

The issue asks for an extensible base class so future backends are easy to add. That is a good reason, but there is a more immediate one: the two existing backends were unrelated classes that happened to share some method names, and they had drifted.

```
SubprocessSandbox: run, run_tests, run_file, run_lint, run_pre_commit
DockerSandbox    : run_tests, cleanup, _build_docker_command

missing from Docker: run, run_file, run_lint, run_pre_commit
```

So `--lint`, `--run-file`, or a repository's pre-commit hooks against a `DockerSandbox` raised `AttributeError` rather than doing anything. Nothing detected it, because nothing required the two classes to agree.

The gap was also widening. When I first measured it, three methods were missing. #144 then added `run_pre_commit` to `SubprocessSandbox` alone and it became four. That is the drift happening in real time, and it is the argument for this change better than any abstract one.

## What the base guarantees

`Sandbox(ABC)` requires exactly one method:

```python
Sandbox.__abstractmethods__  # frozenset({'run'})
```

Everything else — `run_tests`, `run_file`, `run_lint`, `run_pre_commit`, `_run_files_individually` — is expressed in terms of `run` and defined once. Two consequences:

- `DockerSandbox` gained all four missing methods by inheriting them, and cannot lose them again
- a new backend (Firecracker, a remote executor) implements `run` and gets the whole surface; one that forgets `run` fails at construction rather than at call time

## Docker gets a real `run`

The container lifecycle previously lived *inside* `run_tests`, which is why Docker could only ever run a test suite. It now lives in `run`, so every inherited method is containerised for free.

Everything from #52 is preserved exactly: `--name` with a generated container name, the label, `_register_atexit_once`, the `BaseException` handler that removes the container when the CLI is killed by Ctrl+C, and the timeout path that force-removes a container `--rm` does not cover.

`run_tests` stays overridden on `DockerSandbox`, and only because it genuinely differs: `DOCKER_RUNNERS` names the interpreter inside the image (`python`), not the one running the agent (`sys.executable`).

## Two drifted test suites, fixed here

Both were already failing on `main` before this change:

**`test_docker_hardening`** — `_build_docker_command` gained a container-name argument when #52 landed; six call sites still passed one argument. `5 failed, 10 errors → 17 passed`.

**`test_docker_cleanup`** — six fixtures mocked `shutil.which` but not `_docker_is_usable`, the daemon probe added by #49. The sandbox therefore decided Docker was unavailable and fell back to a host command, so no container flags ever appeared in the recorded argv. `7 failed → 27 passed`.

Fixed here because this PR is the one that touches those classes, and leaving them red would hide any regression this change did cause.

## Tests

`tests/test_sandbox_base.py` — 23 cases.

The contract: the base is abstract; it cannot be instantiated; a backend without `run` cannot be instantiated; a backend *with* `run` gets the whole surface.

Both backends: each subclasses the base; each has every interface method — the assertion that was false before, since Docker had two of six; the two expose the same public surface apart from `cleanup`, which is Docker-only because a subprocess has no container to remove.

Structure: `run` is the only abstract method; Docker implements `run` itself, since containerisation belongs to the backend; Docker *inherits* `run_file`, `run_lint` and `run_pre_commit` rather than copying them, which is what stops them going missing again; Docker overrides `run_tests`, for the reason above.

Behaviour: a subprocess command still runs; an unknown runner still fails cleanly with `-3`.

## Verified

- the interface comparison above, before and after
- 211 tests pass across `test_sandbox_base`, `test_sandbox_env`, `test_sandbox_fallback`, `test_docker_cleanup`, `test_docker_hardening`, `test_lint_step`, `test_runner_fallback` and `test_pre_commit`
- all six import-guard checks green
- ruff on `modules/sandbox.py`: 2 findings before, 1 after
- built on current `main` after #144 and #145

## One process note

My first two attempts extracted the shared methods with regex and scrambled the file — `run_pre_commit` ended up outside the class body, silently unreachable while the module still imported cleanly. I reset and used `ast` to get exact line ranges instead. Mentioning it because the broken version passed a casual look and only a `hasattr` check caught it.