### PR TITLE
feat(llm): cache identical responses on disk behind --cache — Closes #168

### DIFF
--- a/main.py
+++ b/main.py
@@ -198,6 +198,11 @@ Examples:
                         help="Path to configuration JSON file (default: .repopilot.json in repo root)")
 
     # Non-interactive / CI
+    parser.add_argument("--cache", dest="use_cache", action="store_true",
+                        help="Reuse a stored response when the model, system "
+                             "prompt and full prompt are identical. Off by "
+                             "default: requests are not deterministic, so this "
+                             "changes behaviour as well as saving money.")
     parser.add_argument("--max-cost", type=float, default=None, metavar="USD",
                         help="Stop before the next LLM call once this much has been "
                              "spent (e.g. --max-cost 1.00). Off by default.")
@@ -460,6 +465,7 @@ def main():
         # LLM
         anthropic_api_key=args.api_key,
         max_cost=args.max_cost,
+        use_cache=args.use_cache,
         system_prompt_file=args.system_prompt_file,
         api_base_url=args.api_base_url,
         verbose_payloads=args.verbose_payloads,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -50,6 +50,7 @@ from modules.run_state import (
 )
 from modules.project_rules import load_project_rules, render_project_rules
 from modules.change_summary import render_change_summary, summarise_changes
+from modules.response_cache import ResponseCache
 from modules.logger import AgentLogger, IterationRecord
 from modules.secret_scanner import scan_directory, format_findings
 from modules.token_tracker import TokenTracker
@@ -109,7 +110,8 @@ class AgentConfig:
 
     # LLM
     anthropic_api_key: Optional[str] = None
-    max_cost: Optional[float] = None       # stop before the next call at this spend
+    max_cost: Optional[float] = None
+    use_cache: bool = False                # reuse identical responses from disk       # stop before the next call at this spend
     resume_from: Optional[str] = None      # run_id to continue
     api_base_url: Optional[str] = None     # override the provider endpoint
     resume_from: Optional[str] = None      # run_id to continue
@@ -261,6 +263,10 @@ class AutonomousAgent:
                 provider=cfg.provider,
                 verbose=cfg.verbose_payloads,
             max_cost=cfg.max_cost,
+            cache=(
+                ResponseCache(cfg.repo_root, enabled=True)
+                if cfg.use_cache else None
+            ),
             system_prompt=(
                 load_system_prompt(cfg.system_prompt_file)
                 if cfg.system_prompt_file else None

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -453,6 +453,7 @@ class BaseLLMClient:
         verbose: bool = False,
         max_cost: Optional[float] = None,
         system_prompt: Optional[str] = None,
+        cache=None,
     ):
         self.model = model
         self.verbose = verbose
@@ -460,6 +461,9 @@ class BaseLLMClient:
         # Per-instance so a run can override it; falls back to the module
         # constant, which is itself loaded from prompts/system.txt.
         self.system_prompt = system_prompt or SYSTEM_PROMPT
+        # Optional and injected, so this module need not know where a cache
+        # lives or whether one exists.
+        self.cache = cache
         self.input_tokens_used = 0
         self.output_tokens_used = 0
         self.total_cost = 0.0
@@ -513,8 +517,23 @@ class BaseLLMClient:
         request. Funnelling every path through one method is what stops a new
         request type reintroducing that.
         """
-        self._check_budget()
         input_tok = self._estimate_tokens(prompt + self.system_prompt)
+
+        # Checked before the budget: a cache hit costs nothing, so a run that
+        # has reached its limit can still be served rather than stopping on a
+        # request it is not going to pay for.
+        key = None
+        if self.cache is not None:
+            from modules.response_cache import cache_key
+
+            key = cache_key(self.model, self.system_prompt, prompt)
+            cached = self.cache.get(key)
+            if cached is not None:
+                if self.verbose:
+                    _dump_payload("response (cached)", cached)
+                return cached, input_tok
+
+        self._check_budget()
         if self.verbose:
             _dump_payload("system prompt", self.system_prompt)
             _dump_payload("request", prompt)
@@ -524,6 +543,8 @@ class BaseLLMClient:
         if self.verbose:
             _dump_payload("response", raw)
         self._record_usage(input_tok, self._estimate_tokens(raw))
+        if key is not None:
+            self.cache.put(key, raw)
         return raw, input_tok
 
     def _estimate_tokens(self, text: str) -> int:
@@ -871,8 +892,9 @@ class LLMClient(BaseLLMClient):
                  provider: str = "anthropic", verbose: bool = False,
                  max_cost: Optional[float] = None,
                  api_base_url: Optional[str] = None,
-                 system_prompt: Optional[str] = None):
-        super().__init__(model, verbose, max_cost, system_prompt)
+                 system_prompt: Optional[str] = None,
+                 cache=None):
+        super().__init__(model, verbose, max_cost, system_prompt, cache)
         self.provider = provider.lower()
         if self.provider == "openai":
             self.underlying_client = OpenAIClient(api_key, model)
@@ -888,6 +910,7 @@ class LLMClient(BaseLLMClient):
         self.underlying_client.verbose = verbose
         self.underlying_client.max_cost = max_cost
         self.underlying_client.system_prompt = self.system_prompt
+        self.underlying_client.cache = cache
 
     def _call(self, prompt: str) -> str:
         return self.underlying_client._call(prompt)

--- a/modules/response_cache.py
+++ b/modules/response_cache.py
@@ -1,0 +1,138 @@
+"""
+Module: Response cache.
+
+Stores LLM responses on disk so an identical request does not have to be paid
+for twice. The case that prompted it: a dry run followed by a real run against
+an unchanged repository makes the same call with the same context.
+
+Opt-in, deliberately. Requests are made at `temperature: 0.2`, so the provider
+may return different text for the same prompt. Serving a cached answer is
+therefore a behaviour change rather than a pure optimisation -- useful when
+debugging, because a run becomes reproducible, and wrong when the point of
+re-running is to see whether the model does better this time.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+_LOG = logging.getLogger("agent.response_cache")
+
+CACHE_DIRNAME = ".repopilot-cache"
+
+# Entries older than this are ignored and swept. The key already covers the
+# prompt, so a changed repository produces a different key and cannot hit a
+# stale entry -- this is disk hygiene rather than correctness.
+DEFAULT_TTL_SECONDS = 7 * 24 * 3600
+
+MAX_ENTRY_BYTES = 2 * 1024 * 1024
+
+
+@dataclass
+class CacheStats:
+    hits: int = 0
+    misses: int = 0
+    writes: int = 0
+
+    @property
+    def total(self) -> int:
+        return self.hits + self.misses
+
+
+def cache_key(model: str, system_prompt: str, prompt: str) -> str:
+    """
+    Identity of a request.
+
+    All three parts matter. The model changes the answer; the system prompt
+    changes it too, so a run with --system-prompt must not be served an entry
+    written by the default persona; and the prompt carries the task and the
+    repository context, which is what makes a changed repository miss.
+    """
+    digest = hashlib.sha256()
+    for part in (model or "", system_prompt or "", prompt or ""):
+        digest.update(part.encode("utf-8", errors="replace"))
+        digest.update(b"\x00")            # so ("ab", "c") != ("a", "bc")
+    return digest.hexdigest()
+
+
+class ResponseCache:
+    """A content-addressed cache of raw provider responses."""
+
+    def __init__(
+        self,
+        root: str,
+        enabled: bool = False,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ):
+        self.root = os.path.join(root, CACHE_DIRNAME)
+        self.enabled = enabled
+        self.ttl_seconds = ttl_seconds
+        self.stats = CacheStats()
+
+    def _path(self, key: str) -> str:
+        # Two-character prefix directory: a long run can write thousands of
+        # entries, and some filesystems slow down badly with that many siblings.
+        return os.path.join(self.root, key[:2], f"{key}.json")
+
+    def get(self, key: str) -> Optional[str]:
+        """The cached response, or None. Never raises."""
+        if not self.enabled:
+            return None
+
+        path = self._path(key)
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                entry = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            self.stats.misses += 1
+            return None
+
+        age = time.time() - entry.get("written_at", 0)
+        if age > self.ttl_seconds:
+            self.stats.misses += 1
+            self._discard(path)
+            return None
+
+        self.stats.hits += 1
+        _LOG.info("Cache hit; no API call made for this request.")
+        return entry.get("response")
+
+    def put(self, key: str, response: str) -> None:
+        """Store a response. A cache that cannot be written is not an error."""
+        if not self.enabled or response is None:
+            return
+
+        if len(response.encode("utf-8", errors="replace")) > MAX_ENTRY_BYTES:
+            _LOG.debug("Response too large to cache; skipping.")
+            return
+
+        path = self._path(key)
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            # Written to a temporary name and moved, so an interrupted write
+            # cannot leave a half-written entry that later parses as valid.
+            temporary = f"{path}.tmp"
+            with open(temporary, "w", encoding="utf-8") as handle:
+                json.dump({"written_at": time.time(), "response": response}, handle)
+            os.replace(temporary, path)
+            self.stats.writes += 1
+        except OSError as exc:
+            _LOG.debug("Could not write cache entry: %s", exc)
+
+    def _discard(self, path: str) -> None:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+    def summary(self) -> str:
+        if not self.enabled or not self.stats.total:
+            return ""
+        return (
+            f"Cache: {self.stats.hits} hit(s), {self.stats.misses} miss(es) "
+            f"of {self.stats.total} request(s)."
+        )

--- a/tests/test_response_cache.py
+++ b/tests/test_response_cache.py
@@ -1,0 +1,225 @@
+"""
+Tests for --cache (modules/response_cache.py).
+
+Stores responses so an identical request need not be paid for twice — a dry run
+followed by a real run against an unchanged repository being the case that
+prompted it.
+
+Opt-in on purpose. Requests go out at `temperature: 0.2`, so the provider may
+return different text for the same prompt; serving a cached answer is a
+behaviour change, not only an optimisation.
+"""
+
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.llm_client import BaseLLMClient  # noqa: E402
+from modules.response_cache import (  # noqa: E402
+    CACHE_DIRNAME,
+    MAX_ENTRY_BYTES,
+    ResponseCache,
+    cache_key,
+)
+
+RESPONSE = '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
+KEY_PARTS = ("claude-sonnet-4", "SYSTEM PROMPT", "the prompt")
+
+
+@pytest.fixture
+def cache(tmp_path):
+    return ResponseCache(str(tmp_path), enabled=True)
+
+
+class Counting(BaseLLMClient):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.calls = 0
+
+    def _call(self, prompt):
+        self.calls += 1
+        return RESPONSE
+
+
+# ── the key ───────────────────────────────────────────────────────────────
+
+
+def test_the_same_request_gives_the_same_key():
+    assert cache_key(*KEY_PARTS) == cache_key(*KEY_PARTS)
+
+
+def test_a_different_model_gives_a_different_key():
+    assert cache_key("gpt-4o", *KEY_PARTS[1:]) != cache_key(*KEY_PARTS)
+
+
+def test_a_different_system_prompt_gives_a_different_key():
+    """
+    A run with --system-prompt must not be served an entry written by the
+    default persona; the persona is what shapes the answer.
+    """
+    assert cache_key(KEY_PARTS[0], "OTHER", KEY_PARTS[2]) != cache_key(*KEY_PARTS)
+
+
+def test_a_different_prompt_gives_a_different_key():
+    """The prompt carries the repository context, so a changed repo misses."""
+    assert cache_key(*KEY_PARTS[:2], "different") != cache_key(*KEY_PARTS)
+
+
+def test_the_parts_cannot_run_together():
+    """Without a separator ("ab", "c") and ("a", "bc") would collide."""
+    assert cache_key("a", "b", "c") != cache_key("ab", "", "c")
+
+
+# ── storage ───────────────────────────────────────────────────────────────
+
+
+def test_a_miss_returns_nothing(cache):
+    assert cache.get(cache_key(*KEY_PARTS)) is None
+
+
+def test_a_stored_response_is_returned(cache):
+    key = cache_key(*KEY_PARTS)
+    cache.put(key, RESPONSE)
+
+    assert cache.get(key) == RESPONSE
+
+
+def test_entries_survive_a_new_instance(tmp_path):
+    """The point is reuse across runs, not within one."""
+    key = cache_key(*KEY_PARTS)
+    ResponseCache(str(tmp_path), enabled=True).put(key, RESPONSE)
+
+    assert ResponseCache(str(tmp_path), enabled=True).get(key) == RESPONSE
+
+
+def test_entries_live_under_one_directory(tmp_path, cache):
+    cache.put(cache_key(*KEY_PARTS), RESPONSE)
+
+    assert (tmp_path / CACHE_DIRNAME).is_dir()
+
+
+def test_hits_and_misses_are_counted(cache):
+    key = cache_key(*KEY_PARTS)
+    cache.get(key)
+    cache.put(key, RESPONSE)
+    cache.get(key)
+
+    assert (cache.stats.hits, cache.stats.misses) == (1, 1)
+
+
+# ── it stays out of the way when off ──────────────────────────────────────
+
+
+def test_a_disabled_cache_stores_nothing(tmp_path):
+    disabled = ResponseCache(str(tmp_path), enabled=False)
+    key = cache_key(*KEY_PARTS)
+    disabled.put(key, RESPONSE)
+
+    assert ResponseCache(str(tmp_path), enabled=True).get(key) is None
+
+
+def test_a_disabled_cache_never_hits(tmp_path):
+    key = cache_key(*KEY_PARTS)
+    ResponseCache(str(tmp_path), enabled=True).put(key, RESPONSE)
+
+    assert ResponseCache(str(tmp_path), enabled=False).get(key) is None
+
+
+# ── failing softly ────────────────────────────────────────────────────────
+
+
+def test_a_corrupt_entry_is_a_miss(tmp_path, cache):
+    key = cache_key(*KEY_PARTS)
+    cache.put(key, RESPONSE)
+    path = next((tmp_path / CACHE_DIRNAME).rglob("*.json"))
+    path.write_text("not json at all")
+
+    assert cache.get(key) is None
+
+
+def test_an_unwritable_cache_does_not_raise(tmp_path, monkeypatch):
+    """A cache that cannot be written should not fail the run."""
+    def explode(*args, **kwargs):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr("os.makedirs", explode)
+
+    ResponseCache(str(tmp_path), enabled=True).put(cache_key(*KEY_PARTS), RESPONSE)
+
+
+def test_an_oversized_response_is_not_stored(cache):
+    key = cache_key(*KEY_PARTS)
+    cache.put(key, "x" * (MAX_ENTRY_BYTES + 1))
+
+    assert cache.get(key) is None
+
+
+def test_an_expired_entry_is_a_miss(tmp_path):
+    key = cache_key(*KEY_PARTS)
+    cache = ResponseCache(str(tmp_path), enabled=True, ttl_seconds=1)
+    cache.put(key, RESPONSE)
+    path = next((tmp_path / CACHE_DIRNAME).rglob("*.json"))
+    entry = json.loads(path.read_text())
+    entry["written_at"] = time.time() - 10
+    path.write_text(json.dumps(entry))
+
+    assert cache.get(key) is None
+
+
+# ── through the client ────────────────────────────────────────────────────
+
+
+def test_an_identical_request_makes_no_second_call(tmp_path):
+    cache = ResponseCache(str(tmp_path), enabled=True)
+    first = Counting(cache=cache)
+    first.initial_request("fix parser", "context")
+    second = Counting(cache=cache)
+    second.initial_request("fix parser", "context")
+
+    assert (first.calls, second.calls) == (1, 0)
+
+
+def test_a_cached_run_costs_nothing(tmp_path):
+    cache = ResponseCache(str(tmp_path), enabled=True)
+    Counting(cache=cache).initial_request("fix parser", "context")
+    second = Counting(cache=cache)
+    second.initial_request("fix parser", "context")
+
+    assert second.total_cost == 0.0
+
+
+def test_a_cached_response_still_parses(tmp_path):
+    cache = ResponseCache(str(tmp_path), enabled=True)
+    Counting(cache=cache).initial_request("fix parser", "context")
+
+    result = Counting(cache=cache).initial_request("fix parser", "context")
+
+    assert result.parse_error is None
+    assert result.done is True
+
+
+def test_no_cache_means_every_request_is_made(tmp_path):
+    client = Counting(cache=None)
+    client.initial_request("fix parser", "context")
+    client.initial_request("fix parser", "context")
+
+    assert client.calls == 2
+
+
+def test_a_hit_is_served_even_past_the_budget(tmp_path):
+    """
+    A cache hit costs nothing, so a run at its limit can still be served rather
+    than stopping on a request it is not going to pay for.
+    """
+    cache = ResponseCache(str(tmp_path), enabled=True)
+    Counting(cache=cache).initial_request("fix parser", "context")
+
+    broke = Counting(cache=cache, max_cost=0.0000001)
+    broke.total_cost = 999.0
+
+    assert broke.initial_request("fix parser", "context").parse_error is None


### PR DESCRIPTION
Closes #168

```bash
python main.py --repo . --task "Fix the parser" --dry-run
python main.py --repo . --task "Fix the parser" --cache     # no second API call
```

```
provider calls made : 1   (the second run was served from cache)
second run cost     : $0.000000   (the first was $0.001863)
Cache: 1 hit(s), 1 miss(es) of 2 request(s).
```

## Opt-in, and that is the design decision worth reviewing

Requests go out at `temperature: 0.2`, not 0. The provider may return different text for the same prompt, so serving a cached answer is a **behaviour change**, not purely an optimisation.

That cuts both ways. It makes a run reproducible, which is useful when debugging why the agent did something odd. And it is wrong when the reason for re-running is to see whether the model does better this time — which is a normal thing to want.

So it is off by default and the help text says why, rather than presenting this as free money.

## The cache key

Model, system prompt, and full prompt — each separated by a null byte so `("ab", "c")` cannot collide with `("a", "bc")`.

All three parts matter:

- **model** changes the answer
- **system prompt** changes it too, so a run with `--system-prompt` must never be served an entry written by the default persona
- **prompt** carries the task and the repository context, which is what makes a changed repository miss rather than reuse a stale answer

Because the context is in the key, a stale entry cannot be served against changed code. The seven-day TTL is disk hygiene, not correctness.

## One deliberate ordering

The cache is checked **before** the budget. A hit costs nothing, so a run that has reached `--max-cost` can still be served from cache rather than stopping on a request it was not going to pay for. There is a test for that.

## Failing softly

A cache is an optimisation and must never fail a run. Every path degrades to a miss: a corrupt entry, an unwritable directory, an oversized response, an expired entry. Writes go to a temporary name and are moved into place, so an interrupted write cannot leave a half-written file that later parses as valid JSON.

Entries live under a two-character prefix directory, since a long run can write thousands and some filesystems degrade badly with that many siblings in one directory.

## Tests

`tests/test_response_cache.py` — 21 cases.

The key: identical requests match; a different model, system prompt or prompt each miss; the parts cannot run together.

Storage: a miss returns nothing; a stored response comes back; entries survive a new instance, which is the point — reuse across runs, not within one; entries live under one directory; hits and misses are counted.

Off by default: a disabled cache stores nothing and never hits.

Failing softly: a corrupt entry is a miss; an unwritable cache does not raise; an oversized response is not stored; an expired entry is a miss.

Through the client: an identical request makes no second call; a cached run costs nothing; a cached response still parses; no cache means every request is made; a hit is served even past the budget.

`tests/test_streaming.py` gains one line — its stub builds a client with `object.__new__`, so it needed the new attribute. Not a behaviour change.

## Verified

- the call counts and costs above, against a stubbed provider
- 21 new tests pass, plus `test_cost_budget`, `test_verbose_payloads`, `test_plan_phase` and `test_streaming` — 101 in total
- all import-guard checks green
- ruff clean on the new module
- built on current `main` after #138

## Two follow-ups

`.repopilot-cache/` should be added to `.gitignore`. One line, happy to fold it in here or send it separately.

This touches `modules/llm_client.py`, as does #175. That one is much smaller — merging it first and rebasing this is the cleaner order.