### PR TITLE
ci: add windows-latest to the import guard matrix — Closes #270

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -17,8 +17,33 @@ on:
 
 jobs:
   imports:
-    name: Package imports and CLI starts
-    runs-on: ubuntu-latest
+    # Windows is in the matrix because three Windows-only bugs reached main
+    # this cycle and none was caught here: --update walking into an ancestor
+    # repository, _discover_test_files emitting backslash paths that then broke
+    # inside the Linux container, and _docker_mount_path passing raw Windows
+    # paths to Docker. All three were found by running the suite by hand.
+    #
+    # The path-handling surface is large -- code_modifier, sandbox,
+    # git_integration and housekeeping all build paths -- and a Linux-only
+    # matrix is structurally blind to it.
+    #
+    # fail-fast is off so a Windows-specific failure does not cancel the Linux
+    # run: knowing whether a break is platform-specific is most of the
+    # diagnosis, and cancelling the other job removes exactly that signal.
+    name: Package imports and CLI starts (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    # Every step here uses a `python - <<'PY'` heredoc, which PowerShell -- the
+    # default shell on windows-latest -- does not understand. bash ships with
+    # the Windows runner, so setting it once at the job level keeps one
+    # workflow rather than two that can drift apart.
+    defaults:
+      run:
+        shell: bash
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Closes #270

```yaml
strategy:
  fail-fast: false
  matrix:
    os: [ubuntu-latest, windows-latest]
```

## Why

Three Windows-only bugs reached `main` this cycle and CI caught none of them:

- `--update` walking into an ancestor repository
- `_discover_test_files` emitting backslash paths that then broke inside the Linux container
- `_docker_mount_path` passing raw Windows paths to Docker — and a test that encoded the bug rather than catching it

All three were found by running the suite on Windows by hand. The path-handling surface is large — `code_modifier`, `sandbox`, `git_integration` and `housekeeping` all build paths — and a Linux-only matrix is structurally blind to it.

## Two decisions worth reviewing

**`fail-fast: false`.** A Windows-specific failure should not cancel the Linux job. Knowing whether a break is platform-specific is most of the diagnosis, and cancelling the other job removes exactly that signal.

**`defaults.run.shell: bash`.** Every step in this workflow uses a `python - <<'PY'` heredoc, which PowerShell — the default shell on `windows-latest` — does not understand. bash ships with the Windows runner, so setting it once at the job level keeps one workflow rather than two that can drift apart.

Without that second line the matrix would run and fail on Windows for a reason that has nothing to do with the code.

## Verified

- YAML parses; both `os` values present, `fail-fast` false, shell set, all 10 steps intact
- the guard steps still pass locally

CI configuration only — no code changes.

## Note

This will surface Windows failures that have presumably always been there. That is the point, but the first run may be red for reasons predating this PR — worth reading the first Windows result as a survey rather than a regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Import validation now runs on both Ubuntu and Windows environments.
  * Platform checks run independently, so one failure does not prevent other checks from completing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->