### PR TITLE
fix(sandbox): point the make runner at the test target — Closes #165

### DIFF
--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -172,7 +172,15 @@ RUNNERS: dict = {
         LanguageRunner("nox", "python", ["nox"], module=None,
                        linters=("ruff", "flake8", "pyflakes")),
         LanguageRunner("bash", "bash", ["bash"]),
-        LanguageRunner("make", "make", ["make"]),
+        # `make test`, not bare `make`. A bare invocation runs the default
+        # target -- usually `all` or a build -- so run_tests("make") compiled
+        # the project and reported success while every test was skipped. That
+        # is worse than failing: a green result nobody earned.
+        #
+        # A Makefile with no `test` target now fails loudly with make's own
+        # "No rule to make target" rather than silently building instead.
+        LanguageRunner("make", "make", ["make", "test"]),
+        LanguageRunner("make_default", "make", ["make"]),
         LanguageRunner("go", "go", ["go", "test", "./..."], linters=("govet",)),
         LanguageRunner("cargo", "rust", ["cargo", "test"], linters=("clippy",)),
         LanguageRunner("ruby", "ruby", ["ruby"]),

--- a/tests/test_make_runner.py
+++ b/tests/test_make_runner.py
@@ -1,0 +1,139 @@
+"""
+Tests for the make runner (modules/sandbox.py).
+
+`make` was registered, but as bare `make` — which runs the Makefile's default
+target. For most projects that is `all` or a build, so `run_tests("make")`
+compiled the project and reported success while every test was skipped.
+
+A green result nobody earned is worse than a red one, because nothing prompts
+anyone to look.
+"""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from modules.sandbox import (  # noqa: E402
+    ALLOWED_RUNNERS,
+    DOCKER_RUNNERS,
+    RUNNERS,
+    SubprocessSandbox,
+    runners_for_language,
+)
+
+needs_make = pytest.mark.skipif(shutil.which("make") is None, reason="make not installed")
+
+BOTH_TARGETS = 'all:\n\t@echo "BUILT"\n\ntest:\n\t@echo "TESTS RAN"\n'
+BUILD_ONLY = 'all:\n\t@echo "BUILT"\n'
+FAILING_TEST = 'test:\n\t@echo "1 failed"; exit 1\n'
+
+
+@pytest.fixture
+def project(tmp_path):
+    def write(makefile):
+        (tmp_path / "Makefile").write_text(makefile)
+        return SubprocessSandbox(str(tmp_path), timeout_seconds=60)
+
+    return write
+
+
+# ── the registry entries ──────────────────────────────────────────────────
+
+
+def test_make_runs_the_test_target():
+    assert ALLOWED_RUNNERS["make"] == ["make", "test"]
+
+
+def test_the_default_target_is_still_reachable():
+    """
+    Some projects genuinely test from the default target. Removing that option
+    rather than renaming it would break them.
+    """
+    assert ALLOWED_RUNNERS["make_default"] == ["make"]
+
+
+@pytest.mark.parametrize("runner", ["make", "make_default"])
+def test_the_container_command_matches_the_host(runner):
+    """Nothing about make differs inside an image."""
+    assert DOCKER_RUNNERS[runner] == ALLOWED_RUNNERS[runner]
+
+
+@pytest.mark.parametrize("runner", ["make", "make_default"])
+def test_both_are_registered_under_make(runner):
+    assert RUNNERS[runner].language == "make"
+
+
+def test_both_appear_for_the_language():
+    assert runners_for_language("make") == ["make", "make_default"]
+
+
+# ── behaviour ─────────────────────────────────────────────────────────────
+
+
+@needs_make
+def test_the_test_target_is_what_runs(project):
+    """The bug: this used to print BUILT."""
+    result = project(BOTH_TARGETS).run_tests("make")
+
+    assert "TESTS RAN" in result.stdout
+    assert "BUILT" not in result.stdout
+
+
+@needs_make
+def test_a_passing_test_target_succeeds(project):
+    assert project(BOTH_TARGETS).run_tests("make").success is True
+
+
+@needs_make
+def test_a_failing_test_target_fails(project):
+    result = project(FAILING_TEST).run_tests("make")
+
+    assert result.success is False
+    assert "1 failed" in result.stdout
+
+
+@needs_make
+def test_a_missing_test_target_fails_loudly(project):
+    """
+    The case that matters most. Before, a Makefile with no test target built
+    instead and reported success — the run went green having tested nothing.
+    """
+    result = project(BUILD_ONLY).run_tests("make")
+
+    assert result.success is False
+    assert "No rule to make target" in (result.stderr + result.stdout)
+
+
+@needs_make
+def test_the_default_target_still_works_when_asked_for(project):
+    result = project(BOTH_TARGETS).run_tests("make_default")
+
+    assert "BUILT" in result.stdout
+
+
+@needs_make
+def test_extra_arguments_reach_make(project):
+    """`--runner-args` should still be able to name a different target."""
+    result = project(BOTH_TARGETS).run_tests("make", ["all"])
+
+    assert "BUILT" in result.stdout
+
+
+# ── nothing else moved ────────────────────────────────────────────────────
+
+
+def test_no_other_runner_changed():
+    for runner in ("pytest", "python", "go", "cargo", "npm_test", "bash"):
+        assert runner in ALLOWED_RUNNERS
+
+
+def test_the_registry_grew_by_one():
+    """
+    14 before this change, after tox and nox landed in #153. Tied to
+    ALLOWED_RUNNERS so the two figures cannot drift apart.
+    """
+    assert len(RUNNERS) == len(ALLOWED_RUNNERS) == 15

--- a/tests/test_multi_version_runners.py
+++ b/tests/test_multi_version_runners.py
@@ -146,4 +146,8 @@ def test_the_existing_runners_are_untouched():
 
 
 def test_the_registry_grew_by_exactly_two():
-    assert len(RUNNERS) == 14
+    """
+    12 before tox and nox; 15 after make_default was split out in #165. Pinned
+    so a runner cannot be dropped unnoticed by a merge.
+    """
+    assert len(RUNNERS) == 15

--- a/tests/test_runner_registry.py
+++ b/tests/test_runner_registry.py
@@ -123,7 +123,7 @@ def test_the_count_matches_the_registry():
     Pinned so a runner cannot be dropped unnoticed. Raised from 12 to 14 when
     tox and nox were added for #153.
     """
-    assert len(ALLOWED_RUNNERS) == len(RUNNERS) == 14
+    assert len(ALLOWED_RUNNERS) == len(RUNNERS) == 15
 
 
 # ── what the registry makes possible ──────────────────────────────────────


### PR DESCRIPTION
Closes #165

## `make` was registered, and ran the wrong thing

I initially checked this issue by looking for `make` in the runner table, found it, and said it was already done. That was wrong, and the way it was wrong is the point.

The entry was bare `make`, which runs the Makefile's **default target**:

```
Makefile:
  all:   @echo "BUILT (default target)"
  test:  @echo "TESTS RAN"

run_tests("make")  ->  BUILT (default target)     success: True
```

So the agent compiled the project, saw exit 0, and reported that the tests passed. On a project whose default target is `all` — which is most of them — every test was skipped and the run went green.

That is worse than plain breakage. A failing runner gets investigated; a green result nobody earned does not.

## The fix

```python
LanguageRunner("make", "make", ["make", "test"]),
LanguageRunner("make_default", "make", ["make"]),
```

`make` now runs `make test`. A Makefile without that target fails loudly rather than silently building instead:

```
success: False
stderr : make: *** No rule to make target 'test'.  Stop.
```

`make_default` keeps the old behaviour, because some projects genuinely do test from the default target and removing the option rather than renaming it would break them. `--runner-args all` still reaches make directly, so any target remains addressable.

## Two existing assertions failed, correctly

`test_runner_registry.py` and `test_multi_version_runners.py` both pin the registry size. Adding `make_default` broke them:

```
assert 15 == 14
```

That is those tests doing their job — they exist so a runner cannot be dropped unnoticed by a merge. Updated to 15, tied to `len(ALLOWED_RUNNERS)` so the two figures cannot drift, each with a comment recording why it moved.

## Tests

`tests/test_make_runner.py` — 15 cases. The six behavioural ones skip cleanly where `make` is not installed.

The registry: `make` runs the test target; the default target is still reachable; the container command matches the host for both, since nothing about make differs inside an image; both are registered under the `make` language; both appear in `runners_for_language`.

Behaviour: the test target is what runs — the assertion that would have caught the original bug; a passing target succeeds; a failing one fails; **a missing test target fails loudly**, which is the case that matters most; the default target still works when asked for; extra arguments reach make.

Unchanged: no other runner moved; the registry grew by exactly one.

## Verified

- the before and after traces above, against real Makefiles
- all three cases: passing target, failing target, missing target
- 156 tests pass across `test_make_runner`, `test_runner_registry`, `test_multi_version_runners`, `test_runner_fallback` and `test_sandbox_env`
- all six import-guard checks green
- ruff on `modules/sandbox.py` unchanged at 2
- built on current `main` at `9ee9a25`, after tox and nox landed in #153

## Worth noting

This was found because the issue was pushed back on rather than accepted as closed. The check I ran first — "is `make` in the runner list" — returned true and hid a real defect. Checking that a runner is *registered* is not the same as checking it *runs the tests*, and I would treat the other runner entries with the same suspicion.