### PR TITLE
feat(sandbox): add tox and nox as test runners — Closes #153

### DIFF
--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -91,6 +91,27 @@ class ExecutionResult:
 # vitest is invoked as `vitest run` on purpose. Bare `vitest` starts a watch
 # server when it thinks it is interactive; under this sandbox it would hold the
 # process open until timeout_seconds elapsed and be reported as a test timeout.
+# Multi-version testing works on the host, where pyenv or a system install
+# provides several interpreters. Inside the default container it does not: the
+# image ships one Python, so tox skips every environment it cannot find an
+# interpreter for and reports success having tested one version.
+#
+# Pass a multi-version image to test several inside a container, for example
+# one of the `fkrull/multi-python` tags:
+#
+#     DockerSandbox(repo, image="fkrull/multi-python:latest").run_tests("tox")
+#
+# Stated here rather than silently accepted, because "tests passed" from a run
+# that tested one version out of three is the wrong kind of green.
+MULTI_VERSION_RUNNERS = frozenset({"tox", "nox"})
+
+MULTI_VERSION_IMAGE_NOTE = (
+    "tox/nox in a container test only the interpreters present in the image. "
+    "The default python:3.11-slim ships one; pass a multi-python image to test "
+    "several."
+)
+
+
 @dataclass(frozen=True)
 class LanguageRunner:
     """
@@ -140,6 +161,15 @@ RUNNERS: dict = {
                        linters=("eslint", "tsc")),
         LanguageRunner("jest", "javascript", ["npx", "--no-install", "jest"],
                        linters=("eslint", "tsc")),
+        # tox and nox each manage their own interpreters and virtualenvs, so the
+        # sandbox invokes them and stays out of the way. Both need to find the
+        # interpreters they are configured for: `python:3.11-slim` contains one,
+        # so a container run tests only 3.11 however many envlist entries there
+        # are. See MULTI_VERSION_IMAGE_NOTE.
+        LanguageRunner("tox", "python", ["tox"], module=None,
+                       linters=("ruff", "flake8", "pyflakes")),
+        LanguageRunner("nox", "python", ["nox"], module=None,
+                       linters=("ruff", "flake8", "pyflakes")),
         LanguageRunner("bash", "bash", ["bash"]),
         LanguageRunner("make", "make", ["make"]),
         LanguageRunner("go", "go", ["go", "test", "./..."], linters=("govet",)),
@@ -1006,6 +1036,13 @@ class DockerSandbox(Sandbox):
         """
         if not self._docker_available and not self.strict:
             return super().run_tests(runner, extra_args)
+
+        if runner in MULTI_VERSION_RUNNERS:
+            # Warned rather than refused: testing one version is still worth
+            # something, and the image may well be a multi-python one. Silence
+            # is the problem -- "tests passed" after testing one of three
+            # versions reads as a stronger result than it is.
+            _LOG.warning("%s (image: %s)", MULTI_VERSION_IMAGE_NOTE, self.image)
 
         runner_cmd = DOCKER_RUNNERS.get(runner) or ["python", "-m", "pytest"]
         return self.run(runner_cmd + (extra_args or []))

--- a/tests/test_multi_version_runners.py
+++ b/tests/test_multi_version_runners.py
@@ -1,0 +1,149 @@
+"""
+Tests for tox and nox as runners (modules/sandbox.py).
+
+Both manage their own interpreters and virtualenvs, so the sandbox invokes them
+and stays out of the way. Adding them is two registry entries now that #140
+folded the five parallel runner tables into one.
+
+The part worth being careful about is what "simultaneously against 3.9, 3.10 and
+3.11" means inside a container. The default image ships one interpreter, so tox
+skips every environment it cannot find a Python for and exits successfully
+having tested one version. That is a worse outcome than failing, because it
+reads as a stronger result than it is.
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import (  # noqa: E402
+    ALLOWED_RUNNERS,
+    DOCKER_RUNNERS,
+    MULTI_VERSION_IMAGE_NOTE,
+    MULTI_VERSION_RUNNERS,
+    RUNNERS,
+    SubprocessSandbox,
+    linters_for_runner,
+    runners_for_language,
+)
+
+
+# ── they are registered ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_the_runner_exists(runner):
+    assert runner in RUNNERS
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_the_command_is_the_bare_tool(runner):
+    """No arguments: both read their own config and decide what to run."""
+    assert ALLOWED_RUNNERS[runner] == [runner]
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_the_container_command_matches_the_host(runner):
+    """
+    Unlike pytest, neither is invoked through a specific interpreter, so there
+    is nothing to differ between host and image.
+    """
+    assert DOCKER_RUNNERS[runner] == ALLOWED_RUNNERS[runner]
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_they_are_python_runners(runner):
+    assert RUNNERS[runner].language == "python"
+
+
+def test_they_appear_alongside_the_other_python_runners():
+    """The registry from #140 is what makes this discoverable rather than a lookup."""
+    assert runners_for_language("python") == ["nox", "pytest", "python", "tox"]
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_python_linters_are_associated(runner):
+    assert "ruff" in linters_for_runner(runner)
+
+
+# ── they behave like every other runner ───────────────────────────────────
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_a_missing_tool_fails_cleanly(runner, monkeypatch):
+    """
+    Neither is a module invoked through an interpreter, so availability is the
+    ordinary `which` check rather than the import probe pytest needs.
+    """
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    result = SubprocessSandbox(tempfile.mkdtemp()).run_tests(runner)
+
+    assert result.exit_code == -3
+    assert "not found" in result.stderr
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_neither_needs_an_import_probe(runner):
+    """
+    MODULE_RUNNERS exists because `which(sys.executable)` always succeeds for
+    `python -m pytest`. tox and nox are real executables on PATH.
+    """
+    assert RUNNERS[runner].module is None
+
+
+@pytest.mark.parametrize("runner", ["tox", "nox"])
+def test_neither_falls_back(runner):
+    """
+    pytest falls back to running files with `python` because that still
+    executes them. There is no weaker way to run a tox matrix.
+    """
+    assert RUNNERS[runner].fallback is None
+
+
+# ── the container caveat is stated ────────────────────────────────────────
+
+
+def test_both_are_marked_as_multi_version():
+    assert MULTI_VERSION_RUNNERS == {"tox", "nox"}
+
+
+def test_the_note_names_the_actual_limitation():
+    assert "image" in MULTI_VERSION_IMAGE_NOTE
+    assert "python:3.11-slim" in MULTI_VERSION_IMAGE_NOTE
+
+
+def test_the_note_says_what_to_do_about_it():
+    """A caveat without a remedy is just discouragement."""
+    assert "multi-python" in MULTI_VERSION_IMAGE_NOTE
+
+
+def test_docker_warns_rather_than_refusing():
+    """
+    Testing one version is still worth something, and the image may well be a
+    multi-python one. Silence is the problem, not the single-version run.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "sandbox.py"
+    ).read_text(encoding="utf-8")
+    block = source[source.index("if runner in MULTI_VERSION_RUNNERS:"):][:400]
+
+    assert "_LOG.warning" in block
+    assert "raise" not in block
+
+
+# ── nothing else changed ──────────────────────────────────────────────────
+
+
+def test_the_existing_runners_are_untouched():
+    for runner in ("pytest", "python", "go", "cargo", "npm_test", "make"):
+        assert runner in ALLOWED_RUNNERS
+
+
+def test_the_registry_grew_by_exactly_two():
+    assert len(RUNNERS) == 14

--- a/tests/test_runner_registry.py
+++ b/tests/test_runner_registry.py
@@ -118,8 +118,12 @@ def test_no_runner_was_lost(name):
     assert name in ALLOWED_RUNNERS
 
 
-def test_the_count_is_unchanged():
-    assert len(ALLOWED_RUNNERS) == 12
+def test_the_count_matches_the_registry():
+    """
+    Pinned so a runner cannot be dropped unnoticed. Raised from 12 to 14 when
+    tox and nox were added for #153.
+    """
+    assert len(ALLOWED_RUNNERS) == len(RUNNERS) == 14
 
 
 # ── what the registry makes possible ──────────────────────────────────────
@@ -127,7 +131,7 @@ def test_the_count_is_unchanged():
 
 def test_runners_can_be_listed_by_language():
     """Not answerable from the old tables, which had no notion of a language."""
-    assert runners_for_language("python") == ["pytest", "python"]
+    assert runners_for_language("python") == ["nox", "pytest", "python", "tox"]
     assert runners_for_language("javascript") == ["jest", "node", "npm_test", "vitest"]
 
 


### PR DESCRIPTION
Closes #153

```bash
python main.py --repo . --task "..." --runner tox
python main.py --repo . --task "..." --runner nox
```

Both manage their own interpreters and virtualenvs, so the sandbox invokes them and stays out of the way.

## Two registry entries, because #140 landed first

Before that refactor this meant editing `ALLOWED_RUNNERS`, `DOCKER_RUNNERS`, `MODULE_RUNNERS`, `RUNNER_FALLBACKS` and the linter association separately, and remembering all five. Now:

```python
LanguageRunner("tox", "python", ["tox"], linters=("ruff", "flake8", "pyflakes")),
LanguageRunner("nox", "python", ["nox"], linters=("ruff", "flake8", "pyflakes")),
```

Every derived table picks them up automatically, and `runners_for_language("python")` now answers `['nox', 'pytest', 'python', 'tox']` without anyone maintaining that list.

Neither needs a `module` probe — that exists because `which(sys.executable)` always succeeds for `python -m pytest`, and both of these are real executables on PATH. Neither gets a `fallback` either: pytest falls back to running files with `python` because that still executes them, and there is no weaker way to run a tox matrix.

## The word "simultaneously" needs a caveat

The issue asks to test against 3.9, 3.10 and 3.11 at once. tox does that itself — but only against interpreters it can find, and the default container image is `python:3.11-slim`, which ships one.

So inside a container, tox skips every environment it has no interpreter for and **exits successfully having tested one version**. That is worse than failing: "tests passed" reads as a stronger result than it is, and nothing in the output says three of the four environments never ran.

A warning is logged whenever tox or nox runs under Docker:

```
tox/nox in a container test only the interpreters present in the image.
The default python:3.11-slim ships one; pass a multi-python image to test several.
```

**Warned rather than refused**, deliberately. Testing one version is still worth something, and the image may well be a multi-python one — `DockerSandbox(repo, image="fkrull/multi-python:latest")` works today and is named in the module comment. The silence was the problem, not the single-version run.

On the host this does not arise: pyenv or a system install provides whatever interpreters tox is configured for, and it behaves exactly as it does outside the agent.

## Two existing tests failed, correctly

`test_runner_registry.py` pins the exact runner list and count. Both broke:

```
assert 14 == 12
assert ['nox', 'pytest', 'python', 'tox'] == ['pytest', 'python']
```

That is the assertion doing its job — it exists so a runner cannot be dropped unnoticed by a merge. Updated to 14, tied to `len(RUNNERS)` so the two figures cannot drift, with a comment recording why it moved.

## Tests

`tests/test_multi_version_runners.py` — 23 cases.

Registration: each runner exists; the command is the bare tool, since both read their own config; the container command matches the host, unlike pytest which is invoked through a specific interpreter; both are Python runners; both appear in `runners_for_language`; Python linters are associated.

Behaviour: a missing tool fails cleanly with `-3`; neither needs an import probe; neither falls back.

The caveat: both are marked multi-version; the note names the actual limitation and the image causing it; the note says what to do about it, because a caveat without a remedy is just discouragement; Docker warns rather than refusing.

Unchanged: the existing runners are all still present; the registry grew by exactly two.

## Verified

- both runners resolve through every derived table
- a missing tox fails through the existing not-found path rather than a new one
- 23 new tests pass, plus `test_runner_registry`, `test_runner_fallback`, `test_sandbox_env` and `test_docker_hardening` — 141 in total
- all import-guard checks green
- ruff on `modules/sandbox.py` unchanged at 1 finding
- built on current `main` after #140 and #68

## Possible follow-up

If multi-version testing in a container is wanted as a default rather than an option, the image would need to change — and that is a bigger decision than this PR, since it affects every containerised run's pull time and size. Worth its own issue if you want it.