### PR TITLE
feat: summarise net file changes when a run finishes — Closes #156

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -47,6 +47,7 @@ from modules.run_state import (
     save_state,
 )
 from modules.project_rules import load_project_rules, render_project_rules
+from modules.change_summary import render_change_summary, summarise_changes
 from modules.logger import AgentLogger, IterationRecord
 from modules.secret_scanner import scan_directory, format_findings
 from modules.token_tracker import TokenTracker
@@ -412,6 +413,10 @@ class AutonomousAgent:
         last_exec: Optional[ExecutionResult] = None
         last_changes: list[FileChange] = []
         last_apply_results: list[ApplyResult] = []
+        # Every applied change across the whole run, not just the last
+        # iteration -- the end-of-run summary reports net effect, and
+        # last_apply_results is overwritten each time round.
+        all_apply_results: list[ApplyResult] = []
         start_iteration = 1
 
         if cfg.resume_from:
@@ -702,6 +707,7 @@ class AutonomousAgent:
                 self.logger.log_apply_results(apply_results)
                 last_changes = valid_changes
                 last_apply_results = apply_results
+                all_apply_results.extend(apply_results)
                 self._applied = apply_results
 
                 iter_record.apply_results = [
@@ -936,6 +942,12 @@ class AutonomousAgent:
                 "or run with --rollback to discard them."
             ),
         }.get(outcome, "Unknown outcome")
+
+        # Printed before the run record closes, so it sits with the outcome
+        # rather than scrolling past earlier in the log.
+        changed = summarise_changes(all_apply_results)
+        if changed:
+            self.logger.info("\n" + render_change_summary(changed))
 
         self.logger.finish_run(outcome, self.branch_name, self.pr_url)
 

--- a/modules/change_summary.py
+++ b/modules/change_summary.py
@@ -1,0 +1,128 @@
+"""
+Module: Change summary.
+
+A table of what a run actually did to the repository, printed when it finishes.
+
+The subtlety is that a run has several iterations and a file can be touched in
+more than one. A file created in iteration 1 and edited again in iteration 3 is
+"added" as far as the repository is concerned, not "modified" -- what a reader
+wants is the net effect against the state the run started from, not a log of
+every intermediate step.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+ADDED = "added"
+MODIFIED = "modified"
+DELETED = "deleted"
+RENAMED = "renamed"
+
+# Column order in the rendered table, and the order sections appear in.
+ACTION_ORDER = (ADDED, MODIFIED, RENAMED, DELETED)
+
+SYMBOLS = {ADDED: "+", MODIFIED: "~", DELETED: "-", RENAMED: ">"}
+
+
+@dataclass
+class ChangedFile:
+    path: str
+    action: str
+    new_path: Optional[str] = None
+
+
+def _net(previous: Optional[str], current: str) -> Optional[str]:
+    """
+    Combine what already happened to a path with what just happened to it.
+
+    Returns None when the two cancel out -- a file created and then deleted
+    within the same run leaves the repository as it was, and listing it would
+    send someone looking for a change that is not there.
+    """
+    if previous is None:
+        return current
+
+    if previous == ADDED:
+        if current == DELETED:
+            return None          # created then removed: no net change
+        return ADDED             # still an addition, however often it was edited
+
+    if previous == DELETED:
+        # Deleted then written again is a modification, not an addition.
+        return MODIFIED if current in (ADDED, MODIFIED) else DELETED
+
+    if previous == MODIFIED and current == DELETED:
+        return DELETED
+
+    if previous == RENAMED:
+        return RENAMED
+
+    return current if current != MODIFIED else previous
+
+
+def summarise_changes(apply_results) -> list:
+    """
+    Fold every applied change across a run into one entry per path.
+
+    Takes anything with `.path`, `.action`, `.success` and optionally
+    `.new_path`; failed applications are ignored, since they changed nothing.
+    """
+    net: dict = {}
+    renames: dict = {}
+
+    for result in apply_results:
+        if not getattr(result, "success", False):
+            continue
+
+        path = result.path
+        action = result.action
+        if action == "create":
+            action = ADDED
+        elif action == "modify" or action == "patch":
+            action = MODIFIED
+        elif action == "delete":
+            action = DELETED
+        elif action == "rename":
+            action = RENAMED
+            renames[path] = getattr(result, "new_path", None)
+
+        combined = _net(net.get(path), action)
+        if combined is None:
+            net.pop(path, None)
+            renames.pop(path, None)
+        else:
+            net[path] = combined
+
+    return [
+        ChangedFile(path=path, action=action, new_path=renames.get(path))
+        for path, action in sorted(net.items())
+    ]
+
+
+def render_change_summary(changed: list) -> str:
+    """A grouped table of the net changes, or a line saying there were none."""
+    if not changed:
+        return "No files were changed."
+
+    by_action: dict = {}
+    for entry in changed:
+        by_action.setdefault(entry.action, []).append(entry)
+
+    counts = ", ".join(
+        f"{len(by_action[a])} {a}" for a in ACTION_ORDER if a in by_action
+    )
+    lines = [
+        "-" * 60,
+        f"Files changed: {counts}",
+        "-" * 60,
+    ]
+
+    for action in ACTION_ORDER:
+        for entry in by_action.get(action, []):
+            symbol = SYMBOLS[action]
+            if action == RENAMED and entry.new_path:
+                lines.append(f"  {symbol} {entry.path} -> {entry.new_path}")
+            else:
+                lines.append(f"  {symbol} {entry.path}")
+
+    return "\n".join(lines)

--- a/tests/test_change_summary.py
+++ b/tests/test_change_summary.py
@@ -1,0 +1,179 @@
+"""
+Tests for the end-of-run file summary (modules/change_summary.py).
+
+A run has several iterations and a file can be touched in more than one, so the
+table reports net effect against the state the run started from rather than a
+log of every intermediate step. A file created in iteration 1 and edited again
+in iteration 3 is an addition, not a modification.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.change_summary import (  # noqa: E402
+    ADDED,
+    DELETED,
+    MODIFIED,
+    RENAMED,
+    render_change_summary,
+    summarise_changes,
+)
+
+
+def applied(path, action, success=True, new_path=None):
+    return SimpleNamespace(
+        path=path, action=action, success=success, new_path=new_path
+    )
+
+
+def actions(results):
+    return {c.path: c.action for c in summarise_changes(results)}
+
+
+# ── one action per file ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "action,expected",
+    [("create", ADDED), ("modify", MODIFIED), ("delete", DELETED),
+     ("patch", MODIFIED), ("rename", RENAMED)],
+)
+def test_each_action_maps_to_an_outcome(action, expected):
+    assert actions([applied("f.py", action)]) == {"f.py": expected}
+
+
+def test_a_failed_change_is_not_reported():
+    """It changed nothing, so listing it would send someone looking for a diff."""
+    assert actions([applied("f.py", "modify", success=False)]) == {}
+
+
+# ── net effect across iterations ──────────────────────────────────────────
+
+
+def test_created_then_edited_is_an_addition():
+    """
+    The case that makes this more than a log replay: the file is new to the
+    repository however many times it was edited afterwards.
+    """
+    result = actions([applied("new.py", "create"), applied("new.py", "modify")])
+
+    assert result == {"new.py": ADDED}
+
+
+def test_edited_repeatedly_is_one_modification():
+    result = actions([applied("f.py", "modify")] * 4)
+
+    assert result == {"f.py": MODIFIED}
+
+
+def test_created_then_deleted_cancels_out():
+    """
+    The repository ends as it began. Reporting it would send someone looking
+    for a change that is not there.
+    """
+    assert actions([applied("t.py", "create"), applied("t.py", "delete")]) == {}
+
+
+def test_modified_then_deleted_is_a_deletion():
+    result = actions([applied("f.py", "modify"), applied("f.py", "delete")])
+
+    assert result == {"f.py": DELETED}
+
+
+def test_deleted_then_recreated_is_a_modification():
+    """
+    The path existed before and exists now with different content — which is
+    what a modification is, even though the steps were delete then create.
+    """
+    result = actions([applied("f.py", "delete"), applied("f.py", "create")])
+
+    assert result == {"f.py": MODIFIED}
+
+
+def test_a_rename_survives_later_edits():
+    result = actions([
+        applied("a.py", "rename", new_path="b.py"),
+        applied("a.py", "modify"),
+    ])
+
+    assert result == {"a.py": RENAMED}
+
+
+# ── the table ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mixed():
+    return summarise_changes([
+        applied("added.py", "create"),
+        applied("edited.py", "modify"),
+        applied("gone.py", "delete"),
+        applied("moved.py", "rename", new_path="elsewhere.py"),
+    ])
+
+
+def test_every_file_appears(mixed):
+    rendered = render_change_summary(mixed)
+
+    for name in ("added.py", "edited.py", "gone.py", "moved.py"):
+        assert name in rendered
+
+
+def test_the_counts_are_reported(mixed):
+    rendered = render_change_summary(mixed)
+
+    assert "1 added" in rendered
+    assert "1 modified" in rendered
+    assert "1 deleted" in rendered
+
+
+def test_a_rename_shows_both_paths(mixed):
+    assert "moved.py -> elsewhere.py" in render_change_summary(mixed)
+
+
+def test_files_are_grouped_by_action(mixed):
+    rendered = render_change_summary(mixed)
+
+    assert rendered.index("+ added.py") < rendered.index("~ edited.py")
+    assert rendered.index("~ edited.py") < rendered.index("- gone.py")
+
+
+def test_paths_are_sorted():
+    changed = summarise_changes([
+        applied("z.py", "modify"), applied("a.py", "modify"),
+    ])
+
+    assert [c.path for c in changed] == ["a.py", "z.py"]
+
+
+def test_no_changes_says_so():
+    assert render_change_summary([]) == "No files were changed."
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_loop_accumulates_across_iterations():
+    """
+    last_apply_results is overwritten each iteration, so summarising it would
+    report only the final one.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "all_apply_results.extend(apply_results)" in source
+
+
+def test_the_summary_is_printed_before_the_run_closes():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert source.index("render_change_summary(changed)") < \
+        source.index("self.logger.finish_run(outcome, self.branch_name, self.pr_url)")


### PR DESCRIPTION
Closes #156

A table of what the run actually did to the repository, printed when it finishes:

```
------------------------------------------------------------
Files changed: 1 added, 1 modified, 1 renamed, 1 deleted
------------------------------------------------------------
  + new.py
  ~ old.py
  > moved.py -> elsewhere.py
  - gone.py
```

## Net effect, not a replay of every step

This is the part worth reviewing, because the obvious implementation gives the wrong answer.

A run has several iterations and a file can be touched in more than one. `last_apply_results` is overwritten each time round the loop, so summarising it reports only the final iteration. Accumulating every result and listing them reports each intermediate step, which is also not what anyone wants.

What a reader wants is the net effect against the state the run started from. Four cases where that differs from a naive listing:

**Created in iteration 1, edited in iteration 3** is an **addition**. The file is new to the repository however many times it was subsequently edited. Listing it as "modified" implies something existed to modify.

**Created then deleted within the same run** appears **nowhere**. The repository ends as it began, and listing it sends someone looking for a diff that is not there.

**Deleted then written again** is a **modification**. The path existed before and exists now with different content, which is what a modification is — even though the steps taken were delete followed by create.

**Modified then deleted** is a **deletion**, and a rename survives later edits to the same path.

Failed applications are ignored throughout: they changed nothing, so reporting them would be misleading in the same way.

## Placement

The summary prints before `finish_run` closes the record, so it sits next to the outcome rather than scrolling past earlier in the log. Nothing is printed when no files changed — a heading over an empty table is noise.

Kept in its own module rather than inside `agent_loop`, because the folding logic is the substance here and it is worth being able to read and test it on its own.

## Tests

`tests/test_change_summary.py` — 20 cases.

Single actions: each of create, modify, delete, patch and rename maps to an outcome; a failed change is not reported.

Net effect: created then edited is an addition; edited repeatedly is one modification; created then deleted cancels out; modified then deleted is a deletion; deleted then recreated is a modification; a rename survives later edits.

The table: every file appears; the counts are reported; a rename shows both paths; files are grouped by action, so additions come before modifications before deletions; paths are sorted within a group; no changes says so.

Wiring: the loop accumulates across iterations rather than summarising the last one; the summary prints before the run record closes.

## Verified

- the folding cases above, against a mixed set of applied results spanning several iterations
- 20 tests pass, plus `test_interactive_commit` (22) with no regressions
- all six import-guard checks green
- ruff clean on the new module
- built on current `main` after #138