### PR TITLE
feat(git): write the PR title and body from the diff — Closes #174

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,6 +116,10 @@ Examples:
                         help="Push the branch to remote after success")
     parser.add_argument("--pr", action="store_true",
                         help="Create a GitHub PR after pushing (requires GITHUB_TOKEN)")
+    parser.add_argument("--describe-pr", action="store_true",
+                        help="With --pr, ask the model to write the PR title and "
+                             "body from the diff. Costs one extra call; falls back "
+                             "to the standard template if it fails.")
     parser.add_argument("--base-branch", default="main",
                         help="Base branch for PR and branch creation (default: main)")
     parser.add_argument("--branch-prefix", default="agent",
@@ -380,6 +384,7 @@ def main():
         git_base_branch=args.base_branch,
         git_push=args.push,
         git_create_pr=args.pr,
+        describe_pr=args.describe_pr,
 
         # Dirs
         backup_dir=args.backup_dir,

--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -100,7 +100,8 @@ class AgentConfig:
     yes: bool = False
     no_commit: bool = False                # stage changes but leave them uncommitted
     git_push: bool = False                  # push to remote?
-    git_create_pr: bool = False             # create GitHub PR?
+    git_create_pr: bool = False
+    describe_pr: bool = False              # have the model write the PR title/body             # create GitHub PR?
 
     # Directories
     backup_dir: str = "backups"
@@ -1011,14 +1012,37 @@ class AutonomousAgent:
 
                 if push_result.success and cfg.git_create_pr:
                     diff_stat = self.git.diff_staged() or "See commit for changes."
+                    title = f"[Agent] {cfg.task[:72]}"
+                    body = (
+                        f"## Autonomous Agent PR\n\n"
+                        f"**Task:** {cfg.task}\n\n"
+                        f"**Run ID:** `{self.run_id}`\n\n"
+                        f"**Changes:**\n```\n{diff_stat}\n```"
+                    )
+
+                    if cfg.describe_pr:
+                        # One extra paid call, so it is opt-in. The templated
+                        # pair stays as the fallback: a PR that opens with a
+                        # plain description beats a run that succeeded and then
+                        # died writing prose about itself.
+                        written_title, written_body = self.llm.pr_description_request(
+                            cfg.task, self.git.diff_staged() or diff_stat
+                        )
+                        if written_title and written_body:
+                            title = written_title
+                            body = (
+                                f"{written_body}\n\n---\n"
+                                f"*Written by RepoPilot, run `{self.run_id}`.*"
+                            )
+                        else:
+                            self.logger.warning(
+                                "  Could not generate a PR description; "
+                                "using the standard template."
+                            )
+
                     self.pr_url = self.git.create_github_pr(
-                        title=f"[Agent] {cfg.task[:72]}",
-                        body=(
-                            f"## Autonomous Agent PR\n\n"
-                            f"**Task:** {cfg.task}\n\n"
-                            f"**Run ID:** `{self.run_id}`\n\n"
-                            f"**Changes:**\n```\n{diff_stat}\n```"
-                        ),
+                        title=title,
+                        body=body,
                         head_branch=self.branch_name,
                         base_branch=cfg.git_base_branch,
                     )

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -280,7 +280,35 @@ class LLMResponse:
 
 SYSTEM_PROMPT = load_prompt("system", _BUILTIN_SYSTEM_PROMPT)
 TASK_PROMPT_TEMPLATE = load_prompt("initial", _BUILTIN_TASK_PROMPT)
+# How much of the diff to send. Enough to describe the change, bounded because
+# this is an extra paid call on top of the run that produced the diff.
+PR_DIFF_CHARS = 12_000
+
+_BUILTIN_PR_PROMPT = """\
+A code change has been made to satisfy this task:
+
+{task}
+
+Here is the diff:
+
+{diff}
+
+Write a pull request title and description for it.
+
+Return ONLY a JSON object:
+
+{{
+  "title": "<one line, imperative, under 72 characters>",
+  "body": "<markdown; what changed and why, not a restatement of the task>"
+}}
+
+Describe what the diff actually does. If it does less than the task asked for,
+say so -- a description that oversells the change is worse than a plain one.
+"""
+
+
 RETRY_PROMPT_TEMPLATE = load_prompt("retry", _BUILTIN_RETRY_PROMPT)
+PR_PROMPT_TEMPLATE = load_prompt("pr", _BUILTIN_PR_PROMPT)
 PLAN_PROMPT_TEMPLATE = load_prompt("plan", _BUILTIN_PLAN_PROMPT)
 PLAN_PROMPT_TEMPLATE = load_prompt("plan", _BUILTIN_PLAN_PROMPT)
 
@@ -369,6 +397,25 @@ def load_system_prompt(path: str) -> str:
             "parse.", ", ".join(missing),
         )
     return text
+
+
+
+def _parse_pr_description(raw: str) -> tuple:
+    """Pull the title and body out of a response, or (None, None)."""
+    text = (raw or "").strip()
+    start, end = text.find("{"), text.rfind("}") + 1
+    if start == -1 or end == 0:
+        return None, None
+    try:
+        data = json.loads(text[start:end])
+    except json.JSONDecodeError:
+        return None, None
+
+    title = str(data.get("title") or "").strip()
+    body = str(data.get("body") or "").strip()
+    if not title or not body:
+        return None, None
+    return title[:72], body
 
 
 class BudgetExceededError(RuntimeError):
@@ -573,6 +620,33 @@ class BaseLLMClient:
             risks=as_list("risks"),
             confidence=float(data.get("confidence", 0.5)),
         )
+
+    def pr_description_request(self, task: str, diff: str) -> tuple:
+        """
+        Ask for a pull request title and body describing what changed.
+
+        Returns (title, body). Falls back to the templated pair on any failure:
+        a PR that opens with a plain description is better than a run that
+        succeeded and then died writing prose about itself.
+
+        Routed through _accounted_call, so this extra request is budget-checked
+        and its cost recorded like any other -- --pr with --max-cost should not
+        be able to overshoot because of the description.
+        """
+        prompt = PR_PROMPT_TEMPLATE.format(
+            task=task, diff=diff[:PR_DIFF_CHARS]
+        )
+        try:
+            raw, _ = self._accounted_call(prompt)
+        except BudgetExceededError:
+            raise
+        except Exception as exc:
+            _LOG.warning(
+                "Could not generate a PR description (%s); using the template.", exc
+            )
+            return None, None
+
+        return _parse_pr_description(raw)
 
     def plan_request(self, task: str, context_str: str) -> Plan:
         """

--- a/prompts/pr.txt
+++ b/prompts/pr.txt
@@ -1,0 +1,19 @@
+A code change has been made to satisfy this task:
+
+{task}
+
+Here is the diff:
+
+{diff}
+
+Write a pull request title and description for it.
+
+Return ONLY a JSON object:
+
+{{
+  "title": "<one line, imperative, under 72 characters>",
+  "body": "<markdown; what changed and why, not a restatement of the task>"
+}}
+
+Describe what the diff actually does. If it does less than the task asked for,
+say so -- a description that oversells the change is worse than a plain one.

--- a/tests/test_pr_description.py
+++ b/tests/test_pr_description.py
@@ -1,0 +1,197 @@
+"""
+Tests for --describe-pr (modules/llm_client.py, modules/agent_loop.py).
+
+`--pr` opened a PR with a templated body: the task, the run id and a diffstat.
+That says what was asked for, not what was done. With --describe-pr the model
+writes the title and body from the actual diff.
+
+Opt-in, because it is one more paid call on top of the run that produced the
+diff — and it falls back to the template on any failure, since a PR that opens
+with a plain description beats a run that succeeded and then died writing prose
+about itself.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.agent_loop import AgentConfig  # noqa: E402
+from modules.llm_client import (  # noqa: E402
+    PR_DIFF_CHARS,
+    BaseLLMClient,
+    BudgetExceededError,
+    _parse_pr_description,
+)
+
+WRITTEN = json.dumps({
+    "title": "Guard against an empty list in calculate_average",
+    "body": "## What\n\nAdds a guard and a regression test.",
+})
+
+
+class Stub(BaseLLMClient):
+    def __init__(self, reply=WRITTEN, error=None, **kwargs):
+        super().__init__(**kwargs)
+        self.reply = reply
+        self.error = error
+        self.prompts = []
+
+    def _call(self, prompt):
+        self.prompts.append(prompt)
+        if self.error:
+            raise self.error
+        return self.reply
+
+
+# ── parsing ───────────────────────────────────────────────────────────────
+
+
+def test_a_well_formed_response_parses():
+    title, body = _parse_pr_description(WRITTEN)
+
+    assert title.startswith("Guard against")
+    assert "## What" in body
+
+
+def test_prose_around_the_json_is_tolerated():
+    """Models preface things. The run should not fail over a "Sure!"."""
+    title, _ = _parse_pr_description(f"Sure, here you go:\n{WRITTEN}\nHope that helps.")
+
+    assert title.startswith("Guard against")
+
+
+@pytest.mark.parametrize(
+    "raw,label",
+    [
+        ("no json here", "no json"),
+        ("{not valid json", "malformed"),
+        (json.dumps({"title": "", "body": "x"}), "empty title"),
+        (json.dumps({"body": "x"}), "missing title"),
+        (json.dumps({"title": "x"}), "missing body"),
+        ("", "empty response"),
+    ],
+)
+def test_anything_unusable_yields_nothing(raw, label):
+    """Every failure funnels to the same place, so the caller has one case."""
+    assert _parse_pr_description(raw) == (None, None)
+
+
+def test_an_over_long_title_is_truncated():
+    """GitHub accepts long titles; a 200-character one is unreadable in a list."""
+    long = json.dumps({"title": "x" * 200, "body": "b"})
+
+    assert len(_parse_pr_description(long)[0]) == 72
+
+
+# ── the request ───────────────────────────────────────────────────────────
+
+
+def test_it_returns_a_title_and_body():
+    title, body = Stub().pr_description_request("fix the average", "a diff")
+
+    assert title and body
+
+
+def test_the_diff_reaches_the_prompt():
+    """
+    The point of the feature: describing what changed rather than restating the
+    task, which the template already did.
+    """
+    stub = Stub()
+    stub.pr_description_request("fix the average", "DISTINCTIVE DIFF MARKER")
+
+    assert "DISTINCTIVE DIFF MARKER" in stub.prompts[0]
+
+
+def test_the_diff_is_bounded():
+    """One extra paid call; sending a megabyte of diff would not be free."""
+    stub = Stub()
+    stub.pr_description_request("task", "x" * (PR_DIFF_CHARS * 3))
+
+    assert len(stub.prompts[0]) < PR_DIFF_CHARS * 2
+
+
+def test_the_call_is_costed():
+    """
+    It goes through _accounted_call, so --pr --max-cost cannot overshoot
+    because of the description.
+    """
+    stub = Stub()
+    stub.pr_description_request("task", "diff")
+
+    assert stub.total_cost > 0
+
+
+def test_a_budget_stop_is_not_swallowed():
+    """
+    Every other failure degrades to the template. This one must not: a run at
+    its limit should stop, not quietly spend one more call's worth of attempt.
+    """
+    stub = Stub(max_cost=0.0000001)
+    stub.total_cost = 999.0
+
+    with pytest.raises(BudgetExceededError):
+        stub.pr_description_request("task", "diff")
+
+
+def test_a_provider_error_degrades():
+    result = Stub(error=RuntimeError("503 Service Unavailable")).pr_description_request(
+        "task", "diff"
+    )
+
+    assert result == (None, None)
+
+
+def test_an_unusable_response_degrades():
+    assert Stub(reply="rambling, no json").pr_description_request("t", "d") == (None, None)
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_it_is_off_by_default():
+    assert AgentConfig(repo_root=".", task="t").describe_pr is False
+
+
+def test_the_template_remains_the_fallback():
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'title = f"[Agent] {cfg.task[:72]}"' in source
+    assert "Autonomous Agent PR" in source
+
+
+def test_the_fallback_is_announced():
+    """
+    Silently opening a templated PR after being asked for a written one looks
+    like the flag was ignored.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "using the standard template" in source
+
+
+def test_a_written_body_records_the_run():
+    """
+    The template carried the run id; a written body would lose it, and that is
+    the only link back to the log.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "agent_loop.py"
+    ).read_text(encoding="utf-8")
+
+    assert "Written by RepoPilot, run" in source
+
+
+def test_main_registers_and_passes_the_flag():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+
+    assert '"--describe-pr"' in source
+    assert "describe_pr=args.describe_pr" in source


### PR DESCRIPTION
Closes #174

```bash
python main.py --repo . --task "Fix the parser" --push --pr --describe-pr
```

## The template described the request, not the change

`--pr` opened a PR with:

```
## Autonomous Agent PR
**Task:** <the task string>
**Run ID:** agent_20260419_192447_57f5a9
**Changes:** <diffstat>
```

Everything there was known before the run started, except the diffstat. It says what was asked for, not what was done — and those differ often enough to matter, since a run can satisfy part of a task, or take a different route to it than the task implied.

With `--describe-pr` the model gets the actual staged diff and writes the title and body from it. The prompt asks it to describe what the diff does, and says explicitly that a description overselling the change is worse than a plain one.

## Three deliberate choices

**Opt-in.** This is one more paid call on top of the run that produced the diff. Making it automatic would silently raise the cost of every `--pr` run.

**Falls back to the template, and says so.** A malformed response, unusable JSON, or a provider error all return `(None, None)` and the templated pair is used. A PR that opens with a plain description beats a run that succeeded and then died writing prose about itself.

The fallback is announced in the log. Silently opening a templated PR after being asked for a written one looks like the flag was ignored.

**A budget stop is not swallowed.** Every other failure degrades; `BudgetExceededError` re-raises:

```python
except BudgetExceededError:
    raise
except Exception as exc:
    ...
    return None, None
```

A run that has reached `--max-cost` should stop, not quietly spend one more call's worth of attempt on prose. The request also goes through `_accounted_call`, so the description is budget-checked and its cost recorded like any other — `--pr --max-cost` cannot overshoot because of it.

## Two smaller decisions

**The diff is capped at 12,000 characters.** Enough to describe a change; bounded because this is a paid call and a large refactor's diff would not be free to send.

**A written body keeps a run-id footer.** The template carried the run id and a written body would lose it — that is the only link back to `logs/<run_id>_human.log`.

## Verified

```
generated title: Guard against an empty list
cost recorded  : $0.002136
bad response   : (None, None)
provider error : (None, None)
```

## Tests

`tests/test_pr_description.py` — 21 cases.

Parsing: a well-formed response parses; prose around the JSON is tolerated, since models preface things and a run should not fail over a "Sure!"; six unusable shapes all yield `(None, None)`, parametrised, so the caller has one failure case rather than six; an over-long title is truncated to 72 characters.

The request: it returns a title and body; the diff reaches the prompt, which is the whole point; the diff is bounded; the call is costed; a budget stop is not swallowed; a provider error degrades; an unusable response degrades.

Wiring: it is off by default; the template remains the fallback; the fallback is announced; a written body records the run; `main.py` registers and passes the flag.

## Verified

- the traces above, against a stubbed provider
- 21 new tests pass, plus `test_cost_budget`, `test_plan_phase` and `test_prompt_files` — 59 in total
- all six import-guard checks green
- ruff on `modules/llm_client.py` back at its baseline of 17
- built on current `main` at `9ee9a25`

## Note

`tests/test_streaming.py` fails on `main` right now, unrelated to this — its stub predates #150 making the system prompt per-instance. Fixed in the `fix/streaming-stub-and-guard` branch, which is worth merging first so this PR's checks are readable.