### PR TITLE
fix: repair the streaming stub after #150 and stop the config check misfiring — Closes #234

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -119,15 +119,25 @@ jobs:
         # from the dataclass, so every run died with TypeError at construction.
         run: |
           python - <<'PY'
-          import dataclasses, re, sys
+          import ast, dataclasses, sys
 
           from modules.agent_loop import AgentConfig
 
           fields = {f.name for f in dataclasses.fields(AgentConfig)}
           source = open("main.py").read()
-          block = source[source.index("config = AgentConfig("):]
-          block = block[: block.index("\n    )")]
-          passed = set(re.findall(r"^\s+(\w+)=", block, re.MULTILINE))
+
+          # Parsed rather than sliced. The previous version cut from
+          # "config = AgentConfig(" to the next "\n    )", which swept up any
+          # other multi-line call inside that span. run_tasks() and clean()
+          # both sit there now, so their keyword arguments were reported as
+          # missing AgentConfig fields -- four false failures.
+          passed = set()
+          for node in ast.walk(ast.parse(source)):
+              if not isinstance(node, ast.Call):
+                  continue
+              called = getattr(node.func, "id", None) or getattr(node.func, "attr", None)
+              if called == "AgentConfig":
+                  passed.update(kw.arg for kw in node.keywords if kw.arg)
 
           missing = sorted(passed - fields)
           for name in missing:

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -20,7 +20,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from modules.llm_client import AnthropicClient  # noqa: E402
+from modules.llm_client import SYSTEM_PROMPT, AnthropicClient  # noqa: E402
 
 RESPONSE = '{"analysis":"a","changes":[],"confidence":0.9,"done":true}'
 
@@ -41,6 +41,8 @@ def client(chunks=None, stream_raises=None, blocking=RESPONSE):
     obj = object.__new__(AnthropicClient)
     obj.model = "claude-sonnet-4-20250514"
     obj.verbose = False
+    obj.system_prompt = SYSTEM_PROMPT
+    obj.cache = None
     obj.max_cost = None
     obj.input_tokens_used = obj.output_tokens_used = 0
     obj.total_cost = 0.0


### PR DESCRIPTION
Closes #234 

Both found by running the full suite and the guard steps against `main` after the fourteen-PR merge. Neither is a defect in any single PR — both only exist once several are on `main` together.

## The streaming stub

```
AttributeError: 'AnthropicClient' object has no attribute 'system_prompt'
```

#150 made the system prompt per-instance. `test_streaming.py` constructs its client with `object.__new__` to avoid needing an API key, which skips `__init__`, so nothing set the attribute.

The file already sets `model`, `verbose`, `max_cost` and the token counters by hand for exactly this reason. `system_prompt` joins them, along with `cache` for the same reason once #168 lands.

Not a behaviour change — the test double simply needs to match the class it stands in for.

## The config check was misfiring

```
FAIL main.py passes base_branch=, AgentConfig has no such field
FAIL main.py passes branch_prefix=, AgentConfig has no such field
FAIL main.py passes max_workers=, AgentConfig has no such field
FAIL main.py passes older_than_days=, AgentConfig has no such field
```

All four are false. They belong to `run_tasks()` from #138 and `clean()` from #163.

The check sliced from `config = AgentConfig(` to the next `\n    )` and regexed every `name=` in between. That held while `AgentConfig(...)` was the only multi-line call in that span; both new calls now sit inside it.

Replaced with an AST walk that collects keywords from calls whose callee is actually `AgentConfig`. Layout-independent, and a neighbouring call cannot be confused for it.

```
40 config arguments, all accepted
```

### It still catches the real thing

The check exists because `main.py` passed `plan_first` and `resume_from` after both were lost from the dataclass, and every run died with `TypeError` at construction. Verified the new version still fails when a field is genuinely missing:

```
with plan_first removed from the dataclass:
  FAIL main.py passes plan_first=, AgentConfig has no such field
  -> exit 1
```

That check matters more than the false positives are annoying. A guard that reports failures nobody can act on gets ignored, and the other five steps in that workflow catch things no test would.

## Verified

- `tests/test_streaming.py` 16 passing
- the config check clean on `main`, and still failing on a simulated missing field
- **full suite: 52 files passing, 0 failing** — first time this has been true
- all six import-guard checks green
- built on current `main` at `9ee9a25`

## Note

`#231` merged with a literal `#<issue>` in its title where the number should have been. Cosmetic, but the link between that PR and its issue is broken — worth a comment on either to restore the trail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation accuracy for agent configuration checks, reducing false failures caused by unrelated multiline code.
* **Tests**
  * Updated streaming test fixtures to support system prompts and caching correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->