### PR TITLE
fix: add two methods that were called and never existed — Closes #230

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -177,6 +177,11 @@ def _checkpoint(agent, cfg, iteration, last_changes, exec_result) -> None:
     )
 
 
+# Coverage is reported to one decimal place and rounding moves it slightly
+# between runs. Failing a run for 0.05% would be noise, not a signal.
+COVERAGE_TOLERANCE = 0.5
+
+
 class AutonomousAgent:
     def __init__(self, config: AgentConfig):
         self.config = config
@@ -252,6 +257,34 @@ class AutonomousAgent:
             api_base_url=cfg.api_base_url,
             )
         return self._llm
+
+    def _coverage_feedback(
+        self,
+        baseline: Optional[float],
+        current: Optional[float],
+    ) -> Optional[str]:
+        """
+        A message when coverage fell, or None when it did not.
+
+        The call site has always existed and this method never did, so a run
+        with --coverage raised AttributeError the moment a percentage parsed.
+
+        Returns None whenever the comparison cannot be made -- no baseline, or
+        no current figure. Treating an unparseable number as a drop would fail
+        runs for a reporting quirk rather than for anything the model did.
+        """
+        if baseline is None or current is None:
+            return None
+
+        if current >= baseline - COVERAGE_TOLERANCE:
+            return None
+
+        return (
+            f"Coverage fell from {baseline:.1f}% to {current:.1f}%. "
+            f"The tests pass, but they cover less of the code than before. "
+            f"Restore the deleted tests, or add tests for the new paths -- "
+            f"deleting a failing test is not fixing it."
+        )
 
     def _run_execution(self) -> ExecutionResult:
         """Run tests or the specified file in the sandbox."""
@@ -923,7 +956,7 @@ class AutonomousAgent:
 
         final_message = {
             "budget_exceeded": (
-                f"Stopped at the --max-cost limit after {self.llm.usage.summary()}. "
+                f"Stopped at the --max-cost limit after {self.llm.usage_summary()}. "
                 f"Any applied changes were rolled back."
             ),
             "success": "Task completed successfully. Tests pass.",

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -395,6 +395,20 @@ class BaseLLMClient:
                 f"limit of ${self.max_cost:.2f}. Stopping before the next call."
             )
 
+    def usage_summary(self) -> str:
+        """
+        One line describing what this client has spent.
+
+        The budget-exceeded message called `self.llm.usage.summary()`, and no
+        `usage` attribute has ever existed -- so a run that correctly stopped at
+        its --max-cost limit then crashed while explaining why. The figures were
+        all already tracked; nothing was aggregating them.
+        """
+        return (
+            f"{self.input_tokens_used:,} input and {self.output_tokens_used:,} "
+            f"output tokens, ${self.total_cost:.4f}"
+        )
+
     def _record_usage(self, input_tok: int, output_tok: int) -> None:
         """Add one call's tokens and cost to the running totals."""
         self.input_tokens_used += input_tok

--- a/tests/test_missing_attributes.py
+++ b/tests/test_missing_attributes.py
@@ -1,0 +1,155 @@
+"""
+Tests for two attributes that were called and never existed
+(modules/agent_loop.py, modules/llm_client.py).
+
+Both were found by mypy, and both are live crashes rather than style problems:
+
+- `self._coverage_feedback(...)` — a run with `--coverage` raised AttributeError
+  the moment a coverage percentage parsed
+- `self.llm.usage.summary()` — a run that correctly stopped at its `--max-cost`
+  limit then crashed while building the message explaining why
+
+Neither shows up in normal use, because both sit on optional paths that the
+test suite never exercised end to end.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import COVERAGE_TOLERANCE, AutonomousAgent  # noqa: E402
+from modules.llm_client import BaseLLMClient  # noqa: E402
+
+
+class Stub(BaseLLMClient):
+    def _call(self, prompt):
+        return '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
+
+
+@pytest.fixture
+def feedback():
+    """_coverage_feedback bound to a bare object; it uses no instance state."""
+    holder = type("Holder", (), {})()
+    return AutonomousAgent._coverage_feedback.__get__(holder)
+
+
+# ── the attributes exist ──────────────────────────────────────────────────
+
+
+def test_the_coverage_helper_exists():
+    assert callable(getattr(AutonomousAgent, "_coverage_feedback", None))
+
+
+def test_the_usage_summary_exists():
+    assert callable(getattr(BaseLLMClient, "usage_summary", None))
+
+
+# ── the coverage gate ─────────────────────────────────────────────────────
+
+
+def test_a_real_drop_is_reported(feedback):
+    message = feedback(80.0, 72.0)
+
+    assert message is not None
+    assert "80.0%" in message and "72.0%" in message
+
+
+def test_unchanged_coverage_does_not_gate(feedback):
+    assert feedback(80.0, 80.0) is None
+
+
+def test_improved_coverage_does_not_gate(feedback):
+    assert feedback(80.0, 85.0) is None
+
+
+def test_rounding_noise_does_not_gate(feedback):
+    """
+    Coverage is reported to one decimal place and moves slightly between runs.
+    Failing for 0.2% would be noise rather than a signal.
+    """
+    assert feedback(80.0, 79.8) is None
+
+
+def test_a_drop_past_the_tolerance_does_gate(feedback):
+    assert feedback(80.0, 80.0 - COVERAGE_TOLERANCE - 0.1) is not None
+
+
+def test_the_tolerance_is_small_enough_to_be_useful():
+    """Wide enough to absorb rounding, narrow enough to still catch a regression."""
+    assert 0 < COVERAGE_TOLERANCE <= 1.0
+
+
+@pytest.mark.parametrize(
+    "baseline,current", [(None, 75.0), (80.0, None), (None, None)]
+)
+def test_an_impossible_comparison_does_not_gate(feedback, baseline, current):
+    """
+    Treating an unparseable figure as a drop would fail runs for a reporting
+    quirk rather than for anything the model did.
+    """
+    assert feedback(baseline, current) is None
+
+
+def test_the_message_names_the_failure_mode(feedback):
+    """
+    The wording is the pre-existing suite's, and it is sharper than a generic
+    "add tests": the concern is a model deleting a failing test to make the
+    run go green, which coverage is exactly what detects.
+    """
+    message = feedback(90.0, 70.0)
+
+    assert "Restore the deleted tests" in message
+    assert "deleting a failing test is not fixing it" in message
+
+
+# ── the usage summary ─────────────────────────────────────────────────────
+
+
+def test_it_reports_tokens_and_cost():
+    client = Stub()
+    client.initial_request("task", "context" * 200)
+
+    summary = client.usage_summary()
+
+    assert "input" in summary and "output" in summary and "$" in summary
+
+
+def test_a_fresh_client_reports_zero():
+    """Called when a run stops early, which can happen before any request."""
+    summary = Stub().usage_summary()
+
+    assert "0 input" in summary
+    assert "$0.0000" in summary
+
+
+def test_the_figures_grow_with_use():
+    client = Stub()
+    client.initial_request("task", "context")
+    first = client.total_cost
+    client.initial_request("task", "context")
+
+    assert client.total_cost > first
+    assert f"${client.total_cost:.4f}" in client.usage_summary()
+
+
+def test_the_budget_message_can_be_built():
+    """
+    The exact expression that used to crash. The run stopping is correct; the
+    crash was in explaining why.
+    """
+    client = Stub()
+    client.initial_request("task", "context")
+
+    assert f"Stopped after {client.usage_summary()}."
+
+
+def test_the_loop_calls_the_method_that_exists():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "self.llm.usage_summary()" in source
+    assert "self.llm.usage.summary()" not in source


### PR DESCRIPTION
Closes #230 

Both were found by mypy and both reproduced as crashes before being fixed.

## `--coverage`

```
AttributeError: 'AutonomousAgent' object has no attribute '_coverage_feedback'
```

The call site has always existed and the method never did, so a run with `--coverage` raised as soon as a coverage percentage parsed — right after the first successful test run.

`tests/test_coverage_gate.py` was already testing this method, and **8 of its 23 tests were failing on `main`**. That suite is #60's, landed without its implementation. It now passes in full.

### The existing tests told me the wording, and it is better than mine

My first version said "add tests for the new paths, or explain why they are untestable". The suite expects something sharper:

> Restore the deleted tests, or add tests for the new paths — deleting a failing test is not fixing it.

That names the actual failure mode. The concern is not a model writing untested code; it is a model deleting a failing test to make the run go green, which is exactly what a coverage drop detects and what a passing test suite does not. I adopted the original wording and updated my own test to match.

### Two judgement calls

**A tolerance of 0.5%.** Coverage is reported to one decimal place and moves slightly between runs; failing a run for 0.2% would be noise rather than signal. Pinned by a test as small enough to still catch a real regression.

**An impossible comparison does not gate.** No baseline, or no current figure, returns `None` — without `pytest-cov` there is no measurement, and treating an unparseable number as a drop would fail runs for a reporting quirk rather than for anything the model did.

## `--max-cost`

```
AttributeError: 'AnthropicClient' object has no attribute 'usage'
```

The budget check worked; the run stopped where it should. It then crashed building the message explaining why — the feature doing its job and the user getting a traceback instead of the explanation.

Every figure the message needs was already tracked on the client. `usage_summary()` aggregates them:

```
Stopped at the --max-cost limit after 1,046 input and 14 output tokens, $0.0033.
```

## Tests

`tests/test_missing_attributes.py` — 17 cases.

Existence: both attributes are callable.

The coverage gate: a real drop is reported; unchanged and improved coverage do not gate; rounding noise does not gate; a drop past the tolerance does; the tolerance is small enough to be useful; three impossible comparisons do not gate, parametrised; the message names the failure mode.

The usage summary: it reports tokens and cost; a fresh client reports zero, since the message can be built before any request; the figures grow with use; the exact expression that used to crash can now be built; the loop calls the method that exists and no longer the one that does not.

## Verified

- both crashes reproduced before the fix and confirmed after
- `tests/test_coverage_gate.py`: 8 failed → 23 passed
- 17 new tests pass, plus `test_cost_budget` and `test_utils` — 63 in total, no regressions
- both `attr-defined` errors in `agent_loop.py` and `llm_client.py` cleared under mypy
- all import-guard checks green
- built on current `main` after #138

## Not addressed

mypy still reports two `attr-defined` errors in `context_builder.py`:

```
"stmt" has no attribute "annotation"
"stmt" has no attribute "target"
```

Those are a narrowing limitation rather than a bug — the `isinstance` check is one line above but stored in a variable, so mypy loses the narrowing. The code is correct and I would rather leave working code alone than restructure it to satisfy a checker that is not in CI.