### PR TITLE
refactor(sandbox): one runner registry instead of five parallel tables — Closes #140

### DIFF
--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -90,20 +90,89 @@ class ExecutionResult:
 # vitest is invoked as `vitest run` on purpose. Bare `vitest` starts a watch
 # server when it thinks it is interactive; under this sandbox it would hold the
 # process open until timeout_seconds elapsed and be reported as a test timeout.
-ALLOWED_RUNNERS = {
-    "python": [sys.executable],
-    "pytest": [sys.executable, "-m", "pytest"],
-    "node": ["node"],
-    "npm_test": ["npm", "test", "--"],
-    "vitest": ["npx", "--no-install", "vitest", "run"],
-    "jest": ["npx", "--no-install", "jest"],
-    "bash": ["bash"],
-    "make": ["make"],
-    "go": ["go", "test", "./..."],
-    "cargo": ["cargo", "test"],
-    "ruby": ["ruby"],
-    "rspec": ["bundle", "exec", "rspec"],
+@dataclass(frozen=True)
+class LanguageRunner:
+    """
+    Everything the sandbox needs to know about one runner, in one place.
+
+    This information used to live in five parallel dicts keyed by the same
+    strings -- ALLOWED_RUNNERS, DOCKER_RUNNERS, MODULE_RUNNERS,
+    RUNNER_FALLBACKS and the linter table. Adding a language meant remembering
+    all of them, and DOCKER_RUNNERS was 10/12 an exact copy of ALLOWED_RUNNERS
+    that existed only because two entries name the interpreter differently.
+
+    The old dicts are still exported, derived from this registry, so nothing
+    that imports them needs to change.
+    """
+
+    name: str
+    language: str
+    command: list[str]
+    # Only set where the container genuinely differs -- for Python the host uses
+    # sys.executable and the image uses whatever `python` resolves to. Ten of
+    # the twelve runners are identical either side and say nothing here.
+    container_command: Optional[list[str]] = None
+    # Runners invoked as `python -m <module>`: shutil.which sees the
+    # interpreter, which always exists, so availability needs an import probe.
+    module: Optional[str] = None
+    # What to try when this runner is unavailable, where a weaker signal beats
+    # none. Only defined where the fallback can actually run the same suite.
+    fallback: Optional[str] = None
+    linters: tuple = ()
+
+
+RUNNERS: dict = {
+    r.name: r
+    for r in [
+        LanguageRunner("python", "python", [sys.executable], ["python"]),
+        LanguageRunner(
+            "pytest", "python", [sys.executable, "-m", "pytest"],
+            ["python", "-m", "pytest"],
+            module="pytest", fallback="python",
+            linters=("ruff", "flake8", "pyflakes"),
+        ),
+        LanguageRunner("node", "javascript", ["node"]),
+        LanguageRunner("npm_test", "javascript", ["npm", "test", "--"],
+                       linters=("eslint", "tsc")),
+        LanguageRunner("vitest", "javascript",
+                       ["npx", "--no-install", "vitest", "run"],
+                       linters=("eslint", "tsc")),
+        LanguageRunner("jest", "javascript", ["npx", "--no-install", "jest"],
+                       linters=("eslint", "tsc")),
+        LanguageRunner("bash", "bash", ["bash"]),
+        LanguageRunner("make", "make", ["make"]),
+        LanguageRunner("go", "go", ["go", "test", "./..."], linters=("govet",)),
+        LanguageRunner("cargo", "rust", ["cargo", "test"], linters=("clippy",)),
+        LanguageRunner("ruby", "ruby", ["ruby"]),
+        LanguageRunner("rspec", "ruby", ["bundle", "exec", "rspec"]),
+    ]
 }
+
+
+def runners_for_language(language: str) -> list[str]:
+    """Runner names registered for a language, for callers choosing one."""
+    return sorted(name for name, r in RUNNERS.items() if r.language == language)
+
+
+def linters_for_runner(runner: str) -> tuple:
+    """Linters that make sense alongside a runner."""
+    entry = RUNNERS.get(runner)
+    return entry.linters if entry else ()
+
+
+# ── Derived views ───────────────────────────────────────────────────────
+#
+# Kept so existing imports keep working. Deriving them is the point: the
+# tables can no longer disagree with each other, because there is only one
+# table.
+
+ALLOWED_RUNNERS = {name: r.command for name, r in RUNNERS.items()}
+DOCKER_RUNNERS = {
+    name: (r.container_command or r.command) for name, r in RUNNERS.items()
+}
+MODULE_RUNNERS = {name: r.module for name, r in RUNNERS.items() if r.module}
+RUNNER_FALLBACKS = {name: r.fallback for name, r in RUNNERS.items() if r.fallback}
+
 
 # Linters run before the suite. A syntax error or an undefined name is caught in
 # under a second and gives the model a precise location, where the same mistake
@@ -129,20 +198,6 @@ ALLOWED_LINTERS = {
     "clippy": ["cargo", "clippy"],
 }
 
-DOCKER_RUNNERS = {
-    "python": ["python"],
-    "pytest": ["python", "-m", "pytest"],
-    "node": ["node"],
-    "npm_test": ["npm", "test", "--"],
-    "vitest": ["npx", "--no-install", "vitest", "run"],
-    "jest": ["npx", "--no-install", "jest"],
-    "bash": ["bash"],
-    "make": ["make"],
-    "go": ["go", "test", "./..."],
-    "cargo": ["cargo", "test"],
-    "ruby": ["ruby"],
-    "rspec": ["bundle", "exec", "rspec"],
-}
 
 # ---------------------------------------------------------------------------
 # Environment sanitization
@@ -302,13 +357,11 @@ def _build_safe_env(extra_env: Optional[dict] = None) -> dict:
 # which for these is the interpreter itself and therefore always present -- so
 # the "runner not found" guard never fires for them. Their availability has to
 # be probed by importing the module instead.
-MODULE_RUNNERS = {"pytest": "pytest"}
 
 # What each runner falls back to when it is unavailable. Only defined where the
 # fallback can actually run the same suite: `python -m pytest` and plain
 # `python <file>` both execute test files, so a repo whose tests are runnable as
 # scripts still gets a real signal. There is no equivalent for cargo or go.
-RUNNER_FALLBACKS = {"pytest": "python"}
 
 
 def _module_is_available(module: str) -> bool:

--- a/tests/test_runner_registry.py
+++ b/tests/test_runner_registry.py
@@ -1,0 +1,151 @@
+"""
+Tests for the runner registry (modules/sandbox.py).
+
+Runner information lived in five parallel dicts keyed by the same strings:
+ALLOWED_RUNNERS, DOCKER_RUNNERS, MODULE_RUNNERS, RUNNER_FALLBACKS and the linter
+table. Adding a language meant remembering all of them, and DOCKER_RUNNERS was
+ten of twelve an exact copy of ALLOWED_RUNNERS — it existed only because two
+entries name the Python interpreter differently.
+
+Those dicts are now derived from one registry. They are still exported, so
+nothing importing them had to change, and they can no longer disagree.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import (  # noqa: E402
+    ALLOWED_LINTERS,
+    ALLOWED_RUNNERS,
+    DOCKER_RUNNERS,
+    MODULE_RUNNERS,
+    RUNNER_FALLBACKS,
+    RUNNERS,
+    LanguageRunner,
+    linters_for_runner,
+    runners_for_language,
+)
+
+
+# ── the registry is the source ────────────────────────────────────────────
+
+
+def test_every_entry_is_a_language_runner():
+    for name, entry in RUNNERS.items():
+        assert isinstance(entry, LanguageRunner), name
+
+
+def test_the_key_matches_the_name():
+    for name, entry in RUNNERS.items():
+        assert entry.name == name
+
+
+def test_every_runner_has_a_command():
+    for name, entry in RUNNERS.items():
+        assert entry.command, name
+
+
+def test_every_runner_declares_a_language():
+    for name, entry in RUNNERS.items():
+        assert entry.language, name
+
+
+def test_entries_are_immutable():
+    """A shared registry that callers can mutate is a bug waiting to happen."""
+    with pytest.raises(Exception):
+        RUNNERS["pytest"].command = ["rm", "-rf", "/"]
+
+
+# ── the derived views match what they replaced ────────────────────────────
+
+
+def test_allowed_runners_covers_every_entry():
+    assert set(ALLOWED_RUNNERS) == set(RUNNERS)
+
+
+def test_docker_runners_covers_every_entry():
+    """
+    The old table was maintained by hand and could silently omit a runner that
+    ALLOWED_RUNNERS had. Deriving it makes that impossible.
+    """
+    assert set(DOCKER_RUNNERS) == set(RUNNERS)
+
+
+def test_docker_falls_back_to_the_host_command():
+    """Ten of twelve runners are identical either side; only Python differs."""
+    for name, entry in RUNNERS.items():
+        if entry.container_command is None:
+            assert DOCKER_RUNNERS[name] == ALLOWED_RUNNERS[name], name
+
+
+@pytest.mark.parametrize("name", ["python", "pytest"])
+def test_python_runners_differ_inside_a_container(name):
+    """
+    The host uses sys.executable; the image uses whatever `python` resolves to.
+    This is the entire reason a separate Docker table existed.
+    """
+    assert DOCKER_RUNNERS[name] != ALLOWED_RUNNERS[name]
+    assert DOCKER_RUNNERS[name][0] == "python"
+
+
+def test_module_runners_are_derived():
+    assert MODULE_RUNNERS == {"pytest": "pytest"}
+
+
+def test_fallbacks_are_derived():
+    assert RUNNER_FALLBACKS == {"pytest": "python"}
+
+
+def test_a_fallback_points_at_a_real_runner():
+    """A fallback naming a runner that does not exist would fail at use time."""
+    for name, fallback in RUNNER_FALLBACKS.items():
+        assert fallback in RUNNERS, f"{name} falls back to unknown {fallback}"
+
+
+# ── the runners that were there before are still there ────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["python", "pytest", "node", "npm_test", "vitest", "jest",
+     "bash", "make", "go", "cargo", "ruby", "rspec"],
+)
+def test_no_runner_was_lost(name):
+    assert name in ALLOWED_RUNNERS
+
+
+def test_the_count_is_unchanged():
+    assert len(ALLOWED_RUNNERS) == 12
+
+
+# ── what the registry makes possible ──────────────────────────────────────
+
+
+def test_runners_can_be_listed_by_language():
+    """Not answerable from the old tables, which had no notion of a language."""
+    assert runners_for_language("python") == ["pytest", "python"]
+    assert runners_for_language("javascript") == ["jest", "node", "npm_test", "vitest"]
+
+
+def test_an_unknown_language_lists_nothing():
+    assert runners_for_language("cobol") == []
+
+
+def test_linters_are_associated_with_runners():
+    assert "ruff" in linters_for_runner("pytest")
+    assert "clippy" in linters_for_runner("cargo")
+
+
+def test_an_unknown_runner_has_no_linters():
+    assert linters_for_runner("nonesuch") == ()
+
+
+def test_associated_linters_exist_in_the_linter_table():
+    """An association naming a linter with no command would break at use time."""
+    for name, entry in RUNNERS.items():
+        for linter in entry.linters:
+            assert linter in ALLOWED_LINTERS, f"{name} -> unknown linter {linter}"


### PR DESCRIPTION
Closes #140

## Five tables keyed by the same strings

Runner information was spread across `ALLOWED_RUNNERS`, `DOCKER_RUNNERS`, `MODULE_RUNNERS`, `RUNNER_FALLBACKS` and the linter table. Adding a language meant remembering all of them, and nothing checked that they agreed.

`DOCKER_RUNNERS` was the clearest symptom — **ten of its twelve entries were an exact copy** of `ALLOWED_RUNNERS`:

| runner | host vs container |
| ------ | ----------------- |
| bash, cargo, go, jest, make, node, npm_test, rspec, ruby, vitest | identical |
| python, pytest | differ — host `sys.executable`, image `python` |

So 83% of that table existed to say "same as the other one", which is exactly the shape that drifts.

## One registry, everything else derived

```python
LanguageRunner(
    "pytest", "python", [sys.executable, "-m", "pytest"],
    ["python", "-m", "pytest"],
    module="pytest", fallback="python",
    linters=("ruff", "flake8", "pyflakes"),
)
```

`container_command` is set only where it genuinely differs; ten runners say nothing there and inherit their host command.

All five old dicts are still exported, now derived from `RUNNERS`. Nothing importing them had to change, and they can no longer disagree with each other, because there is only one table.

## Equivalence checked, not assumed

The tables were snapshotted before the change and compared after:

```
ALLOWED_RUNNERS      identical to before: True
DOCKER_RUNNERS       identical to before: True
ALLOWED_LINTERS      identical to before: True
RUNNER_FALLBACKS     identical to before: True
MODULE_RUNNERS       identical to before: True
```

This is a pure refactor. No runner was added, removed or changed.

## What the registry makes possible

Neither of these was answerable from the old tables, which had no notion of a language:

```python
runners_for_language("javascript")   # ['jest', 'node', 'npm_test', 'vitest']
linters_for_runner("cargo")          # ('clippy',)
```

Two tests use those associations as consistency checks: every fallback must name a runner that exists, and every associated linter must exist in `ALLOWED_LINTERS`. Both would previously have failed silently at use time.

Entries are frozen dataclasses — a shared registry callers can mutate is a bug waiting to happen.

## Tests

`tests/test_runner_registry.py` — 31 cases.

The registry: every entry is a `LanguageRunner`; the key matches the name; every runner has a command and declares a language; entries are immutable.

The derived views: `ALLOWED_RUNNERS` and `DOCKER_RUNNERS` each cover every entry, which the hand-maintained version could not guarantee; Docker falls back to the host command where no override is set; the two Python runners do differ inside a container, which is the whole reason a separate table existed; module runners and fallbacks are derived; a fallback points at a real runner.

Nothing lost: all twelve runners are individually asserted present, and the count is pinned at 12.

New capability: runners can be listed by language; an unknown language lists nothing; linters are associated with runners; an unknown runner has no linters; associated linters exist in the linter table.

## Verified

- the equivalence snapshot above
- 167 tests pass across `test_sandbox_env`, `test_sandbox_fallback`, `test_lint_step`, `test_runner_fallback`, `test_js_runners` and `test_pre_commit`
- 31 new tests pass
- all six import-guard checks green
- ruff on `modules/sandbox.py` unchanged at 2 findings

## Merge order

This conflicts with #68, which also restructures `sandbox.py`. #68 should merge first — it adds the `Sandbox` base class — and I will rebase this onto it rather than hand-resolving.