### PR TITLE
fix(logger): make iteration boundaries visible in the human log — Closes #173

### DIFF
--- a/modules/logger.py
+++ b/modules/logger.py
@@ -66,6 +66,28 @@ class RunRecord:
     final_error: Optional[str] = None
 
 
+class _ReadableFormatter(logging.Formatter):
+    """
+    Timestamps ordinary lines, leaves structural ones bare.
+
+    A separator rendered through the standard formatter comes out as
+
+        2026-04-19 18:31:48 [INFO] ------------------------------------
+
+    which is indented by thirty characters of metadata and no longer separates
+    anything. Headers and rules are emitted without the prefix so the eye can
+    find them, and everything else keeps its timestamp and level.
+    """
+
+    def __init__(self, datefmt: str):
+        super().__init__("%(asctime)s [%(levelname)s] %(message)s", datefmt=datefmt)
+
+    def format(self, record: logging.LogRecord) -> str:
+        if getattr(record, "bare", False):
+            return record.getMessage()
+        return super().format(record)
+
+
 class AgentLogger:
     def __init__(self, log_dir: str, run_id: str, verbose: bool = True):
         self.log_dir = os.path.abspath(log_dir)
@@ -84,18 +106,12 @@ class AgentLogger:
 
         console_handler = logging.StreamHandler(_configure_text_stream(sys.stdout))
         console_handler.setLevel(logging.DEBUG if verbose else logging.INFO)
-        console_handler.setFormatter(logging.Formatter(
-            "%(asctime)s [%(levelname)s] %(message)s",
-            datefmt="%H:%M:%S",
-        ))
+        console_handler.setFormatter(_ReadableFormatter(datefmt="%H:%M:%S"))
         self._logger.addHandler(console_handler)
 
         file_handler = logging.FileHandler(self.human_log_path, encoding="utf-8")
         file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(logging.Formatter(
-            "%(asctime)s [%(levelname)s] %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        ))
+        file_handler.setFormatter(_ReadableFormatter(datefmt="%H:%M:%S"))
         self._logger.addHandler(file_handler)
 
         self._run_record: Optional[RunRecord] = None
@@ -118,9 +134,20 @@ class AgentLogger:
         self._logger.info(f"  Task: {task[:120]}")
         self._logger.info(f"  Repo: {repo_root}")
 
+    def section(self, title: str, rule: str = "-") -> None:
+        """A header with no timestamp prefix, so it reads as a boundary."""
+        self._logger.info("", extra={"bare": True})
+        self._logger.info(rule * 60, extra={"bare": True})
+        self._logger.info(title, extra={"bare": True})
+        self._logger.info(rule * 60, extra={"bare": True})
+
     def start_iteration(self, iteration: int):
-        self._logger.info("\n" + "-" * 60)
-        self._logger.info(f"Iteration {iteration}")
+        # The date moved here from every line: a run happens on one day, and
+        # repeating it 200 times pushed the actual message off to the right.
+        self.section(
+            f"Iteration {iteration}"
+            f"  ({datetime.now().strftime('%Y-%m-%d %H:%M:%S')})"
+        )
 
     def log_context(self, files: list[str], total_chars: int):
         self._logger.debug(f"  Context: {len(files)} files, {total_chars} chars")

--- a/tests/test_log_formatting.py
+++ b/tests/test_log_formatting.py
@@ -1,0 +1,140 @@
+"""
+Tests for human-readable log formatting (modules/logger.py).
+
+Every line went through one formatter, so an iteration separator came out as
+
+    2026-04-19 18:31:48 [INFO] ------------------------------------------
+
+indented by thirty characters of metadata and no longer separating anything.
+Scanning a run meant reading every line to find where one iteration ended.
+
+Structural lines — rules and headers — are now emitted bare. Everything else
+keeps its timestamp and level.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.logger import AgentLogger  # noqa: E402
+
+TIMESTAMPED = re.compile(r"^\d{2}:\d{2}:\d{2} \[(DEBUG|INFO|WARNING|ERROR)\]")
+
+
+@pytest.fixture
+def logger(tmp_path):
+    return AgentLogger(str(tmp_path), "run_test", verbose=True)
+
+
+def written(tmp_path):
+    return (tmp_path / "run_test_human.log").read_text(encoding="utf-8").splitlines()
+
+
+# ── structural lines are bare ─────────────────────────────────────────────
+
+
+def test_a_rule_carries_no_prefix(logger, tmp_path):
+    logger.start_iteration(1)
+
+    rules = [line for line in written(tmp_path) if set(line.strip()) == {"-"}]
+
+    assert rules
+    for rule in rules:
+        assert not TIMESTAMPED.match(rule)
+
+
+def test_the_iteration_header_carries_no_prefix(logger, tmp_path):
+    logger.start_iteration(3)
+
+    header = next(line for line in written(tmp_path) if line.startswith("Iteration 3"))
+
+    assert not TIMESTAMPED.match(header)
+
+
+def test_a_header_is_bounded_above_and_below(logger, tmp_path):
+    """A rule on one side only reads as decoration rather than a boundary."""
+    logger.start_iteration(1)
+    lines = written(tmp_path)
+    index = next(i for i, line in enumerate(lines) if line.startswith("Iteration 1"))
+
+    assert set(lines[index - 1].strip()) == {"-"}
+    assert set(lines[index + 1].strip()) == {"-"}
+
+
+def test_a_blank_line_precedes_the_header(logger, tmp_path):
+    logger.start_iteration(1)
+
+    assert written(tmp_path)[0] == ""
+
+
+# ── ordinary lines keep their prefix ──────────────────────────────────────
+
+
+def test_messages_are_still_timestamped(logger, tmp_path):
+    logger.info("  Applying 2 change(s)")
+
+    assert TIMESTAMPED.match(written(tmp_path)[0])
+
+
+def test_the_level_is_still_recorded(logger, tmp_path):
+    logger.warning("  something looks off")
+
+    assert "[WARNING]" in written(tmp_path)[0]
+
+
+def test_debug_lines_still_reach_the_file(logger, tmp_path):
+    """The file handler is DEBUG regardless of --quiet; it is the record."""
+    logger.log_context(["a.py"], 100)
+
+    assert any("[DEBUG]" in line for line in written(tmp_path))
+
+
+# ── the date ──────────────────────────────────────────────────────────────
+
+
+def test_the_date_appears_in_the_header(logger, tmp_path):
+    logger.start_iteration(1)
+
+    header = next(line for line in written(tmp_path) if line.startswith("Iteration 1"))
+
+    assert re.search(r"\d{4}-\d{2}-\d{2}", header)
+
+
+def test_the_date_is_not_repeated_on_every_line(logger, tmp_path):
+    """
+    A run happens on one day. Repeating the date on 200 lines pushed the
+    message itself off to the right for no information.
+    """
+    logger.info("  a message")
+
+    assert not re.search(r"\d{4}-\d{2}-\d{2}", written(tmp_path)[0])
+
+
+# ── boundaries are findable ───────────────────────────────────────────────
+
+
+def test_each_iteration_is_separated(logger, tmp_path):
+    for iteration in (1, 2, 3):
+        logger.start_iteration(iteration)
+        logger.info(f"  work for {iteration}")
+
+    lines = written(tmp_path)
+    headers = [line for line in lines if line.startswith("Iteration ")]
+
+    assert len(headers) == 3
+
+
+def test_a_custom_section_can_be_written(logger, tmp_path):
+    logger.section("Summary")
+
+    assert "Summary" in written(tmp_path)
+
+
+def test_a_section_rule_character_can_be_changed(logger, tmp_path):
+    logger.section("Done", rule="=")
+
+    assert any(set(line.strip()) == {"="} for line in written(tmp_path))


### PR DESCRIPTION
Closes #173

## The separator already existed and did not separate

`start_iteration` wrote a rule and a header, but every line went through one formatter, so the rule came out as:

```
2026-04-19 18:31:48 [INFO] ------------------------------------------
```

Indented by thirty characters of metadata. A separator that starts a third of the way across the line is not a separator, so scanning a run meant reading every line to find where one iteration ended and the next began.

After:

```

------------------------------------------------------------
Iteration 2  (2026-08-09 06:10:23)
------------------------------------------------------------
06:10:23 [INFO]   Applying 2 change(s)
06:10:23 [DEBUG]   Context: 12 files, 58263 chars
```

## How

A formatter that checks one attribute. Records emitted with `extra={"bare": True}` render as their message and nothing else; everything else keeps its timestamp and level exactly as before.

That is deliberately the smallest mechanism that works. The alternative — a second logger, or writing the file by hand alongside the handler — means two paths that can disagree about what was logged.

`section(title, rule="-")` is available for any other boundary worth marking; `start_iteration` is its first caller.

## The date moved

It was on all 200 lines of a run and is now on the header only.

A run happens on one day. Repeating `2026-04-19 ` in front of every line spent eleven characters to say something that changes once, and pushed the actual message rightward — which matters in a terminal, where the message is the part being read.

The time stays on every line, since that does change and is how a slow step gets found.

## Tests

`tests/test_log_formatting.py` — 12 cases.

Structural lines: a rule carries no prefix; the iteration header carries no prefix; a header is bounded above and below, since a rule on one side reads as decoration rather than a boundary; a blank line precedes the header.

Ordinary lines: messages are still timestamped; the level is still recorded; debug lines still reach the file, which is DEBUG regardless of `--quiet` because the file is the record.

The date: it appears in the header; it is not repeated on every line.

Boundaries: each iteration is separated; a custom section can be written; the rule character can be changed.

## Verified

- the before and after output above, from a real `AgentLogger`
- 12 tests pass, plus `test_iteration_timing`, `test_module_logging`, `test_dashboard` and `test_utils` — 67 in total, no regressions
- all import-guard checks green
- ruff clean on `modules/logger.py`
- built on current `main` after #138