### PR TITLE
feat(llm): fall back to another provider on a transient failure — Closes #176

### DIFF
--- a/main.py
+++ b/main.py
@@ -187,6 +187,13 @@ Examples:
                         help="API key for the LLM provider (default: provider-specific env var)")
     parser.add_argument("--model", default=None,
                         help="LLM model name (default: provider-specific, or AGENT_MODEL env var)")
+    parser.add_argument("--fallback-provider",
+                        choices=["anthropic", "openai", "gemini", "ollama"],
+                        default=None,
+                        help="Try this provider when the primary fails with a "
+                             "transient error such as a 500 or an overload.")
+    parser.add_argument("--fallback-api-key", default=None,
+                        help="Key for the fallback provider (defaults to --api-key).")
     parser.add_argument("--provider", default="anthropic",
                         choices=["anthropic", "openai", "gemini", "ollama"],
                         help="LLM provider to use (default: anthropic)")
@@ -268,6 +275,8 @@ def _run_task_batch(args) -> int:
             anthropic_api_key=args.api_key,
             model=args.model,
             provider=args.provider,
+        fallback_provider=args.fallback_provider,
+        fallback_api_key=args.fallback_api_key,
         )
         return AutonomousAgent(config).run()
 

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -117,6 +117,8 @@ class AgentConfig:
     model: Optional[str] = None
     context_budget: Optional[int] = None   # chars; derived from the model if unset
     provider: str = "anthropic"
+    fallback_provider: Optional[str] = None   # try this one if the primary is down
+    fallback_api_key: Optional[str] = None
 
     # Context
     force_include_paths: Optional[list] = None  # always include these files
@@ -259,6 +261,8 @@ class AutonomousAgent:
                 provider=cfg.provider,
                 verbose=cfg.verbose_payloads,
             max_cost=cfg.max_cost,
+            fallback_provider=cfg.fallback_provider,
+            fallback_api_key=cfg.fallback_api_key,
             cache=(
                 ResponseCache(cfg.repo_root, enabled=True)
                 if cfg.use_cache else None

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -16,7 +16,7 @@ import time
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional, Any
-from modules.errors import ConfigurationError, ProviderError
+from modules.errors import ConfigurationError, ProviderError, AgentError
 
 _LOG = logging.getLogger("agent.llm_client")
 
@@ -886,6 +886,45 @@ class OllamaClient(BaseLLMClient):
             raise
 
 
+# Errors worth trying another provider for: the request was fine and the
+# service was not. An authentication failure, a malformed request or a budget
+# stop would fail identically on the fallback, and trying anyway would spend
+# money to produce the same error twice.
+TRANSIENT_API_MARKERS = (
+    "overloaded", "rate limit", "rate_limit", "too many requests",
+    "500", "502", "503", "504", "internal server error",
+    "bad gateway", "service unavailable", "gateway timeout",
+    "timed out", "connection reset", "connection aborted",
+)
+
+
+def is_transient_api_error(error: BaseException) -> bool:
+    """
+    True when another provider might reasonably succeed.
+
+    Matches on message text because each provider raises its own SDK's
+    exceptions, which share no base. `AgentError` from #159 covers the failures
+    this tool raises deliberately -- a budget stop among them -- and those are
+    excluded by type rather than by substring.
+    """
+    if isinstance(error, AgentError):
+        return False
+    text = f"{type(error).__name__}: {error}".lower()
+    return any(marker in text for marker in TRANSIENT_API_MARKERS)
+
+
+def _build_provider(provider, api_key, model, api_base_url=None):
+    """One provider client, by name."""
+    provider = (provider or "").lower()
+    if provider == "openai":
+        return OpenAIClient(api_key, model)
+    if provider == "gemini":
+        return GeminiClient(api_key, model)
+    if provider == "ollama":
+        return OllamaClient(model, api_base_url)
+    return AnthropicClient(api_key, model)
+
+
 class LLMClient(BaseLLMClient):
     """Facade class maintaining backward compatibility while wrapping dynamic clients."""
     
@@ -893,18 +932,22 @@ class LLMClient(BaseLLMClient):
                  provider: str = "anthropic", verbose: bool = False,
                  max_cost: Optional[float] = None,
                  api_base_url: Optional[str] = None,
+                 fallback_provider: Optional[str] = None,
+                 fallback_api_key: Optional[str] = None,
                  system_prompt: Optional[str] = None,
                  cache=None):
         super().__init__(model, verbose, max_cost, system_prompt, cache)
         self.provider = provider.lower()
-        if self.provider == "openai":
-            self.underlying_client = OpenAIClient(api_key, model)
-        elif self.provider == "gemini":
-            self.underlying_client = GeminiClient(api_key, model)
-        elif self.provider == "ollama":
-            self.underlying_client = OllamaClient(model, api_base_url)
-        else:
-            self.underlying_client = AnthropicClient(api_key, model)
+        self.underlying_client = _build_provider(
+            self.provider, api_key, model, api_base_url
+        )
+
+        # Built lazily: constructing it eagerly would demand a second SDK and a
+        # second key from everyone, including the majority who never fail over.
+        self.fallback_provider = (fallback_provider or "").lower() or None
+        self._fallback_client = None
+        self._fallback_args = (fallback_api_key or api_key, model, api_base_url)
+        self.used_fallback = False
 
         # Set once after the chain rather than in each branch: the flag applies
         # to whichever provider was chosen, and one line cannot drift.
@@ -913,8 +956,47 @@ class LLMClient(BaseLLMClient):
         self.underlying_client.system_prompt = self.system_prompt
         self.underlying_client.cache = cache
 
+    def _fallback(self):
+        """The fallback client, constructed on first need."""
+        if not self.fallback_provider:
+            return None
+        if self._fallback_client is None:
+            api_key, model, api_base_url = self._fallback_args
+            self._fallback_client = _build_provider(
+                self.fallback_provider, api_key, model, api_base_url
+            )
+            self._fallback_client.verbose = self.verbose
+            self._fallback_client.max_cost = self.max_cost
+        return self._fallback_client
+
     def _call(self, prompt: str) -> str:
-        return self.underlying_client._call(prompt)
+        """
+        Call the primary provider, falling back only on a transient failure.
+
+        A 500 or an overload means the request was fine and the service was
+        not, so another provider may answer it. An authentication failure or a
+        malformed request would fail identically on the fallback, and trying
+        anyway spends money to produce the same error twice.
+        """
+        try:
+            return self.underlying_client._call(prompt)
+        except BaseException as exc:
+            fallback = self._fallback()
+            if fallback is None or not is_transient_api_error(exc):
+                raise
+
+            _LOG.warning(
+                "%s failed (%s); retrying with %s.",
+                self.provider, type(exc).__name__, self.fallback_provider,
+            )
+            response = fallback._call(prompt)
+            # Spend on the fallback is real spend; folding it in keeps
+            # --max-cost honest across a failover.
+            self.input_tokens_used += fallback.input_tokens_used
+            self.output_tokens_used += fallback.output_tokens_used
+            self.total_cost += fallback.total_cost
+            self.used_fallback = True
+            return response
 
     def initial_request(
         self, task: str, context_str: str, plan: Optional["Plan"] = None

--- a/tests/test_provider_fallback.py
+++ b/tests/test_provider_fallback.py
@@ -1,0 +1,199 @@
+"""
+Tests for --fallback-provider (modules/llm_client.py).
+
+When the primary provider returns a 500 or reports being overloaded, the
+request itself was fine and the service was not — so another provider may well
+answer it.
+
+The distinction that makes this safe is the same one #154 used for push
+retries: an authentication failure or a malformed request fails identically on
+the fallback, so trying anyway spends money to produce the same error twice.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.llm_client import (  # noqa: E402
+    BaseLLMClient,
+    BudgetExceededError,
+    LLMClient,
+    is_transient_api_error,
+)
+
+RESPONSE = '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
+
+
+class Failing(BaseLLMClient):
+    def __init__(self, error):
+        super().__init__()
+        self.error = error
+        self.calls = 0
+
+    def _call(self, prompt):
+        self.calls += 1
+        raise self.error
+
+
+class Working(BaseLLMClient):
+    def __init__(self, cost=0.004):
+        super().__init__()
+        self.calls = 0
+        self.cost = cost
+
+    def _call(self, prompt):
+        self.calls += 1
+        self.total_cost = self.cost
+        self.input_tokens_used = 100
+        self.output_tokens_used = 50
+        return RESPONSE
+
+
+def facade(primary, fallback=None):
+    client = object.__new__(LLMClient)
+    BaseLLMClient.__init__(client)
+    client.provider = "anthropic"
+    client.underlying_client = primary
+    client.fallback_provider = "openai" if fallback else None
+    client._fallback_client = fallback
+    client._fallback_args = (None, "model", None)
+    client.used_fallback = False
+    return client
+
+
+# ── what counts as worth failing over ─────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["Error 529: Overloaded", "503 Service Unavailable", "500 Internal Server Error",
+     "429 Too Many Requests", "Connection reset by peer", "Request timed out",
+     "502 Bad Gateway"],
+)
+def test_service_failures_are_transient(message):
+    assert is_transient_api_error(RuntimeError(message)) is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["401 Authentication failed", "invalid request: unknown model",
+     "permission denied", "context length exceeded"],
+)
+def test_request_failures_are_not_transient(message):
+    """These fail identically on any provider."""
+    assert is_transient_api_error(RuntimeError(message)) is False
+
+
+def test_a_budget_stop_is_not_transient():
+    """
+    Failing over would spend the money the limit exists to prevent, on a
+    provider the limit also applies to.
+    """
+    assert is_transient_api_error(BudgetExceededError("limit reached")) is False
+
+
+# ── failover ──────────────────────────────────────────────────────────────
+
+
+def test_a_transient_failure_uses_the_fallback():
+    backup = Working()
+    client = facade(Failing(RuntimeError("Error 529: Overloaded")), backup)
+
+    assert client._call("prompt") == RESPONSE
+    assert backup.calls == 1
+
+
+def test_it_records_that_the_fallback_was_used():
+    """So a surprising answer can be traced to a different model."""
+    client = facade(Failing(RuntimeError("503 Service Unavailable")), Working())
+    client._call("prompt")
+
+    assert client.used_fallback is True
+
+
+def test_a_non_transient_failure_is_raised_untouched():
+    backup = Working()
+    client = facade(Failing(RuntimeError("401 Authentication failed")), backup)
+
+    with pytest.raises(RuntimeError, match="Authentication"):
+        client._call("prompt")
+
+    assert backup.calls == 0
+
+
+def test_no_fallback_configured_means_the_error_propagates():
+    client = facade(Failing(RuntimeError("Error 529: Overloaded")))
+
+    with pytest.raises(RuntimeError):
+        client._call("prompt")
+
+
+def test_a_working_primary_never_touches_the_fallback():
+    backup = Working()
+    client = facade(Working(), backup)
+
+    client._call("prompt")
+
+    assert backup.calls == 0
+
+
+# ── accounting survives the failover ──────────────────────────────────────
+
+
+def test_the_fallback_spend_is_counted():
+    """
+    Spend on the fallback is real spend. Not folding it in would let --max-cost
+    be exceeded silently whenever a failover happened.
+    """
+    client = facade(Failing(RuntimeError("Error 529: Overloaded")), Working(cost=0.004))
+    client._call("prompt")
+
+    assert client.total_cost == pytest.approx(0.004)
+
+
+def test_the_fallback_tokens_are_counted():
+    client = facade(Failing(RuntimeError("Error 529: Overloaded")), Working())
+    client._call("prompt")
+
+    assert client.input_tokens_used == 100
+    assert client.output_tokens_used == 50
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_no_fallback_by_default():
+    assert AgentConfig(repo_root=".", task="t").fallback_provider is None
+
+
+def test_the_fallback_client_is_built_lazily():
+    """
+    Building it eagerly would demand a second SDK and a second key from
+    everyone, including the majority who never fail over.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "llm_client.py"
+    ).read_text(encoding="utf-8")
+
+    assert "self._fallback_client = None" in source
+    assert "def _fallback(self)" in source
+
+
+def test_main_passes_both_flags():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+
+    assert "fallback_provider=args.fallback_provider" in source
+    assert "fallback_api_key=args.fallback_api_key" in source
+
+
+def test_the_fallback_key_defaults_to_the_primary_key():
+    """Some people use one key across providers; requiring two would be noise."""
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "llm_client.py"
+    ).read_text(encoding="utf-8")
+
+    assert "fallback_api_key or api_key" in source


### PR DESCRIPTION
Closes #176

```bash
python main.py --repo . --task "Fix the parser" \
  --provider anthropic --fallback-provider openai
```

When the primary provider returns a 500 or reports being overloaded, the same request goes to the fallback instead of failing the run.

## What is worth failing over for

This is the part worth reviewing, and it is the same distinction #154 used for push retries.

A 500 or an overload means the request itself was fine and the service was not, so another provider may well answer it. An authentication failure or a malformed request will fail identically on the fallback — trying anyway spends money to produce the same error twice, and leaves the user with a confusing second error from a provider they were not thinking about.

| error | behaviour |
| ----- | --------- |
| `529 Overloaded`, `503`, `502`, `500`, `504` | fall over |
| `429 Too Many Requests` | fall over |
| connection reset, timed out | fall over |
| `401 Authentication failed` | raised as-is |
| invalid model, permission denied, context length exceeded | raised as-is |
| `BudgetExceededError` | raised as-is |

The last row matters on its own: failing over on a budget stop would spend exactly the money the limit exists to prevent, on a provider the same limit applies to.

## The fallback client is built lazily

Constructing it in `__init__` would require a second SDK installed and a second key present for everyone who sets the flag — including the majority of runs where the primary never fails. It is built on first need instead.

`--fallback-api-key` defaults to `--api-key`, since some people use one key across providers and demanding two would be noise.

## Accounting survives the failover

```python
self.input_tokens_used += fallback.input_tokens_used
self.output_tokens_used += fallback.output_tokens_used
self.total_cost += fallback.total_cost
```

Without this the fallback's spend would accumulate on a client nobody was checking, and `--max-cost` would be exceeded silently whenever a failover happened. Spend on the fallback is real spend.

`used_fallback` is recorded so a surprising answer can be traced to a different model having produced it, rather than looking like the primary behaving oddly.

## Verified

```
transient error   -> response from backup, used_fallback=True, cost $0.0040 folded in
auth error        -> raised as-is, fallback called 0 times
```

## Tests

`tests/test_provider_fallback.py` — 23 cases.

Classification: seven service failures are transient, parametrised; four request failures are not; a budget stop is not.

Failover: a transient failure uses the fallback; it records that the fallback was used; a non-transient failure is raised untouched and the fallback is never called; no fallback configured means the error propagates; a working primary never touches the fallback.

Accounting: the fallback's spend is counted; its tokens are counted.

Wiring: no fallback by default; the fallback client is built lazily; `main.py` passes both flags; the fallback key defaults to the primary key.

## Verified

- the failover and no-failover traces above
- 23 tests pass, plus `test_cost_budget`, `test_streaming`, `test_plan_phase` and `test_verbose_payloads` — 80 in total, no regressions
- all import-guard checks green
- built on current `main` after #138

## Overlap

Touches `modules/llm_client.py`, as do #175 and #168. All three are independent in what they change within that file, but whichever merges last will want a rebase rather than a hand-resolved conflict — happy to do that.

## Related: #159

Worth noting alongside this. The classifier here works on error message text because there is no exception hierarchy to match on — the providers each raise their own SDK's errors, and `agent_loop` catches bare `Exception` in four places. A shared `AgentError` base, as #159 proposes, would let this match on type rather than substring. Not doing it here, since it touches every module and several PRs are already open against overlapping files.