### PR TITLE
feat: add --step to pause between iterations — Closes #172

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,6 +177,10 @@ Examples:
                              "spent (e.g. --max-cost 1.00). Off by default.")
     parser.add_argument("--yes", "-y", action="store_true",
                         help="Auto-approve file changes (bypass confirmation prompt)")
+    parser.add_argument("--step", action="store_true",
+                        help="Pause after each iteration so you can inspect the "
+                             "working tree before the next one. Needs a terminal; "
+                             "ignored when output is piped or --yes is set.")
     parser.add_argument("--interactive", "-i", action="store_true",
                         help="After tests pass, show the diff and confirm before "
                              "committing. Ignored when --yes is set or CI=true.")
@@ -318,6 +322,7 @@ def main():
         context_only=args.context_only,
         yes=yes_flag,
         interactive=args.interactive,
+        step=args.step,
 
         # Execution
         plan_first=args.plan_first,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -14,6 +14,7 @@ Flow per iteration:
 """
 
 import os
+import sys
 import time
 import re
 import uuid
@@ -63,7 +64,8 @@ class AgentConfig:
     dry_run: bool = False
     context_only: bool = False             # print the compiled context and stop
     yes: bool = False
-    interactive: bool = False   # pause for review after tests pass, before commit
+    interactive: bool = False
+    step: bool = False                     # pause between iterations to inspect
 
     # Execution
     skip_tests: bool = False               # accept the LLM's own verdict instead
@@ -268,6 +270,58 @@ class AutonomousAgent:
 
     # Cap the review diff so a large refactor cannot flood the terminal.
     _MAX_DIFF_LINES = 400
+
+    def _pause_after_iteration(self, iteration: int, exec_result) -> bool:
+        """
+        Stop between iterations so the tree can be inspected. Returns False to
+        end the run.
+
+        Placed at the iteration boundary rather than wherever a key is pressed.
+        Mid-iteration there is nothing coherent to look at -- the agent is
+        inside an API call or a test run, and the working tree is either
+        untouched or half-written. At the boundary the changes are applied, the
+        tests have reported, and `git diff` says something true.
+
+        Requires a terminal. `--step` with output piped, or under CI, would
+        block forever on a prompt nobody can answer, so it degrades to a
+        warning and the run continues.
+        """
+        cfg = self.config
+        if not cfg.step or cfg.yes:
+            return True
+
+        if not sys.stdin.isatty():
+            if iteration == 1:
+                self.logger.warning(
+                    "  --step needs a terminal and stdin is not one; continuing "
+                    "without pausing."
+                )
+            return True
+
+        status = (
+            "passed" if exec_result and exec_result.success else "did not pass"
+        )
+        print("\n" + "=" * 60)
+        print(f"  PAUSED after iteration {iteration} - tests {status}")
+        print("=" * 60)
+        print("  The working tree holds this iteration's changes. Inspect it in")
+        print("  another shell -- `git diff`, run something, read the log -- then:")
+        print()
+        print("    [Enter]  continue to the next iteration")
+        print("    s        stop here and finish the run")
+        print()
+
+        try:
+            answer = input("  > ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            # Ctrl+D or Ctrl+C at the prompt means stop, not continue.
+            print()
+            return False
+
+        if answer in ("s", "stop", "q", "quit"):
+            self.logger.info(f"  Stopped at iteration {iteration} by request.")
+            return False
+        return True
 
     def _confirm_commit(self, changed_paths: list[str]) -> bool:
         """
@@ -885,6 +939,14 @@ class AutonomousAgent:
                 self.logger.warning(f"  Max iterations ({cfg.max_iterations}) reached.")
                 outcome = "max_retries"
 
+            # Every path that reaches here has finished an iteration: the
+            # changes are applied and the tests have reported. Placed after the
+            # "feeding back" message so the pause reads as a boundary rather
+            # than an interruption of it.
+            if not self._pause_after_iteration(iteration, last_exec):
+                outcome = "stopped"
+                break
+
         # ── Post-loop: Git push + PR ──
         if outcome == "success" and self.git and self.branch_name:
             if cfg.git_push:
@@ -929,6 +991,11 @@ class AutonomousAgent:
             "success": "Task completed successfully. Tests pass.",
             "failed": "Task could not be completed. Check logs.",
             "max_retries": f"Exhausted {cfg.max_iterations} iterations without passing tests.",
+            "stopped": (
+                "Stopped at your request between iterations. The changes from "
+                "the last iteration are still in the working tree -- commit "
+                "them, or run with --rollback to discard them."
+            ),
             "error": "Agent encountered an unrecoverable error.",
             "aborted": (
                 "Commit declined at the review prompt. Tests passed and the "

--- a/tests/test_step_mode.py
+++ b/tests/test_step_mode.py
@@ -1,0 +1,225 @@
+"""
+Tests for --step (modules/agent_loop.py).
+
+The issue asks for a keypress to pause the loop at any moment. That is not
+viable here and this does something narrower instead — see the PR for the
+reasoning; in short, non-blocking keypress capture needs raw terminal mode,
+which is unavailable whenever output is piped or CI is running, and both are
+the normal case for this tool.
+
+`--step` pauses at the iteration boundary, which is the only point where there
+is anything coherent to inspect: the changes are applied and the tests have
+reported. Mid-iteration the agent is inside an API call or a test run, and the
+working tree is either untouched or half-written.
+"""
+
+import builtins
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig, AutonomousAgent  # noqa: E402
+
+PASSED = SimpleNamespace(success=True)
+FAILED = SimpleNamespace(success=False)
+
+
+def agent(**config):
+    instance = object.__new__(AutonomousAgent)
+    instance.config = AgentConfig(repo_root=".", task="t", **config)
+    instance.logger = SimpleNamespace(
+        warning=lambda message: None, info=lambda message: None
+    )
+    return instance
+
+
+@pytest.fixture
+def terminal(monkeypatch):
+    """Pretend stdin is a terminal, and script the answer."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: True)
+
+    def answer(text):
+        monkeypatch.setattr(builtins, "input", lambda _: text)
+
+    return answer
+
+
+def paused(instance, iteration=1, result=PASSED):
+    with redirect_stdout(io.StringIO()):
+        return instance._pause_after_iteration(iteration, result)
+
+
+# ── off unless asked for ──────────────────────────────────────────────────
+
+
+def test_it_is_off_by_default():
+    assert AgentConfig(repo_root=".", task="t").step is False
+
+
+def test_no_step_flag_never_pauses():
+    assert paused(agent()) is True
+
+
+def test_yes_overrides_it(terminal):
+    """
+    --yes means unattended, and main.py sets it automatically under CI. A run
+    told not to ask questions must not stop on one.
+    """
+    terminal("s")
+
+    assert paused(agent(step=True, yes=True)) is True
+
+
+# ── it needs a terminal ───────────────────────────────────────────────────
+
+
+def test_without_a_terminal_it_continues(monkeypatch):
+    """
+    Piped output is the normal case -- most commands in this repository's own
+    documentation pipe. Blocking on a prompt nobody can answer would hang.
+    """
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+
+    assert paused(agent(step=True)) is True
+
+
+def test_the_warning_is_printed_once(monkeypatch):
+    """Once per run, not once per iteration."""
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
+    warnings = []
+    instance = agent(step=True)
+    instance.logger = SimpleNamespace(warning=warnings.append, info=lambda m: None)
+
+    for iteration in (1, 2, 3):
+        with redirect_stdout(io.StringIO()):
+            instance._pause_after_iteration(iteration, PASSED)
+
+    assert len(warnings) == 1
+
+
+# ── the answers ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("answer", ["", "   ", "y", "anything"])
+def test_continuing_is_the_default(terminal, answer):
+    """Enter is the common case and must not need a word typed."""
+    terminal(answer)
+
+    assert paused(agent(step=True)) is True
+
+
+@pytest.mark.parametrize("answer", ["s", "S", "stop", "q", "quit"])
+def test_stopping_is_accepted_several_ways(terminal, answer):
+    terminal(answer)
+
+    assert paused(agent(step=True)) is False
+
+
+@pytest.mark.parametrize("interrupt", [EOFError, KeyboardInterrupt])
+def test_an_interrupt_at_the_prompt_stops(terminal, monkeypatch, interrupt):
+    """
+    Ctrl+D and Ctrl+C mean stop. Treating them as "continue" would carry on
+    spending money after someone tried to bail out.
+    """
+    def raising(_):
+        raise interrupt()
+
+    monkeypatch.setattr(builtins, "input", raising)
+
+    assert paused(agent(step=True)) is False
+
+
+# ── what it shows ─────────────────────────────────────────────────────────
+
+
+def test_the_banner_names_the_iteration(terminal):
+    terminal("")
+    output = io.StringIO()
+    with redirect_stdout(output):
+        agent(step=True)._pause_after_iteration(3, PASSED)
+
+    assert "iteration 3" in output.getvalue()
+
+
+@pytest.mark.parametrize(
+    "result,expected", [(PASSED, "tests passed"), (FAILED, "tests did not pass")]
+)
+def test_the_banner_reflects_the_test_result(terminal, result, expected):
+    """Whether to keep going usually depends on this."""
+    terminal("")
+    output = io.StringIO()
+    with redirect_stdout(output):
+        agent(step=True)._pause_after_iteration(1, result)
+
+    assert expected in output.getvalue()
+
+
+def test_it_says_what_can_be_inspected(terminal):
+    terminal("")
+    output = io.StringIO()
+    with redirect_stdout(output):
+        agent(step=True)._pause_after_iteration(1, PASSED)
+
+    assert "git diff" in output.getvalue()
+
+
+def test_both_choices_are_shown(terminal):
+    terminal("")
+    output = io.StringIO()
+    with redirect_stdout(output):
+        agent(step=True)._pause_after_iteration(1, PASSED)
+
+    text = output.getvalue()
+    assert "continue" in text and "stop here" in text
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_the_pause_is_at_the_iteration_boundary():
+    """
+    Not mid-iteration: there the agent is inside an API call or a test run and
+    the working tree is half-written, so there is nothing coherent to look at.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert source.index("_pause_after_iteration(iteration, last_exec)") > \
+        source.index("# ── More iterations needed ──")
+
+
+def test_stopping_ends_the_run_cleanly():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+    block = source[source.index("if not self._pause_after_iteration"):][:200]
+
+    assert 'outcome = "stopped"' in block
+    assert "break" in block
+
+
+def test_the_outcome_explains_where_the_changes_are():
+    """
+    A stopped run leaves changes in the tree; saying so is the difference
+    between a deliberate stop and an apparent failure.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "Stopped at your request between iterations" in source
+    assert "--rollback" in source
+
+
+def test_main_registers_and_passes_the_flag():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+
+    assert '"--step"' in source
+    assert "step=args.step" in source


### PR DESCRIPTION
Closes #172

```bash
python main.py --repo . --task "Fix the parser" --step
```

```
============================================================
  PAUSED after iteration 2 - tests passed
============================================================
  The working tree holds this iteration's changes. Inspect it in
  another shell -- `git diff`, run something, read the log -- then:

    [Enter]  continue to the next iteration
    s        stop here and finish the run
```

## This is not the keypress pause the issue describes

The issue asks for a key press to pause the loop at any moment. I could not build that responsibly, and the reasons are worth stating rather than quietly substituting something else.

**Raw terminal mode is unavailable in the normal case.** Non-blocking keypress capture needs `msvcrt` on Windows and `termios` plus `select` on Unix, and both require a TTY:

```
stdin is a tty in this sandbox : False
in a subprocess, as CI runs it : False
```

Most commands in this repository's own documentation pipe their output — `| Select-Object -Last 2` appears throughout. A feature that only works when nothing is piped, and never under CI, is one that fails in the situations people actually run in.

**Concurrent tasks have no single target.** `--tasks` runs N agents in separate worktrees against one stdin. A keypress has no well-defined meaning there.

**Mid-iteration there is nothing coherent to inspect.** The agent is inside an API call or a test run; the working tree is either untouched or half-written. Pausing to look at it would show a state that never existed as a coherent step.

## What it does instead

Pauses at the iteration boundary, which is the point where inspection is meaningful: the changes are applied, the tests have reported, and `git diff` says something true.

That also happens to be the gap in the existing flags. `--interactive` asks before committing, and `--dry-run` shows changes before applying — neither lets you look at what iteration 2 did before iteration 3 starts.

## Degrading rather than hanging

**No terminal** — warns once and continues. Blocking on a prompt nobody can answer would hang a piped run or a CI job indefinitely, which is worse than not pausing.

**`--yes`** — skips entirely, matching `_confirm_commit`. `main.py` sets `--yes` automatically when `CI=true`, so a run told not to ask questions never stops on one.

**Ctrl+D or Ctrl+C at the prompt means stop**, not continue. Treating an interrupt as "carry on" would keep spending after someone tried to bail out.

A stopped run reports where the work is:

> Stopped at your request between iterations. The changes from the last iteration are still in the working tree — commit them, or run with `--rollback` to discard them.

## Tests

`tests/test_step_mode.py` — 25 cases.

Off unless asked: it is off by default; no flag never pauses; `--yes` overrides it.

Needs a terminal: without one it continues; the warning is printed once per run, not once per iteration.

The answers: four inputs continue, parametrised, since Enter is the common case and must not need a word typed; five inputs stop; `EOFError` and `KeyboardInterrupt` both stop.

What it shows: the banner names the iteration; it reflects whether tests passed, since that is usually what the decision turns on; it says `git diff` can be run; both choices are shown.

Wiring: the pause is after the iteration boundary; stopping ends the run cleanly with a `break`; the outcome message explains where the changes are; `main.py` registers and passes the flag.

## Verified

- every degradation path and every answer, above
- 25 tests pass, plus `test_interactive_commit`, `test_run_state` and `test_context_only` — 62 in total, no regressions
- all import-guard checks green
- ruff on `modules/agent_loop.py` back at its baseline of 22

## One thing I could not test here

The sandbox has no TTY, so the interactive path is exercised by patching `isatty` and `input`. The prompt itself has not been driven by a real terminal — worth a manual run on a machine that has one before merging.

## If the original is still wanted

A keypress-anytime pause is buildable behind a platform check that no-ops without a TTY, but it would be dead in CI, dead when piped, and undefined under `--tasks`. Happy to add it as well if you want it, though I would keep this boundary pause regardless — it is the one that works everywhere.