### PR TITLE
fix: handle Windows paths consistently in the modifier and docker mounts — Closes #170, #177

### DIFF
--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -9,7 +9,7 @@ import os
 import shutil
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -179,9 +179,23 @@ class CodeModificationEngine:
         if not relative_path or not relative_path.strip():
             raise ValueError("Path is empty")
 
-        candidate = Path(relative_path.replace("\\", "/"))
-        if candidate.is_absolute():
+        normalised = relative_path.replace("\\", "/")
+
+        # Checked against both path flavours, not just the current platform's.
+        # `Path` picks the host flavour, so "C:/Windows/evil.txt" is absolute on
+        # Windows and merely odd on Linux -- the same model output was rejected
+        # on one machine and silently created a directory named "C:" inside the
+        # repository on another. A drive letter, a UNC share and a leading slash
+        # are all refused everywhere.
+        if PureWindowsPath(normalised).is_absolute() or PurePosixPath(normalised).is_absolute():
             raise ValueError(f"Absolute paths are not allowed: '{relative_path}'")
+
+        # "C:file.txt" is drive-relative: absolute on neither flavour, but it
+        # names a location on another drive rather than in this repository.
+        if PureWindowsPath(normalised).drive:
+            raise ValueError(f"Drive-qualified paths are not allowed: '{relative_path}'")
+
+        candidate = Path(normalised)
 
         abs_path = (Path(self.repo_root) / candidate).resolve()
         repo_root = Path(self.repo_root).resolve()

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -17,6 +17,7 @@ import shlex
 import shutil
 import subprocess
 from abc import ABC, abstractmethod
+from pathlib import PurePosixPath, PureWindowsPath
 import time
 import sys
 import uuid
@@ -863,6 +864,34 @@ def _docker_user_flags() -> list[str]:
     return ["--user", f"{getuid()}:{getgid()}"]
 
 
+def _docker_mount_path(path: str) -> str:
+    """
+    A host path in the form Docker accepts for `-v`.
+
+    Docker Desktop on Windows takes forward slashes and treats a colon as the
+    separator between host path, container path and mode. `D:\\repo` therefore
+    has to become `D:/repo`, and an already-posix path is returned unchanged.
+
+    A UNC path (`\\\\server\\share`) cannot be bind-mounted at all; saying so is
+    better than emitting an argument Docker will reject with its own message.
+    """
+    if path.startswith("\\\\") or path.startswith("//"):
+        raise ValueError(
+            f"Docker cannot bind-mount a network path: {path}. "
+            f"Use a local drive, or run without Docker."
+        )
+
+    normalised = path.replace("\\", "/")
+
+    # Only relative paths need resolving. os.path.abspath uses the host
+    # flavour, so calling it on "D:/repo" from Linux would prepend the current
+    # directory and produce something meaningless.
+    if PureWindowsPath(normalised).is_absolute() or PurePosixPath(normalised).is_absolute():
+        return normalised
+
+    return os.path.abspath(normalised).replace("\\", "/")
+
+
 class DockerSandbox(Sandbox):
     """
     Docker-based sandbox for untrusted code.
@@ -934,7 +963,7 @@ class DockerSandbox(Sandbox):
         cmd += [
             "--tmpfs", "/tmp:rw,nosuid,nodev,size=256m",
             "-e", "HOME=/tmp",
-            "-v", f"{self.working_dir}:/workspace:rw",
+            "-v", f"{_docker_mount_path(self.working_dir)}:/workspace:rw",
             "-w", "/workspace",
             self.image,
             "sh", "-c", shlex.join(inner_cmd),

--- a/tests/test_docker_hardening.py
+++ b/tests/test_docker_hardening.py
@@ -18,7 +18,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from modules.sandbox import DockerSandbox, _docker_user_flags  # noqa: E402
+from modules.sandbox import (  # noqa: E402
+    DockerSandbox,
+    _docker_mount_path,
+    _docker_user_flags,
+)
 
 
 @pytest.fixture
@@ -137,7 +141,11 @@ def test_existing_isolation_flags_are_preserved(cmd):
 
 def test_workspace_stays_writable(cmd, tmp_path):
     """Made rw in #8 so tests can create fixtures; that is not reverted here."""
-    assert f"{os.path.abspath(str(tmp_path))}:/workspace:rw" in cmd
+    # Compared against the converted form: Docker takes forward slashes, and on
+    # Windows a raw path would carry backslashes and a drive colon that Docker
+    # reads as its own separator. This assertion previously encoded the bug and
+    # passed on Linux only because abspath already matched there.
+    assert f"{_docker_mount_path(str(tmp_path))}:/workspace:rw" in cmd
     assert _flag_value(cmd, "-w") == "/workspace"
 
 

--- a/tests/test_windows_paths.py
+++ b/tests/test_windows_paths.py
@@ -1,0 +1,145 @@
+"""
+Tests for cross-platform path handling (modules/code_modifier.py, modules/sandbox.py).
+
+Two places treated paths with the host's flavour, so the same input behaved
+differently depending on which machine the agent ran on.
+
+`_safe_abs_path` normalised backslashes and then called `Path.is_absolute()`.
+That picks the host flavour: `C:/Windows/evil.txt` is absolute on Windows and
+rejected, and merely unusual on Linux, where it silently created a directory
+named `C:` inside the repository.
+
+`_build_docker_command` interpolated the host path directly. Docker Desktop on
+Windows needs forward slashes, and a colon there is the separator between host
+path, container path and mode.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.code_modifier import CodeModificationEngine  # noqa: E402
+from modules.sandbox import _docker_mount_path  # noqa: E402
+
+
+@pytest.fixture
+def engine():
+    root = tempfile.mkdtemp()
+    return CodeModificationEngine(root, f"{root}/.backups")
+
+
+# ── paths the model must not be able to write to ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../../etc/passwd",
+        "/etc/passwd",
+        "sub/../../../out.txt",
+        r"C:\Windows\system32\evil.txt",
+        "C:/Windows/system32/evil.txt",
+        r"\\server\share\evil.txt",
+        "//server/share/evil.txt",
+        r"\Windows\evil.txt",
+    ],
+)
+def test_escaping_paths_are_refused(engine, path):
+    with pytest.raises(ValueError):
+        engine._safe_abs_path(path)
+
+
+def test_a_drive_relative_path_is_refused(engine):
+    """
+    "C:file.txt" is absolute on neither flavour, but it still names a location
+    on another drive rather than in this repository.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        engine._safe_abs_path("C:file.txt")
+
+    assert "Drive-qualified" in str(excinfo.value)
+
+
+def test_the_rejection_is_the_same_on_every_platform(engine):
+    """
+    The point of the fix. Previously a drive-absolute path was rejected on
+    Windows and quietly accepted on Linux, so the same model output produced
+    different behaviour depending on the machine.
+    """
+    for path in (r"C:\Windows\evil.txt", "C:/Windows/evil.txt"):
+        with pytest.raises(ValueError):
+            engine._safe_abs_path(path)
+
+
+# ── ordinary paths still work ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", ["file.py", "sub/file.py", "a/b/c/file.py", "./file.py"])
+def test_normal_paths_are_allowed(engine, path):
+    assert engine._safe_abs_path(path)
+
+
+def test_backslash_separators_are_accepted(engine):
+    """A model on Windows may well emit sub\\file.py; that is not an escape."""
+    assert engine._safe_abs_path(r"sub\file.py")
+
+
+def test_an_empty_path_is_refused(engine):
+    with pytest.raises(ValueError):
+        engine._safe_abs_path("   ")
+
+
+# ── docker mounts ─────────────────────────────────────────────────────────
+
+
+def test_a_posix_path_is_unchanged():
+    assert _docker_mount_path("/home/user/repo") == "/home/user/repo"
+
+
+@pytest.mark.parametrize(
+    "windows,expected",
+    [
+        (r"C:\Users\saket\repo", "C:/Users/saket/repo"),
+        (r"D:\repopilot", "D:/repopilot"),
+        (r"C:\Program Files\repo", "C:/Program Files/repo"),
+    ],
+)
+def test_windows_paths_become_forward_slashed(windows, expected):
+    assert _docker_mount_path(windows) == expected
+
+
+def test_an_absolute_path_is_not_re_resolved():
+    """
+    os.path.abspath uses the host flavour, so calling it on "D:/repo" from
+    Linux would prepend the working directory and produce nonsense.
+    """
+    assert _docker_mount_path("D:/repo") == "D:/repo"
+
+
+def test_a_relative_path_is_resolved():
+    assert Path(_docker_mount_path("some/dir")).is_absolute()
+
+
+@pytest.mark.parametrize("unc", [r"\\server\share\repo", "//server/share/repo"])
+def test_a_network_path_is_refused(unc):
+    """
+    Docker cannot bind-mount a UNC path. Saying so beats emitting an argument
+    that fails later with Docker's own less specific message.
+    """
+    with pytest.raises(ValueError) as excinfo:
+        _docker_mount_path(unc)
+
+    assert "network path" in str(excinfo.value)
+
+
+def test_the_mount_argument_uses_the_converted_path():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "sandbox.py"
+    ).read_text(encoding="utf-8")
+
+    assert '_docker_mount_path(self.working_dir)' in source
+    assert 'f"{self.working_dir}:/workspace:rw"' not in source


### PR DESCRIPTION
Closes #170
Closes #177

Two places treated paths with the host's flavour, so the same input behaved differently depending on which machine the agent ran on. Both surfaced only when the suite was run on Windows; the Linux run was green throughout.

## #170 — Docker mounts, exactly as reported

`_build_docker_command` interpolated the host path straight into the `-v` argument:

```python
"-v", f"{self.working_dir}:/workspace:rw",
```

On Windows that produces:

```
C:\Users\saket\repo:/workspace:rw
```

Docker Desktop needs forward slashes, and a colon is its own separator between host path, container path and mode — so the drive letter's colon is read as a separator and the argument is malformed. After:

```
C:/Users/saket/repo:/workspace:rw
```

A UNC path is now refused with a clear message rather than handed to Docker to fail on with a less specific one, since a network share cannot be bind-mounted at all.

One detail worth noting: `os.path.abspath` also uses the host flavour, so calling it on `D:/repo` from Linux prepends the working directory and produces nonsense. Only genuinely relative paths are resolved.

## The existing test encoded the bug

`test_workspace_stays_writable` asserted:

```python
assert f"{os.path.abspath(str(tmp_path))}:/workspace:rw" in cmd
```

That is the raw host path. On Linux `abspath` already returns forward slashes, so it passed and nobody noticed; on Windows it returns `C:\Users\...`, which is precisely what Docker cannot accept. The test was enforcing the broken behaviour. It now compares against the converted path.

## #177 — not the vulnerability described, but a real inconsistency

I want to be accurate about this one. The containment check was already working. Every genuine escape was rejected before this change:

```
../../etc/passwd        blocked
/etc/passwd             blocked
sub/../../../out.txt    blocked
```

Nothing could be written outside the repository root, so this is not the path traversal vulnerability the issue reports.

What it does fix is a platform split. `_safe_abs_path` normalised backslashes and then called `Path.is_absolute()`, which picks the host flavour:

| input | absolute on Linux | absolute on Windows |
| ----- | ----------------- | ------------------- |
| `C:/Windows/evil.txt` | no | yes |
| `\Windows\evil.txt` | yes | no |

So the same model output was rejected on one machine and, on the other, quietly created a directory named `C:` inside the repository. Contained, but wrong — and confusing to debug, because the run behaves differently on a colleague's machine for no visible reason.

Both flavours are now checked. Drive-relative paths like `C:file.txt` are also refused: absolute on neither flavour, but still naming a location on another drive rather than in this repository.

Ordinary paths are unaffected, including `sub\file.py` — a model running against a Windows checkout may well emit backslash separators, and that is not an escape attempt.

## Tests

`tests/test_windows_paths.py` — 25 cases.

Refused: eight escaping forms, parametrised — relative traversal, posix absolute, nested traversal, both slash styles of a drive-absolute path, both styles of a UNC path, and a rooted path. Drive-relative paths are refused with their own message. One test asserts the rejection is identical on every platform, which is the actual point of the change.

Allowed: ordinary relative paths, nested paths, `./` prefixes, and backslash separators. An empty path is still refused.

Docker mounts: a posix path is unchanged; three Windows forms including one with a space become forward-slashed; an already-absolute path is not re-resolved; a relative path is; both UNC forms are refused; and the mount argument is asserted to use the converted path rather than the raw one.

## Verified

- the before/after mount arguments above
- every path form in the table, against both `PurePosixPath` and `PureWindowsPath`
- 25 new tests pass, plus `test_docker_hardening`, `test_docker_cleanup`, `test_sandbox_base`, `test_rollback_created_files` and `test_rename_action` — no regressions
- all six import-guard checks green
- ruff clean on both changed modules
- confirmed on Windows, where the pre-existing test failure surfaced

## Suggested follow-up

This is the third Windows-only defect found this way — the others were `--update` walking into an ancestor repository, and `_discover_test_files` emitting backslash paths that would not resolve inside a Linux container. Each passed CI and each was caught by running the suite locally on Windows.

A `windows-latest` entry in the existing workflow matrix would catch this class automatically. Happy to open that separately if you want it.