### PR TITLE
fix(modifier): remove a duplicated function and guard against recurrence — Closes #219

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -148,3 +148,57 @@ jobs:
           python main.py --repo . --task "smoke" --no-git --context-only > /tmp/smoke.txt
           tail -5 /tmp/smoke.txt
           grep -q "No API call was made" /tmp/smoke.txt
+
+      - name: No duplicate definitions
+        # A merge that lands the same function twice leaves the second copy
+        # shadowing the first. It imports cleanly and passes every test, so
+        # nothing else here would notice -- `_apply_unified_diff` sat
+        # duplicated in code_modifier.py exactly this way.
+        run: |
+          python - <<'PY'
+          import ast, collections, os, sys
+
+          problems = []
+          for root, dirs, files in os.walk("."):
+              dirs[:] = [
+                  d for d in dirs
+                  if not d.startswith(".") and d not in ("node_modules", "__pycache__")
+              ]
+              for name in sorted(files):
+                  if not name.endswith(".py"):
+                      continue
+                  path = os.path.join(root, name)
+                  try:
+                      tree = ast.parse(open(path, encoding="utf-8").read())
+                  except SyntaxError:
+                      continue
+
+                  counts = collections.Counter(
+                      node.name for node in tree.body
+                      if isinstance(node, (ast.FunctionDef, ast.ClassDef))
+                  )
+                  for symbol, count in counts.items():
+                      if count > 1:
+                          problems.append(f"{path}: {symbol} defined {count}x")
+
+                  for node in tree.body:
+                      if not isinstance(node, ast.ClassDef):
+                          continue
+                      methods = collections.Counter(
+                          item.name for item in node.body
+                          if isinstance(item, ast.FunctionDef)
+                      )
+                      for symbol, count in methods.items():
+                          if count > 1:
+                              problems.append(
+                                  f"{path}: {node.name}.{symbol} defined {count}x"
+                              )
+
+          for problem in problems:
+              print(f"FAIL {problem}")
+
+          if problems:
+              sys.exit(1)
+
+          print("no duplicate definitions")
+          PY

--- a/modules/code_modifier.py
+++ b/modules/code_modifier.py
@@ -105,64 +105,6 @@ def _apply_unified_diff(original: str, patch: str) -> str:
 
 import re
 
-def _apply_unified_diff(original: str, patch: str) -> str:
-    """Apply a unified diff patch to the original text in pure Python."""
-    original_lines = original.splitlines(keepends=True)
-    patch_lines = patch.splitlines(keepends=True)
-    
-    result_lines = []
-    orig_idx = 0
-    
-    hunk_re = re.compile(r'^@@\s+-(?P<old_start>\d+)(?:,(?P<old_len>\d+))?\s+\+(?P<new_start>\d+)(?:,(?P<new_len>\d+))?\s+@@')
-    
-    patch_idx = 0
-    # Skip diff header lines until the first hunk
-    while patch_idx < len(patch_lines) and not patch_lines[patch_idx].startswith('@@'):
-        patch_idx += 1
-        
-    if patch_idx == len(patch_lines):
-        # No hunks found, treat as full replacement fallback
-        return patch
-        
-    while patch_idx < len(patch_lines):
-        match = hunk_re.match(patch_lines[patch_idx])
-        if not match:
-            patch_idx += 1
-            continue
-            
-        old_start = int(match.group('old_start'))
-        # Adjust 1-based index to 0-based
-        old_start = max(0, old_start - 1)
-        
-        # Copy original lines up to the start of this hunk
-        result_lines.extend(original_lines[orig_idx:old_start])
-        orig_idx = old_start
-        
-        patch_idx += 1
-        # Process hunk lines
-        while patch_idx < len(patch_lines) and not patch_lines[patch_idx].startswith('@@'):
-            line = patch_lines[patch_idx]
-            patch_idx += 1
-            if line.startswith(' '):
-                # Context line: verify and copy
-                if orig_idx < len(original_lines):
-                    result_lines.append(original_lines[orig_idx])
-                    orig_idx += 1
-            elif line.startswith('-'):
-                # Deletion line: verify and skip original line
-                if orig_idx < len(original_lines):
-                    orig_idx += 1
-            elif line.startswith('+'):
-                # Addition line: append new line
-                result_lines.append(line[1:])
-                
-    # Copy any remaining original lines
-    if orig_idx < len(original_lines):
-        result_lines.extend(original_lines[orig_idx:])
-        
-    return "".join(result_lines)
-
-
 class CodeModificationEngine:
     def __init__(self, repo_root: str, backup_dir: str):
         self.repo_root = os.path.abspath(repo_root)

--- a/tests/test_no_duplicate_definitions.py
+++ b/tests/test_no_duplicate_definitions.py
@@ -1,0 +1,154 @@
+"""
+Tests against duplicate definitions (all modules).
+
+`_apply_unified_diff` was defined twice in `modules/code_modifier.py`, 56 lines
+each, byte-identical. The second shadowed the first silently: the module
+imported, every test passed, and nothing indicated a problem.
+
+That is what a merge landing the same block twice looks like, and this repository
+has had several. A shadowed definition is harmless only while the copies agree —
+the moment one is edited, the edit has no effect and the reason is invisible.
+"""
+
+import ast
+import collections
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+SKIP_DIRS = {"node_modules", "__pycache__", "logs", "backups", ".git"}
+
+
+def python_files():
+    for root, dirs, files in os.walk(ROOT):
+        dirs[:] = [
+            d for d in dirs if not d.startswith(".") and d not in SKIP_DIRS
+        ]
+        for name in sorted(files):
+            if name.endswith(".py"):
+                yield Path(root) / name
+
+
+def duplicates(path):
+    """Top-level and per-class names defined more than once in one file."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+
+    found = []
+    counts = collections.Counter(
+        node.name for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    )
+    found += [f"{name} ({count}x)" for name, count in counts.items() if count > 1]
+
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        methods = collections.Counter(
+            item.name for item in node.body if isinstance(item, ast.FunctionDef)
+        )
+        found += [
+            f"{node.name}.{name} ({count}x)"
+            for name, count in methods.items() if count > 1
+        ]
+
+    return found
+
+
+# ── the check ─────────────────────────────────────────────────────────────
+
+
+def test_no_module_defines_anything_twice():
+    offenders = {
+        str(path.relative_to(ROOT)): found
+        for path in python_files()
+        if (found := duplicates(path))
+    }
+
+    assert offenders == {}, f"duplicate definitions: {offenders}"
+
+
+# ── the detector itself works ─────────────────────────────────────────────
+
+
+def test_a_duplicate_function_is_detected(tmp_path):
+    """Otherwise the test above passes for the wrong reason."""
+    path = tmp_path / "dupe.py"
+    path.write_text("def f():\n    pass\n\n\ndef f():\n    pass\n")
+
+    assert duplicates(path) == ["f (2x)"]
+
+
+def test_a_duplicate_method_is_detected(tmp_path):
+    path = tmp_path / "dupe.py"
+    path.write_text("class C:\n    def m(self):\n        pass\n\n    def m(self):\n        pass\n")
+
+    assert duplicates(path) == ["C.m (2x)"]
+
+
+def test_a_clean_file_reports_nothing(tmp_path):
+    path = tmp_path / "clean.py"
+    path.write_text("def f():\n    pass\n\n\ndef g():\n    pass\n")
+
+    assert duplicates(path) == []
+
+
+def test_the_same_name_in_different_classes_is_fine(tmp_path):
+    """Two classes may both define run; that is not a duplicate."""
+    path = tmp_path / "ok.py"
+    path.write_text(
+        "class A:\n    def run(self):\n        pass\n\n\n"
+        "class B:\n    def run(self):\n        pass\n"
+    )
+
+    assert duplicates(path) == []
+
+
+def test_an_unparseable_file_is_skipped(tmp_path):
+    """A syntax error is someone else's problem, not a reason to fail here."""
+    path = tmp_path / "broken.py"
+    path.write_text("def f(:\n")
+
+    assert duplicates(path) == []
+
+
+# ── the specific case that prompted this ──────────────────────────────────
+
+
+def test_the_patch_helper_is_defined_once():
+    path = ROOT / "modules" / "code_modifier.py"
+
+    assert "_apply_unified_diff" not in " ".join(duplicates(path))
+
+
+@pytest.mark.parametrize(
+    "original,patch,expected",
+    [
+        (
+            "line one\nline two\nline three\n",
+            "--- a/f.py\n+++ b/f.py\n@@ -1,3 +1,3 @@\n line one\n-line two\n+line TWO\n line three\n",
+            "line one\nline TWO\nline three\n",
+        ),
+        (
+            "",
+            "--- /dev/null\n+++ b/new.py\n@@ -0,0 +1,2 @@\n+first\n+second\n",
+            "first\nsecond\n",
+        ),
+    ],
+    ids=["modify", "new-file"],
+)
+def test_patching_still_works(original, patch, expected):
+    """
+    Including the `@@ -0,0` form a new file produces, since that is the case
+    #151 suspected of an off-by-one.
+    """
+    from modules.code_modifier import _apply_unified_diff
+
+    assert _apply_unified_diff(original, patch) == expected


### PR DESCRIPTION
Closes #219

## `_apply_unified_diff` was defined twice

`modules/code_modifier.py` contained two definitions of the same function, 56 lines each, byte-identical. The second shadowed the first.

```
[(48, 103), (108, 163)]
```

Nothing indicated a problem. The module imported cleanly, every test passed, ruff did not flag it, and the import guard was green. A shadowed definition is valid Python — the interpreter keeps the last one and says nothing.

It is harmless only while the two copies agree. The moment someone edits one, the edit either takes effect or silently does not, depending on which copy they happened to open, and there is no visible reason why.

I confirmed the two were genuinely identical before deleting either, rather than assuming it.

## A sweep, not a spot fix

Rather than fix the one I happened to find, I walked every `.py` file with `ast` and compared top-level function and class names, plus method names within each class. This was the only occurrence.

`modules/code_modifier.py` drops from 30 ruff findings to 18, entirely from removing the dead copy.

## Guard step

Added to `.github/workflows/import-guard.yml`, alongside the existing import, CLI, duplicate-flag, config-field and smoke checks. Verified against both trees:

```
against main:  FAIL ./modules/code_modifier.py: _apply_unified_diff defined 2x   exit 1
against fix:   no duplicate definitions                                          exit 0
```

It catches top-level functions and classes, and methods within a class. The same name defined in two *different* classes is not a duplicate and is explicitly allowed — several classes here legitimately define `run`.

This is the fifth thing the guard checks that no test would catch, because each of them produces a codebase that imports and passes.

## Patching still works

The function this removes a copy of applies unified diffs, so both forms are verified:

```
modify   'line one\nline two\nline three\n'  ->  'line one\nline TWO\nline three\n'
new file ''                                  ->  'first\nsecond\n'
```

The second is the `@@ -0,0 +1,N @@` header a new file produces. It is handled correctly — `max(0, old_start - 1)` gives 0 for a hunk starting at 0, which is right.

## Tests

`tests/test_no_duplicate_definitions.py` — 9 cases.

The check: no module defines anything twice, across the whole tree.

The detector itself: a duplicate function is detected; a duplicate method is detected; a clean file reports nothing; the same name in different classes is fine; an unparseable file is skipped rather than failing. Those five exist so the first test cannot pass for the wrong reason.

The specific case: the patch helper is defined once; patching still works for both a modification and a new file.

## Verified

- the sweep above, across every `.py` file in the repository
- the guard failing on `main` and passing here
- 9 new tests pass, plus `test_rollback_created_files`, `test_rename_action` and `test_interactive_commit` — 72 in total, no regressions
- all import-guard checks green
- built on current `main` after #138

## Related: #151

I found this while investigating #151, which reports the diff logger showing line numbers starting from 0 after a file is created. That one is not reproducible — there is no diff renderer in the codebase. No `difflib` import, and nothing formats or logs a diff, so there is no diff logger to be showing wrong numbers.

The patch-application path does handle the new-file hunk header correctly, as shown above.

This PR does not close #151, since it fixes something different. If there is a run where the wrong numbers appeared, that output would help and I will take another look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a duplicate patch-processing definition, preserving existing patch behavior.
* **Quality Improvements**
  * Added automated checks to detect duplicate functions and methods in Python files.
  * Added test coverage for duplicate detection, valid source files, syntax-invalid files, and patch application.
* **CI**
  * Builds now fail when duplicate Python definitions are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->