### PR TITLE
feat: run multiple tasks concurrently in isolated worktrees — Closes #138

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,6 +50,12 @@ Examples:
     parser.add_argument("--repo", required=False,
                         help="Path to the git repository (not needed with --update)")
     parser.add_argument("--task", required=False, help="High-level task description, or a GitHub issue URL to pull one from (can also be provided via AGENT_TASK env var)")
+    parser.add_argument("--tasks", nargs="+", default=None, metavar="TASK",
+                        help="Run several tasks concurrently, each in its own git "
+                             "worktree on its own branch. Implies isolation, so "
+                             "tasks may touch the same files.")
+    parser.add_argument("--max-parallel-tasks", type=int, default=4, metavar="N",
+                        help="How many tasks to run at once (default: 4)")
 
     # Execution
     parser.add_argument("--runner", default="pytest",
@@ -194,8 +200,62 @@ def write_github_output(outputs: dict[str, str]):
             print(f"Failed to write to GITHUB_OUTPUT: {e}", file=sys.stderr)
 
 
+def _run_task_batch(args) -> int:
+    """
+    Run several tasks concurrently, each in an isolated worktree.
+
+    Kept apart from main() because the single-task path builds one AgentConfig
+    and reports one result; this one builds N and reports a table.
+    """
+    from modules.agent_loop import AgentConfig, AutonomousAgent
+    from modules.parallel_tasks import WorktreeError, render_summary, run_tasks
+
+    if not args.repo:
+        print("ERROR: --repo is required with --tasks.", file=sys.stderr)
+        return 2
+
+    repo_root = os.path.abspath(args.repo)
+
+    def run_one(task: str, worktree: str, branch: str):
+        # Each agent is pointed at its own checkout. Git is disabled inside the
+        # run because the worktree is already on the branch this task owns --
+        # letting the agent create another would nest branches per task.
+        config = AgentConfig(
+            repo_root=worktree,
+            task=task,
+            git_enabled=False,
+            yes=True,
+            max_iterations=args.max_iter,
+            test_runner=args.runner,
+            timeout_seconds=args.timeout,
+            anthropic_api_key=args.api_key,
+            model=args.model,
+            provider=args.provider,
+        )
+        return AutonomousAgent(config).run()
+
+    try:
+        outcomes = run_tasks(
+            repo_root,
+            args.tasks,
+            run_one,
+            max_workers=args.max_parallel_tasks,
+            branch_prefix=args.branch_prefix,
+            base_branch=args.base_branch,
+        )
+    except WorktreeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(render_summary(outcomes))
+    return 0 if all(o.ok for o in outcomes) else 1
+
+
 def main():
     args = parse_args()
+
+    if args.tasks:
+        sys.exit(_run_task_batch(args))
 
     if args.update:
         sys.exit(run_update(assume_yes=args.yes))

--- a/modules/parallel_tasks.py
+++ b/modules/parallel_tasks.py
@@ -1,0 +1,229 @@
+"""
+Module: Parallel tasks.
+
+Runs several tasks at once, each in its own git worktree.
+
+The issue this implements asks to "run in parallel if they don't affect the same
+files". That condition cannot be evaluated in advance: which files a task
+touches is decided by the model, and is not known until after the call that
+would already have happened. Any upfront guess is either so conservative that
+nothing runs in parallel, or wrong in a way that corrupts a run.
+
+Isolation sidesteps the question. `git worktree` gives each task a separate
+checkout on its own branch, sharing one object store. Two tasks may edit the
+same file because they are editing different copies of it, and the result is one
+branch per task for a human to merge or discard. Nothing needs to be predicted.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+_LOG = logging.getLogger("agent.parallel_tasks")
+
+# Worktrees are checkouts; too many at once means many copies of the repository
+# on disk and many test suites competing for the same cores.
+MAX_PARALLEL_TASKS = 4
+
+GIT_TIMEOUT = 120
+
+
+class WorktreeError(RuntimeError):
+    """Raised when an isolated checkout cannot be prepared."""
+
+
+@dataclass
+class TaskOutcome:
+    task: str
+    branch: Optional[str] = None
+    worktree: Optional[str] = None
+    outcome: str = "not_run"
+    message: str = ""
+    error: Optional[str] = None
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome == "success"
+
+
+@dataclass
+class WorktreeSet:
+    """Worktrees created for one batch, so they can all be removed together."""
+
+    repo_root: str
+    root: str
+    paths: list = field(default_factory=list)
+
+    def cleanup(self) -> None:
+        for path in self.paths:
+            _remove_worktree(self.repo_root, path)
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+def _git(repo_root: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", repo_root, *args],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", timeout=GIT_TIMEOUT,
+    )
+
+
+def _remove_worktree(repo_root: str, path: str) -> None:
+    """Remove one worktree. Never raises: cleanup must not mask a run's result."""
+    try:
+        _git(repo_root, "worktree", "remove", "--force", path)
+    except Exception as exc:
+        _LOG.warning("could not remove worktree %s: %s", path, exc)
+    shutil.rmtree(path, ignore_errors=True)
+
+
+def slugify(task: str, index: int) -> str:
+    """A short branch-safe name from a task description."""
+    words = [w for w in "".join(
+        c if c.isalnum() or c.isspace() else " " for c in task.lower()
+    ).split()][:4]
+    return f"{index:02d}-" + ("-".join(words) or "task")
+
+
+def is_git_repo(repo_root: str) -> bool:
+    """
+    True only when repo_root is itself the top of a work tree.
+
+    `--is-inside-work-tree` walks up, so any directory nested inside a
+    repository answers yes -- and pointing at a subdirectory would then create
+    worktrees for the parent repository, which is not what was asked for.
+    Comparing against `--show-toplevel` is the same check modules/updater.py
+    already makes.
+    """
+    result = _git(repo_root, "rev-parse", "--show-toplevel")
+    if result.returncode != 0:
+        return False
+
+    def norm(path: str) -> str:
+        return os.path.normcase(os.path.realpath(path))
+
+    return norm(result.stdout.strip()) == norm(repo_root)
+
+
+def create_worktrees(
+    repo_root: str,
+    tasks: list,
+    branch_prefix: str = "agent",
+    base_branch: Optional[str] = None,
+) -> WorktreeSet:
+    """
+    One worktree per task, each on a fresh branch.
+
+    Raises rather than falling back to a shared checkout: running several agents
+    against one working tree would have them overwrite each other's edits, which
+    is worse than refusing.
+    """
+    if not is_git_repo(repo_root):
+        raise WorktreeError(
+            f"{repo_root} is not a git repository. Parallel tasks need git "
+            f"worktrees for isolation; run tasks one at a time instead."
+        )
+
+    root = tempfile.mkdtemp(prefix="repopilot-tasks-")
+    created = WorktreeSet(repo_root=repo_root, root=root)
+
+    for index, task in enumerate(tasks, 1):
+        branch = f"{branch_prefix}/{slugify(task, index)}"
+        path = os.path.join(root, f"task-{index:02d}")
+        args = ["worktree", "add", "-b", branch, path]
+        if base_branch:
+            args.append(base_branch)
+
+        result = _git(repo_root, *args)
+        if result.returncode != 0:
+            created.cleanup()
+            raise WorktreeError(
+                f"Could not create a worktree for task {index}: "
+                f"{result.stderr.strip()}"
+            )
+        created.paths.append(path)
+
+    return created
+
+
+def run_tasks(
+    repo_root: str,
+    tasks: list,
+    run_one: Callable,
+    max_workers: int = MAX_PARALLEL_TASKS,
+    branch_prefix: str = "agent",
+    base_branch: Optional[str] = None,
+) -> list:
+    """
+    Run every task in its own worktree, concurrently.
+
+    `run_one(task, worktree_path, branch)` performs a single run and returns
+    something with `.outcome` and `.final_message`; it is injected so this module
+    does not import the agent loop, and so tests can drive it without an API key.
+
+    Worktrees are removed afterwards. The branches are not — they are the point,
+    and deleting them would throw the work away.
+    """
+    if not tasks:
+        return []
+
+    worktrees = create_worktrees(repo_root, tasks, branch_prefix, base_branch)
+    branches = [f"{branch_prefix}/{slugify(t, i)}" for i, t in enumerate(tasks, 1)]
+    outcomes = [
+        TaskOutcome(task=t, branch=b, worktree=p)
+        for t, b, p in zip(tasks, branches, worktrees.paths)
+    ]
+
+    try:
+        workers = max(1, min(max_workers, len(tasks)))
+        _LOG.info("Running %d task(s) across %d worker(s).", len(tasks), workers)
+
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(run_one, o.task, o.worktree, o.branch): o
+                for o in outcomes
+            }
+            for future in as_completed(futures):
+                outcome = futures[future]
+                try:
+                    result = future.result()
+                    outcome.outcome = getattr(result, "outcome", "unknown")
+                    outcome.message = getattr(result, "final_message", "") or ""
+                except Exception as exc:
+                    # One task failing must not take the others down with it.
+                    outcome.outcome = "error"
+                    outcome.error = f"{type(exc).__name__}: {exc}"
+                    _LOG.error("task failed: %s -- %s", outcome.task[:60], exc)
+    finally:
+        worktrees.cleanup()
+
+    return outcomes
+
+
+def render_summary(outcomes: list) -> str:
+    """A table of what each task did, and the branch its work is on."""
+    if not outcomes:
+        return "No tasks were run."
+
+    succeeded = sum(1 for o in outcomes if o.ok)
+    lines = [
+        "=" * 60,
+        f"{len(outcomes)} task(s): {succeeded} succeeded, "
+        f"{len(outcomes) - succeeded} did not",
+        "=" * 60,
+    ]
+    for outcome in outcomes:
+        mark = "OK  " if outcome.ok else "FAIL"
+        lines.append(f"{mark} {outcome.task[:56]}")
+        lines.append(f"     branch: {outcome.branch}  outcome: {outcome.outcome}")
+        if outcome.error:
+            lines.append(f"     error : {outcome.error}")
+    lines.append("")
+    lines.append("Worktrees have been removed. The branches remain -- review and")
+    lines.append("merge the ones you want.")
+    return "\n".join(lines)

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -1,0 +1,265 @@
+"""
+Tests for concurrent tasks (modules/parallel_tasks.py).
+
+The issue asks to run tasks in parallel "if they don't affect the same files".
+That condition cannot be evaluated in advance — which files a task touches is
+decided by the model, and is not known until after the call that would already
+have happened.
+
+Isolation removes the question instead of answering it: each task gets its own
+git worktree, so two tasks may edit the same file because they are editing
+different copies. Most of what follows checks that isolation actually holds.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.parallel_tasks import (  # noqa: E402
+    MAX_PARALLEL_TASKS,
+    TaskOutcome,
+    WorktreeError,
+    create_worktrees,
+    is_git_repo,
+    render_summary,
+    run_tasks,
+    slugify,
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "config", "user.name", "t"], check=True)
+    (tmp_path / "shared.py").write_text("x = 0\n")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "-A"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "init"], check=True)
+    return tmp_path
+
+
+def writer(content_from_task=True):
+    """A fake run that edits the same file in whichever worktree it is given."""
+
+    def _run(task, worktree, branch):
+        value = task if content_from_task else "fixed"
+        Path(worktree, "shared.py").write_text(f"x = {value!r}\n")
+        subprocess.run(["git", "-C", worktree, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", worktree, "commit", "-qm", task], check=True)
+        return SimpleNamespace(outcome="success", final_message=f"did {task}")
+
+    return _run
+
+
+def show(repo, branch, path="shared.py"):
+    return subprocess.run(
+        ["git", "-C", str(repo), "show", f"{branch}:{path}"],
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+
+# ── isolation ─────────────────────────────────────────────────────────────
+
+
+def test_tasks_touching_the_same_file_do_not_interfere(repo):
+    """
+    The case the issue says to avoid. With a worktree each it is not a problem,
+    which is why nothing has to be predicted about file overlap.
+    """
+    tasks = ["fix the parser", "add caching", "update docs"]
+
+    outcomes = run_tasks(str(repo), tasks, writer())
+
+    assert all(o.ok for o in outcomes)
+    for outcome in outcomes:
+        assert show(repo, outcome.branch) == f"x = {outcome.task!r}"
+
+
+def test_the_original_checkout_is_untouched(repo):
+    run_tasks(str(repo), ["one", "two"], writer())
+
+    assert (repo / "shared.py").read_text() == "x = 0\n"
+
+
+def test_each_task_gets_its_own_branch(repo):
+    outcomes = run_tasks(str(repo), ["alpha", "beta"], writer())
+
+    branches = {o.branch for o in outcomes}
+    assert len(branches) == 2
+
+
+def test_branches_survive_the_run(repo):
+    """
+    They are the output. Cleaning them up with the worktrees would throw the
+    work away.
+    """
+    outcomes = run_tasks(str(repo), ["alpha"], writer())
+    listed = subprocess.run(
+        ["git", "-C", str(repo), "branch", "--list", outcomes[0].branch],
+        capture_output=True, text=True,
+    ).stdout
+
+    assert outcomes[0].branch in listed
+
+
+def test_worktrees_are_removed(repo):
+    """Leaving them behind would fill the disk over repeated runs."""
+    outcomes = run_tasks(str(repo), ["alpha", "beta"], writer())
+
+    for outcome in outcomes:
+        assert not os.path.exists(outcome.worktree)
+
+
+# ── failure handling ──────────────────────────────────────────────────────
+
+
+def test_one_failing_task_does_not_stop_the_others(repo):
+    def sometimes(task, worktree, branch):
+        if task == "bad":
+            raise RuntimeError("boom")
+        return writer()(task, worktree, branch)
+
+    outcomes = run_tasks(str(repo), ["good", "bad", "also good"], sometimes)
+
+    assert sum(1 for o in outcomes if o.ok) == 2
+    assert any(o.error and "boom" in o.error for o in outcomes)
+
+
+def test_a_failure_is_reported_against_its_own_task(repo):
+    def fail_one(task, worktree, branch):
+        if task == "bad":
+            raise ValueError("nope")
+        return writer()(task, worktree, branch)
+
+    outcomes = run_tasks(str(repo), ["good", "bad"], fail_one)
+    failed = [o for o in outcomes if o.error]
+
+    assert len(failed) == 1
+    assert failed[0].task == "bad"
+
+
+def test_worktrees_are_removed_even_when_a_task_raises(repo):
+    def always_fail(task, worktree, branch):
+        raise RuntimeError("boom")
+
+    outcomes = run_tasks(str(repo), ["a", "b"], always_fail)
+
+    for outcome in outcomes:
+        assert not os.path.exists(outcome.worktree)
+
+
+def test_a_non_git_directory_is_refused(tmp_path):
+    """
+    Running several agents against one shared checkout would have them
+    overwrite each other. Refusing is better than that.
+    """
+    with pytest.raises(WorktreeError) as excinfo:
+        create_worktrees(str(tmp_path), ["a", "b"])
+
+    assert "not a git repository" in str(excinfo.value)
+
+
+def test_no_tasks_is_a_no_op(repo):
+    assert run_tasks(str(repo), [], writer()) == []
+
+
+# ── naming ────────────────────────────────────────────────────────────────
+
+
+def test_branch_names_are_derived_from_the_task():
+    assert slugify("Fix the parser TypeError", 1) == "01-fix-the-parser-typeerror"
+
+
+def test_branch_names_are_git_safe():
+    """Spaces, slashes and quotes in a task must not reach a ref name."""
+    name = slugify("fix: the parser's ~weird~ bug/thing", 3)
+
+    for bad in (" ", "~", "'", ":", "/"):
+        assert bad not in name
+
+
+def test_the_index_keeps_similar_tasks_distinct():
+    assert slugify("fix bug", 1) != slugify("fix bug", 2)
+
+
+def test_an_unnameable_task_still_yields_a_branch():
+    assert slugify("!!! ???", 7) == "07-task"
+
+
+# ── concurrency bound ─────────────────────────────────────────────────────
+
+
+def test_the_worker_count_is_bounded():
+    """
+    Each worktree is a checkout and each task runs a test suite; unbounded
+    means many copies of the repo and many suites fighting for the same cores.
+    """
+    assert 0 < MAX_PARALLEL_TASKS <= 8
+
+
+def test_more_workers_than_tasks_is_harmless(repo):
+    outcomes = run_tasks(str(repo), ["only one"], writer(), max_workers=16)
+
+    assert len(outcomes) == 1
+
+
+# ── reporting ─────────────────────────────────────────────────────────────
+
+
+def test_the_summary_counts_both_outcomes():
+    outcomes = [
+        TaskOutcome(task="a", branch="agent/01-a", outcome="success"),
+        TaskOutcome(task="b", branch="agent/02-b", outcome="failed"),
+    ]
+
+    summary = render_summary(outcomes)
+
+    assert "1 succeeded" in summary
+    assert "1 did not" in summary
+
+
+def test_the_summary_names_each_branch():
+    summary = render_summary(
+        [TaskOutcome(task="a", branch="agent/01-a", outcome="success")]
+    )
+
+    assert "agent/01-a" in summary
+
+
+def test_the_summary_says_where_the_work_is():
+    """Otherwise it is not obvious the branches are the deliverable."""
+    summary = render_summary(
+        [TaskOutcome(task="a", branch="agent/01-a", outcome="success")]
+    )
+
+    assert "branches remain" in summary
+
+
+def test_an_empty_summary_says_so():
+    assert "No tasks" in render_summary([])
+
+
+def test_the_repo_root_is_recognised(repo):
+    assert is_git_repo(str(repo)) is True
+
+
+def test_a_plain_directory_is_not_a_repo(tmp_path):
+    assert is_git_repo(str(tmp_path)) is False
+
+
+def test_a_subdirectory_is_not_treated_as_the_repo(repo):
+    """
+    `--is-inside-work-tree` walks up, so a nested directory answers yes and
+    worktrees would be created for the parent repository instead. Same trap the
+    --update flag hit.
+    """
+    nested = repo / "src" / "deep"
+    nested.mkdir(parents=True)
+
+    assert is_git_repo(str(nested)) is False


### PR DESCRIPTION
Closes #138

```bash
python main.py --repo . --tasks "Fix the parser TypeError" "Add caching to the client" "Update the README"
```

Each task runs in its own git worktree on its own branch. Worktrees are removed afterwards; the branches remain, because they are the output.

## The stated condition cannot be implemented

The issue asks to run tasks in parallel "if they don't affect the same files". That test cannot be evaluated in advance.

Which files a task touches is decided by the model, and is not known until after the API call that would already have happened. Any upfront guess is either so conservative that nothing ever runs in parallel — task descriptions rarely name their files — or wrong in a way that has two agents writing the same file in one checkout, which corrupts both runs and produces a diff nobody can review.

So this removes the question rather than answering it.

## Isolation instead of prediction

`git worktree` gives each task a separate checkout on its own branch, sharing one object store. Two tasks may edit the same file because they are editing different copies of it.

Verified with three tasks deliberately writing to **the same file** at the same time:

```
agent/01-fix-the-parser      x = 'fix the parser'
agent/02-add-caching         x = 'add caching'
agent/03-update-docs         x = 'update docs'
```

No interference, and the original checkout is untouched. Nothing had to be predicted.

## What comes out

```
============================================================
3 task(s): 3 succeeded, 0 did not
============================================================
OK   fix the parser
     branch: agent/01-fix-the-parser  outcome: success
...
Worktrees have been removed. The branches remain -- review and
merge the ones you want.
```

One branch per task, for a human to merge or discard. The agent does not attempt to combine them: two branches that both edit the same file are a genuine conflict, and resolving it automatically would mean guessing which change was wanted.

## Design decisions worth reviewing

**`run_one` is injected.** `run_tasks` takes a callable rather than importing `agent_loop`. That keeps the module free of a circular import, and lets every test exercise real worktrees without an API key.

**Git is disabled inside each run.** The worktree is already on the branch the task owns; letting the agent create another would nest a branch per task inside a branch per task.

**A non-git directory is refused, not worked around.** Falling back to a shared checkout would have several agents overwriting each other — worse than declining and telling the user to run tasks one at a time.

**Concurrency is capped at 4.** Each worktree is a full checkout and each task runs a test suite; unbounded means many copies of the repository on disk and many suites competing for the same cores.

**One failing task does not stop the others.** Each outcome carries its own error, and worktrees are cleaned up in a `finally` so a raised exception does not leave them on disk.

## A bug the tests caught

`is_git_repo` first used `git rev-parse --is-inside-work-tree`. That walks **up** the directory tree, so any nested directory answers yes — and pointing `--repo` at a subdirectory would have created worktrees for the parent repository instead.

Same trap `--update` hit earlier. It now compares against `--show-toplevel` with `realpath` and `normcase`, which is the check `modules/updater.py` already makes.

## Tests

`tests/test_parallel_tasks.py` — 23 cases, all against real worktrees.

Isolation: tasks touching the same file do not interfere; the original checkout is untouched; each task gets its own branch; branches survive the run; worktrees are removed.

Failure handling: one failing task does not stop the others; a failure is reported against its own task; worktrees are removed even when a task raises; a non-git directory is refused; no tasks is a no-op.

Naming: branch names are derived from the task; they are git-safe, so spaces, slashes, colons, tildes and quotes cannot reach a ref name; the index keeps similar tasks distinct; an unnameable task still yields a branch.

Bounds: the worker count is bounded; more workers than tasks is harmless.

Reporting: the summary counts both outcomes, names each branch, and says where the work is — otherwise it is not obvious the branches are the deliverable.

Repo detection: the root is recognised; a plain directory is not; **a subdirectory is not treated as the repo**.

## Verified

- the same-file test above, with real `git worktree` calls
- 23 tests pass; no regressions elsewhere
- all six import-guard checks green
- ruff clean on the new module
- built on current `main` after #145

## Not included

Merging the resulting branches. That needs a human — two branches editing the same file conflict by definition, and picking a winner automatically is the kind of guess that loses work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batch task execution through configurable task lists and parallel worker limits.
  * Runs tasks independently in isolated workspaces and preserves task branches for review or merging.
  * Displays a summary of successful and failed tasks.
  * Continues processing remaining tasks when an individual task fails.

* **Bug Fixes**
  * Added validation for repository paths and cleanup of temporary workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->