### PR TITLE
feat: add --clean to remove old logs and backups — Closes #163

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,6 +153,12 @@ Examples:
                              "iteration. Use --list-resumable to see candidates.")
     parser.add_argument("--list-resumable", action="store_true",
                         help="List run ids that can be resumed, then exit.")
+    parser.add_argument("--clean", action="store_true",
+                        help="Remove this tool's old logs and backups, then exit. "
+                             "Only files it created are touched.")
+    parser.add_argument("--clean-older-than", type=float, default=None,
+                        metavar="DAYS",
+                        help="With --clean, keep anything newer than this.")
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
 
     # API key
@@ -288,6 +294,23 @@ def main():
             print("No resumable runs found.")
         for run_id in candidates:
             print(run_id)
+        sys.exit(0)
+
+    if args.clean:
+        from modules.housekeeping import clean, render_clean_summary
+
+        if not args.repo:
+            print("ERROR: --repo is required with --clean.", file=sys.stderr)
+            sys.exit(2)
+
+        results = clean(
+            os.path.abspath(args.repo),
+            log_dir=args.log_dir,
+            backup_dir=args.backup_dir,
+            older_than_days=args.clean_older_than,
+            dry_run=args.dry_run,
+        )
+        print(render_clean_summary(results, dry_run=args.dry_run))
         sys.exit(0)
 
     if args.rollback:

--- a/modules/housekeeping.py
+++ b/modules/housekeeping.py
@@ -1,0 +1,151 @@
+"""
+Module: Housekeeping.
+
+Removes old run logs and file backups.
+
+Written defensively, because this is the one part of the tool whose whole job is
+deleting things. Two rules it does not bend: only files matching the shapes this
+tool creates are removed, and only from inside the directories it was given. A
+stray `--log-dir /` should delete nothing rather than everything.
+"""
+
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+_LOG = logging.getLogger("agent.housekeeping")
+
+# Names this tool writes. Anything else in these directories belongs to someone
+# else and is left alone -- a log directory is a plausible place for a person to
+# have put something of their own.
+LOG_PATTERNS = (
+    re.compile(r"^[\w.-]+_\d{8}_\d{6}_[0-9a-f]{6}\.jsonl$"),
+    re.compile(r"^[\w.-]+_\d{8}_\d{6}_[0-9a-f]{6}_human\.log$"),
+    re.compile(r"^[\w.-]+_\d{8}_\d{6}_[0-9a-f]{6}_summary\.json$"),
+    re.compile(r"^[\w.-]+_\d{8}_\d{6}_[0-9a-f]{6}_state\.json$"),
+)
+
+BACKUP_PATTERN = re.compile(r"^\d{8}_\d{6}_")
+
+
+@dataclass
+class CleanResult:
+    removed: list = field(default_factory=list)
+    kept: list = field(default_factory=list)
+    freed_bytes: int = 0
+    errors: list = field(default_factory=list)
+
+    @property
+    def freed_human(self) -> str:
+        size = float(self.freed_bytes)
+        for unit in ("B", "KB", "MB", "GB"):
+            if size < 1024 or unit == "GB":
+                return f"{size:.1f} {unit}"
+            size /= 1024
+        return f"{size:.1f} GB"
+
+
+def _is_removable(name: str, patterns) -> bool:
+    return any(p.match(name) for p in patterns)
+
+
+def _within(root: str, path: str) -> bool:
+    """True when path really sits inside root, symlinks resolved."""
+    root_real = os.path.realpath(root)
+    return os.path.realpath(path).startswith(root_real + os.sep)
+
+
+def clean_directory(
+    directory: str,
+    patterns,
+    older_than_days: Optional[float] = None,
+    dry_run: bool = False,
+) -> CleanResult:
+    """
+    Remove matching files from one directory.
+
+    Never recurses. A run writes its logs flat, and walking subdirectories would
+    mean deciding what to do about a directory someone else created inside this
+    one -- which is exactly the judgement this should not be making.
+    """
+    result = CleanResult()
+    if not os.path.isdir(directory):
+        return result
+
+    cutoff = None
+    if older_than_days is not None:
+        cutoff = time.time() - (older_than_days * 86400)
+
+    for name in sorted(os.listdir(directory)):
+        path = os.path.join(directory, name)
+
+        if not os.path.isfile(path) or os.path.islink(path):
+            result.kept.append(name)
+            continue
+
+        if not _is_removable(name, patterns):
+            result.kept.append(name)
+            continue
+
+        if not _within(directory, path):
+            # A hard link or an unexpected resolution: refuse rather than guess.
+            result.kept.append(name)
+            continue
+
+        try:
+            stat = os.stat(path)
+            if cutoff is not None and stat.st_mtime > cutoff:
+                result.kept.append(name)
+                continue
+
+            if not dry_run:
+                os.remove(path)
+            result.removed.append(name)
+            result.freed_bytes += stat.st_size
+        except OSError as exc:
+            result.errors.append(f"{name}: {exc}")
+            _LOG.warning("could not remove %s: %s", path, exc)
+
+    return result
+
+
+def clean(
+    repo_root: str,
+    log_dir: str = "logs",
+    backup_dir: str = "backups",
+    older_than_days: Optional[float] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Clean both directories, returning a result for each."""
+    return {
+        "logs": clean_directory(
+            os.path.join(repo_root, log_dir), LOG_PATTERNS, older_than_days, dry_run
+        ),
+        "backups": clean_directory(
+            os.path.join(repo_root, backup_dir), (BACKUP_PATTERN,),
+            older_than_days, dry_run,
+        ),
+    }
+
+
+def render_clean_summary(results: dict, dry_run: bool = False) -> str:
+    """What was removed, or what would be."""
+    verb = "Would remove" if dry_run else "Removed"
+    total_files = sum(len(r.removed) for r in results.values())
+    total_bytes = sum(r.freed_bytes for r in results.values())
+
+    if not total_files:
+        return "Nothing to clean."
+
+    lines = [f"{verb} {total_files} file(s), freeing {CleanResult(freed_bytes=total_bytes).freed_human}."]
+    for label, result in results.items():
+        if result.removed:
+            lines.append(f"  {label}: {len(result.removed)} file(s)")
+        if result.kept:
+            lines.append(f"  {label}: {len(result.kept)} left alone (not ours)")
+        for error in result.errors:
+            lines.append(f"  {label}: could not remove {error}")
+    return "\n".join(lines)

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,0 +1,226 @@
+"""
+Tests for --clean (modules/housekeeping.py).
+
+This is the one part of the tool whose job is deleting things, so most of what
+follows is about what it must *not* remove. A log directory is a plausible place
+for someone to have put a file of their own, and `--log-dir` pointing somewhere
+unexpected should cost nothing.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.housekeeping import (  # noqa: E402
+    BACKUP_PATTERN,
+    LOG_PATTERNS,
+    clean,
+    clean_directory,
+    render_clean_summary,
+)
+
+OURS = [
+    "agent_20260419_192447_57f5a9.jsonl",
+    "agent_20260419_192447_57f5a9_human.log",
+    "demo_20260419_183148_ae2caf_summary.json",
+    "agent_20260419_192447_57f5a9_state.json",
+]
+
+NOT_OURS = ["notes.md", "README.md", "config.json", "important.log", ".gitkeep"]
+
+
+@pytest.fixture
+def logs(tmp_path):
+    directory = tmp_path / "logs"
+    directory.mkdir()
+    for name in OURS + NOT_OURS:
+        (directory / name).write_text("x" * 100)
+    return directory
+
+
+def remaining(directory):
+    return sorted(p.name for p in directory.iterdir())
+
+
+# ── what it removes ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", OURS)
+def test_our_own_files_are_removed(tmp_path, name):
+    (tmp_path / name).write_text("x")
+
+    clean_directory(str(tmp_path), LOG_PATTERNS)
+
+    assert not (tmp_path / name).exists()
+
+
+def test_backups_are_removed(tmp_path):
+    (tmp_path / "20260419_192447_main.py.bak").write_text("x")
+
+    clean_directory(str(tmp_path), (BACKUP_PATTERN,))
+
+    assert remaining(tmp_path) == []
+
+
+def test_the_freed_size_is_reported(tmp_path):
+    (tmp_path / OURS[0]).write_text("x" * 2048)
+
+    assert clean_directory(str(tmp_path), LOG_PATTERNS).freed_bytes == 2048
+
+
+# ── what it must not remove ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", NOT_OURS)
+def test_other_peoples_files_are_left_alone(logs, name):
+    """Only names matching the shapes this tool writes are removed."""
+    clean_directory(str(logs), LOG_PATTERNS)
+
+    assert (logs / name).exists()
+
+
+def test_directories_are_left_alone(tmp_path):
+    """
+    Never recurses. Walking subdirectories means deciding what to do about a
+    directory someone else created — a judgement this should not make.
+    """
+    nested = tmp_path / "archive"
+    nested.mkdir()
+    (nested / OURS[0]).write_text("x")
+
+    clean_directory(str(tmp_path), LOG_PATTERNS)
+
+    assert (nested / OURS[0]).exists()
+
+
+def test_symlinks_are_left_alone(tmp_path):
+    target = tmp_path / "real.txt"
+    target.write_text("x")
+    link = tmp_path / OURS[0]
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks unavailable")
+
+    clean_directory(str(tmp_path), LOG_PATTERNS)
+
+    assert link.exists()
+    assert target.exists()
+
+
+def test_a_missing_directory_is_not_an_error(tmp_path):
+    result = clean_directory(str(tmp_path / "nope"), LOG_PATTERNS)
+
+    assert result.removed == []
+
+
+def test_an_unrelated_directory_loses_nothing(tmp_path):
+    """`--log-dir /etc` should cost nothing, not everything."""
+    for name in ("passwd", "hosts", "fstab"):
+        (tmp_path / name).write_text("x")
+
+    clean_directory(str(tmp_path), LOG_PATTERNS)
+
+    assert len(remaining(tmp_path)) == 3
+
+
+# ── dry run ───────────────────────────────────────────────────────────────
+
+
+def test_a_dry_run_deletes_nothing(logs):
+    clean_directory(str(logs), LOG_PATTERNS, dry_run=True)
+
+    assert len(remaining(logs)) == len(OURS) + len(NOT_OURS)
+
+
+def test_a_dry_run_still_reports_what_would_go(logs):
+    result = clean_directory(str(logs), LOG_PATTERNS, dry_run=True)
+
+    assert len(result.removed) == len(OURS)
+
+
+# ── age filter ────────────────────────────────────────────────────────────
+
+
+def test_recent_files_are_kept(tmp_path):
+    (tmp_path / OURS[0]).write_text("x")
+
+    result = clean_directory(str(tmp_path), LOG_PATTERNS, older_than_days=7)
+
+    assert result.removed == []
+    assert (tmp_path / OURS[0]).exists()
+
+
+def test_old_files_are_removed(tmp_path):
+    path = tmp_path / OURS[0]
+    path.write_text("x")
+    old = time.time() - (30 * 86400)
+    os.utime(path, (old, old))
+
+    result = clean_directory(str(tmp_path), LOG_PATTERNS, older_than_days=7)
+
+    assert result.removed == [OURS[0]]
+
+
+def test_no_age_filter_removes_everything_matching(logs):
+    result = clean_directory(str(logs), LOG_PATTERNS)
+
+    assert len(result.removed) == len(OURS)
+
+
+# ── both directories ──────────────────────────────────────────────────────
+
+
+def test_both_directories_are_cleaned(tmp_path):
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "backups").mkdir()
+    (tmp_path / "logs" / OURS[0]).write_text("x")
+    (tmp_path / "backups" / "20260419_192447_a.py.bak").write_text("x")
+
+    results = clean(str(tmp_path))
+
+    assert len(results["logs"].removed) == 1
+    assert len(results["backups"].removed) == 1
+
+
+# ── reporting ─────────────────────────────────────────────────────────────
+
+
+def test_nothing_to_clean_says_so(tmp_path):
+    assert render_clean_summary(clean(str(tmp_path))) == "Nothing to clean."
+
+
+def test_the_summary_reports_counts_and_size(tmp_path):
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / OURS[0]).write_text("x" * 4096)
+
+    summary = render_clean_summary(clean(str(tmp_path)))
+
+    assert "1 file(s)" in summary
+    assert "KB" in summary
+
+
+def test_a_dry_run_summary_uses_the_conditional(tmp_path):
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / OURS[0]).write_text("x")
+
+    summary = render_clean_summary(clean(str(tmp_path), dry_run=True), dry_run=True)
+
+    assert summary.startswith("Would remove")
+
+
+def test_files_left_alone_are_mentioned(tmp_path):
+    """
+    So it is visible that something was skipped, rather than looking like the
+    directory was already clean.
+    """
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs" / OURS[0]).write_text("x")
+    (tmp_path / "logs" / "notes.md").write_text("x")
+
+    assert "not ours" in render_clean_summary(clean(str(tmp_path)))


### PR DESCRIPTION
Closes #163

```bash
python main.py --repo . --clean
python main.py --repo . --clean --dry-run
python main.py --repo . --clean --clean-older-than 7
```

## Written defensively, because it deletes things

This is the one part of the tool whose entire job is removing files, so most of the design is about what it must *not* touch. Two rules it does not bend: only names matching the shapes this tool writes are removed, and only from directly inside the directories it was given.

A log directory is a plausible place for someone to have kept a file of their own, and `--log-dir` pointing somewhere unexpected should cost nothing rather than everything.

```
logs/  agent_20260419_192447_57f5a9.jsonl        removed
       demo_20260419_183148_ae2caf_summary.json  removed
       README.md                                 left alone
       my_notes.txt                              left alone
       archive/                                  left alone
```

**Filename patterns, not extensions.** A run writes `<prefix>_<date>_<time>_<id>` with a known suffix. `notes.jsonl` sitting in the same directory does not match and survives.

**It never recurses.** Runs write flat, and walking subdirectories would mean deciding what to do about a directory someone else created inside this one — exactly the judgement this should not be making.

**Symlinks are skipped**, so a link that happens to match a pattern cannot be used to remove its target.

**Paths are re-checked after resolution**, so anything that resolves outside the directory it was found in is refused rather than guessed at.

There is a test asserting that pointing this at a directory of unrelated files removes none of them.

## `--dry-run` and `--clean-older-than`

`--dry-run` reports exactly what would go and deletes nothing — the same code path, so the preview cannot disagree with the real thing.

`--clean-older-than 7` keeps anything modified within the last seven days, for the case where the last few runs are still worth reading.

The summary reports what was left alone as well as what was removed:

```
Removed 4 file(s), freeing 3.4 KB.
  logs: 3 file(s)
  logs: 3 left alone (not ours)
  backups: 1 file(s)
```

Without that line, a skip looks like an already-clean directory.

## Tests

`tests/test_housekeeping.py` — 25 cases.

What it removes: each of the four log shapes, parametrised; backups; the freed size is reported.

What it must not remove: five kinds of unrelated file, parametrised; directories; symlinks; a missing directory is not an error; **an unrelated directory loses nothing**.

Dry run: it deletes nothing; it still reports what would go.

Age filter: recent files are kept; old files are removed, with `os.utime` used to age them; no filter removes everything matching.

Both directories are cleaned in one pass.

Reporting: nothing to clean says so; counts and size are reported; a dry run uses the conditional wording; files left alone are mentioned.

## Verified

- the before/after listings above, on a directory mixing agent files with unrelated ones
- `--clean --dry-run` end to end through the CLI
- 25 tests pass
- all six import-guard checks green
- ruff clean on the new module
- built on current `main` after #138

## Note on overlap

Touches `main.py`, as does #160. Whichever merges second needs a trivial rebase.