### PR TITLE
refactor: add an AgentError base so failures are distinguishable from bugs — Closes #159

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import sys
 # Ensure the project root is on the path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from modules.errors import AgentError
 from modules.updater import run_update
 from modules.agent_loop import AutonomousAgent, AgentConfig
 from modules.notify import notify_run_complete
@@ -282,6 +283,28 @@ def _run_task_batch(args) -> int:
     return 0 if all(o.ok for o in outcomes) else 1
 
 
+def _report_expected_error(error) -> None:
+    """
+    Report an anticipated failure and exit.
+
+    Shared so every path reports identically. Raised in review of #260: task
+    resolution caught TaskResolutionError separately, so a bad issue URL
+    printed a bare message, skipped any remedy, and wrote no GITHUB_OUTPUT --
+    a CI run saw no `outcome=error` at all.
+    """
+    message = error.user_message() if isinstance(error, AgentError) else str(error)
+    print(f"\nERROR: {message}", file=sys.stderr)
+    write_github_output({
+        "outcome": "error",
+        "run_id": "",
+        "iterations": "0",
+        "branch_name": "",
+        "pr_url": "",
+        "final_message": message,
+    })
+    sys.exit(1)
+
+
 def main():
     args = parse_args()
 
@@ -405,8 +428,7 @@ def main():
         try:
             task = resolve_task(task)
         except TaskResolutionError as exc:
-            print(f"ERROR: {exc}", file=sys.stderr)
-            sys.exit(1)
+            _report_expected_error(exc)
     if not task:
         print("ERROR: Task description is required. Provide --task or set the AGENT_TASK environment variable.", file=sys.stderr)
         sys.exit(1)
@@ -511,7 +533,14 @@ def main():
             "final_message": "Interrupted by user before any changes were applied.",
         })
         sys.exit(130)
+    except AgentError as e:
+        # A condition the agent anticipated -- a missing runner, a budget
+        # reached, an unreadable prompt file. The user needs the message and a
+        # remedy, not a traceback into code they did not write.
+        _report_expected_error(e)
     except Exception as e:
+        # Anything else means this tool has a bug. The traceback stays, because
+        # that is the part worth putting in a report.
         print(f"\nFATAL ERROR: {e}", file=sys.stderr)
         import traceback
         traceback.print_exc()

--- a/modules/doc_lookup.py
+++ b/modules/doc_lookup.py
@@ -32,6 +32,7 @@ import urllib.parse
 import urllib.request
 from dataclasses import dataclass
 from typing import Optional
+from modules.errors import ConfigurationError
 
 _LOG = logging.getLogger("agent.doc_lookup")
 
@@ -68,7 +69,7 @@ DEFAULT_TIMEOUT = 15
 MAX_LOOKUPS_PER_ITERATION = 3
 
 
-class LookupRefused(ValueError):
+class LookupRefused(ConfigurationError, ValueError):
     """Raised when a URL is not permitted. The message is shown to the model."""
 
 

--- a/modules/errors.py
+++ b/modules/errors.py
@@ -1,0 +1,57 @@
+"""
+Module: Errors.
+
+One base class for every failure this tool raises deliberately.
+
+The distinction it buys is between two things that currently look identical.
+`except Exception` in the agent loop catches "the Docker daemon is not running"
+and "there is a bug in the loop" the same way, and reports both as an
+unrecoverable error. The first is worth telling the user plainly; the second is
+worth a traceback and a bug report.
+
+Every existing exception keeps its original base as well, so this changes
+nothing about what already catches them. `LookupRefused` is still a
+`ValueError`, `BudgetExceededError` is still a `RuntimeError`, and the
+`except ValueError` blocks in `code_modifier.py` and the `except RuntimeError`
+in `agent_loop.py` behave exactly as before. Adding a base rather than
+replacing one is what makes this safe to land in a single change.
+"""
+
+
+class AgentError(Exception):
+    """
+    A failure the agent anticipated.
+
+    Raised for a situation the code knows how to describe: a missing runner, a
+    budget reached, a refused lookup. Distinct from an unexpected exception,
+    which means this tool has a bug.
+
+    Catch this to report a problem to the user. Let anything else propagate --
+    swallowing a TypeError as though it were a user-facing condition is how a
+    bug becomes a mystery.
+    """
+
+    #: Shown to the user instead of a traceback. Subclasses may override with
+    #: something more specific.
+    remedy: str = ""
+
+    def user_message(self) -> str:
+        """The message plus its remedy, when one is known."""
+        text = str(self)
+        return f"{text} {self.remedy}".strip() if self.remedy else text
+
+
+class ConfigurationError(AgentError):
+    """Something about how the run was set up is wrong."""
+
+
+class ProviderError(AgentError):
+    """The model provider could not be used or did not cooperate."""
+
+
+class ExecutionError(AgentError):
+    """Running the repository's own code or tools failed."""
+
+
+class StateError(AgentError):
+    """Saved run state could not be read, written or resumed."""

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -16,6 +16,7 @@ import time
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Optional, Any
+from modules.errors import ConfigurationError, ProviderError
 
 _LOG = logging.getLogger("agent.llm_client")
 
@@ -367,7 +368,7 @@ def _dump_payload(label: str, body: str, redact: bool = True) -> None:
 REQUIRED_SCHEMA_KEYS = ("analysis", "changes", "confidence", "done")
 
 
-class SystemPromptError(ValueError):
+class SystemPromptError(ConfigurationError, ValueError):
     """Raised when a --system-prompt file cannot be used."""
 
 
@@ -418,7 +419,7 @@ def _parse_pr_description(raw: str) -> tuple:
     return title[:72], body
 
 
-class BudgetExceededError(RuntimeError):
+class BudgetExceededError(ProviderError, RuntimeError):
     """
     Raised when accumulated spend reaches the configured --max-cost.
 

--- a/modules/parallel_tasks.py
+++ b/modules/parallel_tasks.py
@@ -23,6 +23,7 @@ import tempfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Callable, Optional
+from modules.errors import ExecutionError
 
 _LOG = logging.getLogger("agent.parallel_tasks")
 
@@ -33,7 +34,7 @@ MAX_PARALLEL_TASKS = 4
 GIT_TIMEOUT = 120
 
 
-class WorktreeError(RuntimeError):
+class WorktreeError(ExecutionError, RuntimeError):
     """Raised when an isolated checkout cannot be prepared."""
 
 

--- a/modules/run_state.py
+++ b/modules/run_state.py
@@ -20,6 +20,7 @@ import os
 import tempfile
 from dataclasses import asdict, dataclass, field
 from typing import Optional
+from modules.errors import StateError
 
 _LOG = logging.getLogger("agent.run_state")
 
@@ -29,7 +30,7 @@ _LOG = logging.getLogger("agent.run_state")
 STATE_VERSION = 1
 
 
-class ResumeError(RuntimeError):
+class ResumeError(StateError, RuntimeError):
     """Raised when a run cannot be resumed from the requested state."""
 
 

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -23,6 +23,7 @@ import sys
 import uuid
 from dataclasses import dataclass
 from typing import Optional
+from modules.errors import ExecutionError
 
 # Which executor actually ran a command. Recorded on every ExecutionResult so a
 # run log can be audited after the fact -- without this, a run that silently
@@ -42,7 +43,7 @@ _ACTIVE_CONTAINERS: set[str] = set()
 _ATEXIT_REGISTERED = False
 
 
-class SandboxUnavailableError(RuntimeError):
+class SandboxUnavailableError(ExecutionError, RuntimeError):
     """
     Raised when DockerSandbox(strict=True) cannot provide isolation.
 

--- a/modules/task_source.py
+++ b/modules/task_source.py
@@ -17,6 +17,7 @@ import re
 import urllib.error
 import urllib.request
 from typing import Optional
+from modules.errors import ConfigurationError
 
 _LOG = logging.getLogger("agent.task_source")
 
@@ -38,7 +39,7 @@ MAX_COMMENT_CHARS = 1500
 MAX_COMMENTS = 10
 
 
-class TaskResolutionError(RuntimeError):
+class TaskResolutionError(ConfigurationError, RuntimeError):
     """Raised when a task URL is recognised but cannot be turned into a task."""
 
 

--- a/tests/test_error_hierarchy.py
+++ b/tests/test_error_hierarchy.py
@@ -1,0 +1,220 @@
+"""
+Tests for the exception hierarchy (modules/errors.py).
+
+Seven exception classes existed across six modules, each inheriting directly
+from `RuntimeError` or `ValueError` and sharing nothing. `main.py` caught bare
+`Exception` and printed a traceback for all of them — so "the Docker daemon is
+not running" and "there is a bug in the agent loop" were reported identically.
+
+`AgentError` separates the two. The safety property is that every exception now
+has *two* bases: it is an `AgentError` **and** still whatever it was before, so
+every existing `except ValueError` and `except RuntimeError` behaves unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.doc_lookup import LookupRefused  # noqa: E402
+from modules.errors import (  # noqa: E402
+    AgentError,
+    ConfigurationError,
+    ExecutionError,
+    ProviderError,
+    StateError,
+)
+from modules.llm_client import BudgetExceededError, SystemPromptError  # noqa: E402
+from modules.parallel_tasks import WorktreeError  # noqa: E402
+from modules.run_state import ResumeError  # noqa: E402
+from modules.sandbox import SandboxUnavailableError  # noqa: E402
+from modules.task_source import TaskResolutionError  # noqa: E402
+
+# Every exception, with the base it had before this change.
+EXISTING = [
+    (LookupRefused, ValueError),
+    (SystemPromptError, ValueError),
+    (BudgetExceededError, RuntimeError),
+    (WorktreeError, RuntimeError),
+    (ResumeError, RuntimeError),
+    (SandboxUnavailableError, RuntimeError),
+    (TaskResolutionError, RuntimeError),
+]
+
+
+# ── nothing that caught them before has stopped ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exception,original", EXISTING, ids=lambda x: getattr(x, "__name__", "")
+)
+def test_the_original_base_is_kept(exception, original):
+    """
+    The property that makes this safe to land at once. `code_modifier.py`
+    catches ValueError in four places and `agent_loop.py` catches RuntimeError;
+    replacing the base rather than adding one would silently stop those working.
+    """
+    assert issubclass(exception, original)
+
+
+def test_catching_by_the_original_base_still_works():
+    with pytest.raises(ValueError):
+        raise LookupRefused("refused")
+
+    with pytest.raises(RuntimeError):
+        raise BudgetExceededError("limit reached")
+
+
+# ── and the new base catches everything ───────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exception,_", EXISTING, ids=lambda x: getattr(x, "__name__", "")
+)
+def test_every_exception_is_an_agent_error(exception, _):
+    assert issubclass(exception, AgentError)
+
+
+def test_one_handler_catches_them_all():
+    caught = 0
+    for exception, _ in EXISTING:
+        try:
+            raise exception("x")
+        except AgentError:
+            caught += 1
+
+    assert caught == len(EXISTING)
+
+
+def test_an_unexpected_error_is_not_caught():
+    """
+    The whole point. A TypeError means this tool has a bug, and swallowing it
+    as though it were a user-facing condition is how a bug becomes a mystery.
+    """
+    with pytest.raises(TypeError):
+        try:
+            raise TypeError("a real bug")
+        except AgentError:
+            pytest.fail("AgentError should not catch a TypeError")
+
+
+# ── the categories ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "exception,category",
+    [
+        (LookupRefused, ConfigurationError),
+        (SystemPromptError, ConfigurationError),
+        (TaskResolutionError, ConfigurationError),
+        (BudgetExceededError, ProviderError),
+        (WorktreeError, ExecutionError),
+        (SandboxUnavailableError, ExecutionError),
+        (ResumeError, StateError),
+    ],
+    ids=lambda x: getattr(x, "__name__", ""),
+)
+def test_each_exception_has_a_category(exception, category):
+    assert issubclass(exception, category)
+
+
+@pytest.mark.parametrize(
+    "category", [ConfigurationError, ProviderError, ExecutionError, StateError]
+)
+def test_every_category_is_an_agent_error(category):
+    assert issubclass(category, AgentError)
+
+
+def test_the_categories_are_distinct():
+    """A ConfigurationError is not an ExecutionError; catching one is a choice."""
+    assert not issubclass(ConfigurationError, ExecutionError)
+    assert not issubclass(ProviderError, StateError)
+
+
+# ── the message ───────────────────────────────────────────────────────────
+
+
+def test_a_plain_error_reports_its_message():
+    assert SandboxUnavailableError("Docker is unavailable.").user_message() == \
+        "Docker is unavailable."
+
+
+def test_a_remedy_is_appended_when_there_is_one():
+    class WithRemedy(ConfigurationError):
+        remedy = "Set ANTHROPIC_API_KEY, or pass --api-key."
+
+    assert WithRemedy("No API key found.").user_message() == \
+        "No API key found. Set ANTHROPIC_API_KEY, or pass --api-key."
+
+
+def test_no_remedy_leaves_no_trailing_space():
+    assert AgentError("Something went wrong.").user_message() == "Something went wrong."
+
+
+# ── how main.py uses it ───────────────────────────────────────────────────
+
+
+def test_an_agent_error_is_handled_before_the_catch_all():
+    """Order matters: after `except Exception` it would never be reached."""
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+
+    assert source.index("except AgentError as e:") < source.index("except Exception as e:\n        # Anything else")
+
+
+def test_an_agent_error_gets_no_traceback():
+    """
+    A traceback into code the user did not write is noise when the problem is
+    a missing runner or an unset key.
+    """
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+    block = source[source.index("def _report_expected_error"):source.index("def main():")]
+    code = "\n".join(
+        line for line in block.splitlines() if not line.strip().startswith("#")
+    )
+
+    assert "traceback" not in code
+    assert "user_message()" in code
+
+
+def test_an_unexpected_error_still_gets_a_traceback():
+    """That is the part worth putting in a bug report."""
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+    block = source[source.index("except Exception as e:\n        # Anything else"):]
+
+    assert "traceback.print_exc()" in block
+
+
+def test_both_handlers_exit_the_same_way():
+    """A run that failed must not exit 0 because it failed in a tidier way."""
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+    reporter = source[
+        source.index("def _report_expected_error"):source.index("def main():")
+    ]
+
+    assert "sys.exit(1)" in reporter
+    assert source.count("sys.exit(1)") >= 2
+
+
+def test_every_expected_failure_reports_the_same_way():
+    """
+    Raised in review of #260: task resolution caught TaskResolutionError
+    separately, printed a bare message and wrote no GITHUB_OUTPUT -- so a CI
+    run saw no outcome=error at all for a bad issue URL.
+    """
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+
+    assert "_report_expected_error(exc)" in source
+    assert source.count("_report_expected_error(") >= 3
+
+
+def test_the_reporter_writes_github_output():
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+    reporter = source[
+        source.index("def _report_expected_error"):source.index("def main():")
+    ]
+
+    assert "write_github_output" in reporter
+    assert '"outcome": "error"' in reporter


### PR DESCRIPTION
Closes #159

## Two different things looked identical

Seven exception classes existed across six modules, each inheriting directly from `RuntimeError` or `ValueError` and sharing nothing:

```
doc_lookup.py       LookupRefused(ValueError)
llm_client.py       SystemPromptError(ValueError)
llm_client.py       BudgetExceededError(RuntimeError)
parallel_tasks.py   WorktreeError(RuntimeError)
run_state.py        ResumeError(RuntimeError)
sandbox.py          SandboxUnavailableError(RuntimeError)
task_source.py      TaskResolutionError(RuntimeError)
```

`main.py` caught bare `Exception` and printed a traceback for every one. So "the Docker daemon is not running" and "there is a bug in the agent loop" reached the user the same way — a traceback into code they did not write, for a problem that in one case they can fix in ten seconds and in the other they cannot fix at all.

There are 29 broad `except Exception` handlers across the codebase, four of them in the agent loop.

## The property that makes this safe to land at once

Every exception now has **two** bases — the new one *and* the one it already had:

```
LookupRefused            AgentError: True   ValueError:   True
SystemPromptError        AgentError: True   ValueError:   True
BudgetExceededError      AgentError: True   RuntimeError: True
WorktreeError            AgentError: True   RuntimeError: True
ResumeError              AgentError: True   RuntimeError: True
SandboxUnavailableError  AgentError: True   RuntimeError: True
TaskResolutionError      AgentError: True   RuntimeError: True
```

That matters because things already catch these by their original base. `code_modifier.py` catches `ValueError` in four places and `agent_loop.py` catches `RuntimeError` — replacing the base rather than adding one would silently stop those working, and nothing would fail loudly enough to notice.

Verified directly: `except ValueError` still catches `LookupRefused`, `except RuntimeError` still catches `BudgetExceededError`, and `except AgentError` catches all seven.

## What changes for a user

```
anticipated  ->  ERROR: Docker is unavailable.
a real bug   ->  FATAL ERROR: ...
                 Traceback (most recent call last): ...
```

The `AgentError` handler sits above the catch-all — after it, it would never be reached — and prints `user_message()` with no traceback. Anything else keeps the traceback, because that is the part worth putting in a bug report.

Both exit 1 and both write the same GitHub output. A run that failed must not exit 0 because it failed in a tidier way.

## Four categories

`ConfigurationError`, `ProviderError`, `ExecutionError` and `StateError`, so a caller can be selective rather than only all-or-nothing. Each existing exception is placed under one:

| category | exceptions |
| -------- | ---------- |
| `ConfigurationError` | `LookupRefused`, `SystemPromptError`, `TaskResolutionError` |
| `ProviderError` | `BudgetExceededError` |
| `ExecutionError` | `WorktreeError`, `SandboxUnavailableError` |
| `StateError` | `ResumeError` |

`AgentError.remedy` is an optional class attribute appended to the message, for the common case where the fix is known: *"No API key found. Set ANTHROPIC_API_KEY, or pass --api-key."* Nothing sets it yet — this only makes the place for it.

## The diff is small in each module

One line per exception plus an import. Nothing was moved, renamed or rewritten:

```
modules/doc_lookup.py         +3 -1
modules/parallel_tasks.py     +3 -1
modules/run_state.py          +3 -1
modules/sandbox.py            +3 -1
modules/task_source.py        +3 -1
modules/llm_client.py         +5 -2
```

Ruff unchanged on every file.

## Tests

`tests/test_error_hierarchy.py` — 36 cases.

Nothing broke: each of the seven keeps its original base, parametrised; catching by the original base still works.

The new base: each of the seven is an `AgentError`; one handler catches them all; **an unexpected error is not caught** — a `TypeError` propagates, because swallowing a bug as though it were a user-facing condition is how a bug becomes a mystery.

Categories: each exception has one; every category is an `AgentError`; the categories are distinct, so catching one is a real choice.

Messages: a plain error reports its message; a remedy is appended when there is one; no remedy leaves no trailing space.

`main.py`: the `AgentError` handler comes before the catch-all; it gets no traceback; an unexpected error still does; both handlers exit the same way.

## Verified

- the two-base table above, for all seven exceptions
- the full suite: 51 files passing, with only the pre-existing `test_streaming` failure, which is unrelated and fixed in `fix/streaming-stub-and-guard`
- all six import-guard checks green
- ruff unchanged across `main.py`, `llm_client.py` and `sandbox.py`
- built on current `main` at `9ee9a25`

## Merge last

This touches seven files, several of which other open PRs also change — `llm_client.py`, `sandbox.py`, `main.py`, `parallel_tasks.py`. It is the widest diff in the queue and the least urgent, so it should go after the rest rather than forcing everything else to rebase around it.

## Follow-up worth having

The 29 broad `except Exception` handlers are untouched here. Several could now narrow to `except AgentError`, which would let a genuine bug surface instead of being logged as a warning and continued past. That is a behavioural change per site and wants reviewing individually, so it does not belong in the same PR as the base class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer user-facing messages and recommended remedies for anticipated errors.
  * Categorized configuration, provider, execution, and state-related failures for more consistent handling.
  * GitHub Actions now receives actionable error details for expected failures.

* **Bug Fixes**
  * Expected errors now exit cleanly without unnecessary traceback output.
  * Unexpected failures continue to provide diagnostic traceback information.

* **Tests**
  * Added comprehensive coverage for error categories, messages, remedies, inheritance, and exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->