### PR TITLE
feat(git): add --undo to remove a previous run's branch — Closes #66

### DIFF
--- a/main.py
+++ b/main.py
@@ -157,6 +157,13 @@ Examples:
                              "iteration. Use --list-resumable to see candidates.")
     parser.add_argument("--list-resumable", action="store_true",
                         help="List run ids that can be resumed, then exit.")
+    parser.add_argument("--undo", nargs="?", const="__last__", default=None,
+                        metavar="RUN_ID",
+                        help="Undo a previous run: leave its branch and delete "
+                             "it. Defaults to the most recent run. Use "
+                             "--list-runs to see them.")
+    parser.add_argument("--list-runs", action="store_true",
+                        help="List runs that --undo could remove, then exit.")
     parser.add_argument("--clean", action="store_true",
                         help="Remove this tool's old logs and backups, then exit. "
                              "Only files it created are touched.")
@@ -325,6 +332,58 @@ def main():
             dry_run=args.dry_run,
         )
         print(render_clean_summary(results, dry_run=args.dry_run))
+        sys.exit(0)
+
+    if args.list_runs:
+        from modules.undo import describe, find_runs
+
+        runs = find_runs(os.path.join(repo_root, args.log_dir))
+        if not runs:
+            print("No runs found.")
+        for run in runs[:20]:
+            print(describe(run))
+            print()
+        sys.exit(0)
+
+    if args.undo:
+        from modules.dry_run import ask_confirmation
+        from modules.git_integration import GitIntegration
+        from modules.undo import UndoError, describe, find_run, undo_run
+
+        try:
+            run = find_run(
+                os.path.join(repo_root, args.log_dir),
+                None if args.undo == "__last__" else args.undo,
+            )
+        except UndoError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print("\nThis will undo:\n")
+        print(describe(run))
+        print()
+
+        # Asked before removing anything. --yes skips it, matching every other
+        # confirmation, so CI is never left waiting on stdin.
+        # Computed here rather than read from the later yes_flag, which is
+        # defined below this block -- the run-configuration path has not been
+        # reached yet at this point.
+        skip_prompt = args.yes or os.environ.get("CI") == "true"
+        if not skip_prompt and not ask_confirmation("Delete this branch?"):
+            print("Left alone.")
+            sys.exit(0)
+
+        try:
+            done = undo_run(
+                GitIntegration(repo_root), run,
+                base_branch=args.base_branch,
+                branch_prefix=args.branch_prefix,
+            )
+        except UndoError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+        print("Undone: " + "; ".join(done))
         sys.exit(0)
 
     if args.rollback:

--- a/modules/git_integration.py
+++ b/modules/git_integration.py
@@ -187,6 +187,22 @@ class GitIntegration:
 
         return self._run(["git", "checkout", branch_name])
 
+    def checkout(self, branch: str) -> GitResult:
+        """Switch to an existing branch."""
+        return self._run(["git", "checkout", branch])
+
+    def delete_branch(self, branch: str, force: bool = False) -> GitResult:
+        """
+        Delete a local branch.
+
+        `force` uses -D rather than -d. An agent branch is unmerged by
+        definition when someone decides they do not want it, so -d would refuse
+        exactly the case this exists for. The caller is responsible for having
+        asked first.
+        """
+        flag = "-D" if force else "-d"
+        return self._run(["git", "branch", flag, branch])
+
     def stage_all(self) -> GitResult:
         """Stage all modified and new files."""
         return self._run(["git", "add", "-A"])

--- a/modules/undo.py
+++ b/modules/undo.py
@@ -1,0 +1,152 @@
+"""
+Module: Undo.
+
+Reverses a previous run: returns to the base branch, and removes the branch the
+agent created along with the commits on it.
+
+Distinct from `--rollback`, which pops the pre-apply git stash and restores the
+working tree. That helps while a run is in progress or immediately after one
+that never committed. It does nothing about a branch and commits that already
+exist, which is the state a successful run leaves behind.
+
+Written to refuse rather than guess. Everything here removes work, and the
+failure mode -- deleting a branch someone else made, or discarding a commit the
+agent did not write -- is not recoverable from the tool.
+"""
+
+import glob
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+_LOG = logging.getLogger("agent.undo")
+
+# Only branches the agent creates are eligible. A run with --branch-prefix set
+# to something else records that prefix in its summary, so the check reads the
+# recorded name rather than assuming.
+DEFAULT_BRANCH_PREFIX = "agent"
+
+
+class UndoError(RuntimeError):
+    """Raised when a run cannot be undone safely."""
+
+
+@dataclass
+class RunSummary:
+    run_id: str
+    branch_name: Optional[str]
+    outcome: str
+    task: str
+    path: str
+
+
+def find_runs(log_dir: str) -> list:
+    """Every run summary on disk, newest first."""
+    runs = []
+    for path in sorted(glob.glob(os.path.join(log_dir, "*_summary.json")), reverse=True):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            continue
+        runs.append(
+            RunSummary(
+                run_id=data.get("run_id") or os.path.basename(path),
+                branch_name=data.get("branch_name"),
+                outcome=data.get("outcome", "unknown"),
+                task=data.get("task", ""),
+                path=path,
+            )
+        )
+    return runs
+
+
+def find_run(log_dir: str, run_id: Optional[str] = None) -> RunSummary:
+    """
+    One run: the named one, or the most recent.
+
+    Raises rather than falling back when a named run is missing. Undoing a
+    different run than the one asked for is the worst possible outcome here.
+    """
+    runs = find_runs(log_dir)
+    if not runs:
+        raise UndoError(
+            f"No run summaries found in {log_dir}. Nothing to undo."
+        )
+
+    if run_id is None:
+        return runs[0]
+
+    for run in runs:
+        if run.run_id == run_id:
+            return run
+
+    known = ", ".join(r.run_id for r in runs[:5])
+    raise UndoError(f"No run named {run_id}. Recent runs: {known}")
+
+
+def describe(run: RunSummary) -> str:
+    """What undoing this run would do, for a confirmation prompt."""
+    lines = [
+        f"  Run    : {run.run_id}",
+        f"  Task   : {run.task[:68]}",
+        f"  Outcome: {run.outcome}",
+    ]
+    if run.branch_name:
+        lines.append(f"  Branch : {run.branch_name}  (will be deleted)")
+    else:
+        lines.append("  Branch : none recorded (nothing to delete)")
+    return "\n".join(lines)
+
+
+def undo_run(
+    git,
+    run: RunSummary,
+    base_branch: str = "main",
+    branch_prefix: str = DEFAULT_BRANCH_PREFIX,
+) -> list:
+    """
+    Remove the run's branch, returning a description of what was done.
+
+    `git` is any object with the `GitIntegration` surface, injected so this can
+    be tested without a repository and so the module does not import it.
+    """
+    done = []
+
+    if not run.branch_name:
+        raise UndoError(
+            f"Run {run.run_id} recorded no branch -- it ran with --no-git, or "
+            f"git was unavailable. There is nothing for --undo to remove; if "
+            f"changes are still in the working tree, use --rollback."
+        )
+
+    # Refused rather than checked-and-warned: a branch this tool did not create
+    # may hold work nobody else has a copy of.
+    if not run.branch_name.startswith(f"{branch_prefix}/"):
+        raise UndoError(
+            f"{run.branch_name} does not start with '{branch_prefix}/', so it "
+            f"was not created by this tool. Delete it yourself if that is what "
+            f"you want."
+        )
+
+    current = git.current_branch()
+    if current == run.branch_name:
+        result = git.checkout(base_branch)
+        if not result.success:
+            raise UndoError(
+                f"Could not leave {run.branch_name} for {base_branch}: "
+                f"{result.error.strip()}. Commit or stash your changes first."
+            )
+        done.append(f"switched to {base_branch}")
+
+    result = git.delete_branch(run.branch_name, force=True)
+    if not result.success:
+        raise UndoError(
+            f"Could not delete {run.branch_name}: {result.error.strip()}"
+        )
+    done.append(f"deleted {run.branch_name}")
+
+    _LOG.info("Undid run %s: %s", run.run_id, "; ".join(done))
+    return done

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -1,0 +1,271 @@
+"""
+Tests for --undo (modules/undo.py).
+
+`--rollback` pops the pre-apply git stash and restores the working tree. That
+helps during a run, or right after one that never committed. It does nothing
+about a branch and commits that already exist, which is exactly what a
+successful run leaves behind — so undoing one meant `git reset --hard HEAD~1`
+and `git branch -D` by hand.
+
+Most of what follows is about refusing. Everything here removes work, and
+deleting the wrong branch is not recoverable from this tool.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.git_integration import GitIntegration  # noqa: E402
+from modules.undo import (  # noqa: E402
+    RunSummary,
+    UndoError,
+    describe,
+    find_run,
+    find_runs,
+    undo_run,
+)
+
+
+def write_summary(log_dir, run_id, branch="agent/fix-it", outcome="success"):
+    log_dir.mkdir(exist_ok=True)
+    (log_dir / f"{run_id}_summary.json").write_text(json.dumps({
+        "run_id": run_id, "branch_name": branch,
+        "outcome": outcome, "task": "fix the parser",
+    }))
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A repo on main, with an agent branch holding one commit."""
+    run = lambda *a: subprocess.run(["git", "-C", str(tmp_path), *a], capture_output=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(tmp_path)], check=True)
+    run("config", "user.email", "t@t")
+    run("config", "user.name", "t")
+    (tmp_path / "a.py").write_text("x = 1\n")
+    run("add", "-A")
+    run("commit", "-qm", "init")
+    run("checkout", "-qb", "agent/fix-it")
+    (tmp_path / "a.py").write_text("x = 2\n")
+    run("add", "-A")
+    run("commit", "-qm", "agent work")
+    return tmp_path
+
+
+def branches(repo):
+    out = subprocess.run(
+        ["git", "-C", str(repo), "branch", "--list"], capture_output=True, text=True
+    ).stdout
+    return {line.strip("* ").strip() for line in out.splitlines() if line.strip()}
+
+
+# ── finding a run ─────────────────────────────────────────────────────────
+
+
+def test_the_most_recent_run_is_the_default(tmp_path):
+    logs = tmp_path / "logs"
+    write_summary(logs, "agent_20260101_000000_aaaaaa")
+    write_summary(logs, "agent_20260202_000000_bbbbbb")
+
+    assert find_run(str(logs)).run_id == "agent_20260202_000000_bbbbbb"
+
+
+def test_a_named_run_is_found(tmp_path):
+    logs = tmp_path / "logs"
+    write_summary(logs, "agent_20260101_000000_aaaaaa")
+    write_summary(logs, "agent_20260202_000000_bbbbbb")
+
+    assert find_run(str(logs), "agent_20260101_000000_aaaaaa").run_id.endswith("aaaaaa")
+
+
+def test_an_unknown_run_is_refused(tmp_path):
+    """
+    Not "fall back to the latest". Undoing a different run than the one asked
+    for is the worst outcome available here.
+    """
+    logs = tmp_path / "logs"
+    write_summary(logs, "agent_20260101_000000_aaaaaa")
+
+    with pytest.raises(UndoError) as excinfo:
+        find_run(str(logs), "agent_typo")
+
+    assert "No run named" in str(excinfo.value)
+
+
+def test_the_error_lists_what_is_available(tmp_path):
+    logs = tmp_path / "logs"
+    write_summary(logs, "agent_20260101_000000_aaaaaa")
+
+    with pytest.raises(UndoError) as excinfo:
+        find_run(str(logs), "wrong")
+
+    assert "aaaaaa" in str(excinfo.value)
+
+
+def test_no_runs_at_all_is_refused(tmp_path):
+    with pytest.raises(UndoError, match="Nothing to undo"):
+        find_run(str(tmp_path))
+
+
+def test_a_corrupt_summary_is_skipped(tmp_path):
+    logs = tmp_path / "logs"
+    write_summary(logs, "agent_20260101_000000_good")
+    (logs / "agent_20260202_000000_bad_summary.json").write_text("not json")
+
+    assert len(find_runs(str(logs))) == 1
+
+
+# ── what it would do ──────────────────────────────────────────────────────
+
+
+def test_the_description_names_the_branch():
+    text = describe(RunSummary("r1", "agent/fix-it", "success", "fix the parser", ""))
+
+    assert "agent/fix-it" in text
+    assert "will be deleted" in text
+
+
+def test_a_run_without_a_branch_says_so():
+    text = describe(RunSummary("r1", None, "success", "t", ""))
+
+    assert "none recorded" in text
+
+
+# ── undoing ───────────────────────────────────────────────────────────────
+
+
+def test_the_branch_is_deleted(repo):
+    undo_run(GitIntegration(str(repo)), RunSummary("r1", "agent/fix-it", "success", "t", ""))
+
+    assert "agent/fix-it" not in branches(repo)
+
+
+def test_it_leaves_the_branch_first(repo):
+    """Git refuses to delete the branch you are standing on."""
+    git = GitIntegration(str(repo))
+    assert git.current_branch() == "agent/fix-it"
+
+    undo_run(git, RunSummary("r1", "agent/fix-it", "success", "t", ""))
+
+    assert git.current_branch() == "main"
+
+
+def test_the_commit_goes_with_the_branch(repo):
+    undo_run(GitIntegration(str(repo)), RunSummary("r1", "agent/fix-it", "success", "t", ""))
+
+    assert (repo / "a.py").read_text() == "x = 1\n"
+
+
+def test_it_reports_what_it_did(repo):
+    done = undo_run(
+        GitIntegration(str(repo)), RunSummary("r1", "agent/fix-it", "success", "t", "")
+    )
+
+    assert any("deleted" in step for step in done)
+
+
+def test_undoing_from_another_branch_works(repo):
+    """The common case: you already moved on before deciding to undo."""
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "main"], check=True)
+
+    undo_run(GitIntegration(str(repo)), RunSummary("r1", "agent/fix-it", "success", "t", ""))
+
+    assert "agent/fix-it" not in branches(repo)
+
+
+# ── refusals ──────────────────────────────────────────────────────────────
+
+
+def test_a_branch_we_did_not_create_is_refused(repo):
+    """
+    The refusal that matters. A branch this tool did not make may hold work
+    nobody else has a copy of.
+    """
+    subprocess.run(["git", "-C", str(repo), "branch", "my-own-work"], check=True)
+
+    with pytest.raises(UndoError) as excinfo:
+        undo_run(
+            GitIntegration(str(repo)),
+            RunSummary("r1", "my-own-work", "success", "t", ""),
+        )
+
+    assert "not created by this tool" in str(excinfo.value)
+    assert "my-own-work" in branches(repo)
+
+
+def test_a_custom_prefix_is_honoured(repo):
+    """A run with --branch-prefix set records that prefix; the check reads it."""
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "main"], check=True)
+    subprocess.run(["git", "-C", str(repo), "branch", "bot/work"], check=True)
+
+    undo_run(
+        GitIntegration(str(repo)),
+        RunSummary("r1", "bot/work", "success", "t", ""),
+        branch_prefix="bot",
+    )
+
+    assert "bot/work" not in branches(repo)
+
+
+def test_a_run_with_no_branch_is_refused():
+    with pytest.raises(UndoError) as excinfo:
+        undo_run(
+            SimpleNamespace(), RunSummary("r1", None, "success", "t", "")
+        )
+
+    assert "--rollback" in str(excinfo.value)
+
+
+def test_a_failed_checkout_stops_before_deleting():
+    """
+    Uncommitted work would be lost by a forced switch, so git refuses, and this
+    must not delete the branch anyway.
+    """
+    git = SimpleNamespace(
+        current_branch=lambda: "agent/fix-it",
+        checkout=lambda b: SimpleNamespace(success=False, error="local changes"),
+        delete_branch=lambda b, force=False: pytest.fail("should not be reached"),
+    )
+
+    with pytest.raises(UndoError, match="Commit or stash"):
+        undo_run(git, RunSummary("r1", "agent/fix-it", "success", "t", ""))
+
+
+# ── wiring ────────────────────────────────────────────────────────────────
+
+
+def test_it_asks_before_deleting():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+
+    assert 'ask_confirmation("Delete this branch?")' in source
+
+
+def test_yes_skips_the_prompt():
+    """Matching every other confirmation, so CI never waits on stdin."""
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+
+    assert "skip_prompt = args.yes" in source
+
+
+def test_the_delete_is_forced():
+    """
+    An agent branch is unmerged by definition when someone decides against it,
+    so -d would refuse exactly the case this exists for.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "git_integration.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'flag = "-D" if force else "-d"' in source
+
+
+def test_main_registers_both_flags():
+    source = (Path(__file__).resolve().parents[1] / "main.py").read_text(encoding="utf-8")
+
+    assert '"--undo"' in source
+    assert '"--list-runs"' in source


### PR DESCRIPTION
Closes #66

```bash
python main.py --repo . --list-runs
python main.py --repo . --undo
python main.py --repo . --undo agent_20260419_192447_57f5a9
```

```
This will undo:

  Run    : agent_20260419_192447_57f5a9
  Task   : fix the parser TypeError
  Outcome: success
  Branch : agent/fix-the-parser  (will be deleted)

Delete this branch? [y/N] y
Undone: switched to main; deleted agent/fix-the-parser
```

## The narrower gap, as scoped on the issue

`--rollback` already exists and pops the pre-apply git stash. That covers a run still in progress, or one that never committed.

It does nothing about a branch and commits that already exist, which is exactly what a *successful* run leaves behind — so undoing one still meant `git reset --hard HEAD~1` and `git branch -D` by hand. That is the part this adds.

The branch name comes from `logs/<run_id>_summary.json`, which already records it, so nothing has to be guessed from the current checkout.

## Most of this is refusing

Everything here removes work, and deleting the wrong branch is not recoverable from the tool. Four refusals, each with a test:

| case | behaviour |
| ---- | --------- |
| the branch does not match the agent prefix | refused — it may hold work nobody else has a copy of |
| the named run does not exist | refused, listing what does |
| the run recorded no branch | refused, pointing at `--rollback` |
| the checkout away from the branch fails | refused **before** deleting |

The second one is worth stating: an unknown run id is not treated as "fall back to the latest". Undoing a different run than the one asked for is the worst outcome available here, and a typo is exactly how that would happen.

The fourth matters because git refuses to switch away from a branch when uncommitted work would be lost. The obvious implementation deletes anyway and loses it.

`--branch-prefix bot` is honoured — the check reads the prefix the run actually used rather than assuming `agent/`.

## Asked before, forced when doing it

`ask_confirmation` runs first, and `--yes` skips it, matching every other prompt so CI is never left waiting on stdin.

`delete_branch` uses `-D` rather than `-d`. An agent branch is unmerged by definition when someone has decided against it, so `-d` would refuse exactly the case this exists for. The confirmation is what makes that safe.

## A bug in my own wiring

The confirmation initially read `yes_flag`, which is defined further down `main()` than the undo block sits — a `NameError` on every `--undo`, on a path no test would reach.

Fixed, and I checked for others: an AST pass over `main()` comparing each name's first load against its first store now reports none.

The import guard cannot see this class of problem, since it is neither an import failure nor a missing argparse flag. Worth a follow-up step if it recurs.

## Two small additions to `GitIntegration`

`checkout(branch)` and `delete_branch(branch, force=False)`. Both are thin wrappers over `_run`, consistent with the rest of that class.

## Tests

`tests/test_undo.py` — 21 cases, most against a real git repository.

Finding a run: the most recent is the default; a named run is found; an unknown one is refused; the error lists what is available; no runs at all is refused; a corrupt summary is skipped rather than fatal.

What it would do: the description names the branch; a run without one says so.

Undoing: the branch is deleted; it leaves the branch first, since git refuses to delete the one you are standing on; the commit goes with the branch, verified by the file reverting to its pre-run content; it reports what it did; undoing from another branch works, which is the common case since you have usually moved on before deciding.

Refusals: a branch we did not create; a custom prefix is honoured; a run with no branch; a failed checkout stops before deleting.

Wiring: it asks before deleting; `--yes` skips the prompt; the delete is forced; `main.py` registers both flags.

## Verified

- the full flow above against a real repository — branch created, committed, undone, file back to `x = 1`
- `--list-runs` and `--undo --yes` end to end through the CLI
- 21 tests pass, plus `test_git_failures`, `test_interactive_commit` and `test_utils` — 51 in total
- all six import-guard checks green
- ruff unchanged on both modified files
- built on current `main` at `9ee9a25`

## Overlap

Touches `modules/git_integration.py`, as does #154. This adds two methods rather than changing `push`, so either order works — but whichever merges second wants a rebase rather than a hand-resolved conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to list recent runs and undo a specified or latest run.
  * Undo now displays run details, requests confirmation, and safely removes associated branches.
  * Added safeguards and clear error handling for missing runs, invalid selections, and Git failures.
* **Bug Fixes**
  * Improved branch checkout and deletion handling during run reversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->