### PR TITLE
test: cover secret_scanner and token_tracker — Closes #271

### DIFF
--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -1,0 +1,148 @@
+"""
+Tests for modules/secret_scanner.py.
+
+This module had no tests. It is what stops a key reaching a log, and its
+failure mode is silent: a pattern that stops matching does not raise, it just
+returns nothing and the secret goes through.
+
+Every case below uses a fabricated key of the right *shape*. None is real.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.secret_scanner import (  # noqa: E402
+    SECRET_PATTERNS,
+    format_findings,
+    scan_directory,
+    scan_file,
+)
+
+# Fabricated, shape-correct only.
+AWS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+GITHUB_TOKEN = "ghp_" + "a" * 36
+PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----"
+
+
+def found(content, name=None):
+    findings = scan_file("example.py", content)
+    if name is None:
+        return findings
+    return [f for f in findings if f.pattern_name == name]
+
+
+# ── it finds what it is for ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "content,expected",
+    [
+        (f"key = '{AWS_KEY_ID}'", "AWS Access Key ID"),
+        (f"token = '{GITHUB_TOKEN}'", "GitHub Token"),
+        (f"api_key = '{'x' * 24}'", "Generic API Key"),
+        ("password = 'hunter2hunter2'", "Generic Secret/Token"),
+        (PRIVATE_KEY, "Private Key Block"),
+    ],
+    ids=["aws", "github", "api-key", "password", "private-key"],
+)
+def test_a_known_shape_is_detected(content, expected):
+    assert found(content, expected)
+
+
+def test_the_finding_names_the_line():
+    """A file path alone is not actionable in a large file."""
+    content = f"first\nsecond\nkey = '{AWS_KEY_ID}'\n"
+
+    assert found(content, "AWS Access Key ID")[0].line_number == 3
+
+
+def test_the_finding_carries_a_severity():
+    assert found(f"key = '{AWS_KEY_ID}'", "AWS Access Key ID")[0].severity == "high"
+
+
+def test_several_secrets_in_one_file_are_all_found():
+    content = f"a = '{AWS_KEY_ID}'\nb = '{GITHUB_TOKEN}'\n"
+
+    assert len(found(content)) >= 2
+
+
+# ── it leaves ordinary code alone ─────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "def parse(x):\n    return x.strip()\n",
+        "AKIA = 'not a key'",
+        "# api_key documentation mentions the term",
+        "password = get_password()",
+        "",
+    ],
+    ids=["source", "short-aws", "comment", "indirection", "empty"],
+)
+def test_ordinary_content_is_not_flagged(content):
+    """
+    False positives are not harmless here: a scanner that cries wolf gets
+    switched off, and then it catches nothing at all.
+    """
+    assert scan_file("example.py", content) == []
+
+
+# ── scanning a tree ───────────────────────────────────────────────────────
+
+
+def test_a_directory_is_scanned(tmp_path):
+    (tmp_path / "clean.py").write_text("x = 1\n")
+    (tmp_path / "leaky.py").write_text(f"key = '{AWS_KEY_ID}'\n")
+
+    paths = {Path(f.file_path).name for f in scan_directory(str(tmp_path))}
+
+    assert "leaky.py" in paths
+    assert "clean.py" not in paths
+
+
+def test_a_clean_directory_reports_nothing(tmp_path):
+    (tmp_path / "clean.py").write_text("def f():\n    return 1\n")
+
+    assert scan_directory(str(tmp_path)) == []
+
+
+def test_a_missing_directory_does_not_raise(tmp_path):
+    """A scanner that crashes on a bad path fails the run it was protecting."""
+    assert scan_directory(str(tmp_path / "nope")) == []
+
+
+# ── reporting ─────────────────────────────────────────────────────────────
+
+
+def test_findings_are_rendered_with_their_location():
+    rendered = format_findings(found(f"key = '{AWS_KEY_ID}'"))
+
+    assert "AWS Access Key ID" in rendered
+
+
+def test_no_findings_renders_without_error():
+    assert isinstance(format_findings([]), str)
+
+
+# ── the pattern table itself ──────────────────────────────────────────────
+
+
+def test_every_pattern_is_well_formed():
+    """A malformed regex would raise at scan time, on the run it should protect."""
+    import re
+
+    for pattern in SECRET_PATTERNS:
+        assert pattern["name"]
+        assert pattern["severity"] in {"high", "medium", "low"}
+        re.compile(pattern["regex"])
+
+
+def test_the_table_is_not_empty():
+    """An empty table scans clean and protects nothing."""
+    assert len(SECRET_PATTERNS) >= 5

--- a/tests/test_token_tracker.py
+++ b/tests/test_token_tracker.py
@@ -1,0 +1,154 @@
+"""
+Tests for modules/token_tracker.py.
+
+This module had no tests. It feeds cost reporting and, indirectly, the numbers
+a user checks against --max-cost — so an error here is a wrong figure rather
+than a crash, which is the kind that goes unnoticed.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.llm_client import MODEL  # noqa: E402
+from modules.token_tracker import PRICING_TABLE, TokenTracker, TokenUsage  # noqa: E402
+
+PRICED = MODEL  # the default model, which is in the table
+
+
+@pytest.fixture
+def tracker():
+    return TokenTracker()
+
+
+# ── accumulation ──────────────────────────────────────────────────────────
+
+
+def test_a_fresh_tracker_is_empty(tracker):
+    assert tracker.calls == 0
+    assert tracker.total_usage.total_tokens == 0
+
+
+def test_one_call_is_recorded(tracker):
+    tracker.add_usage(PRICED, 100, 50)
+
+    assert tracker.calls == 1
+    assert tracker.total_usage.input_tokens == 100
+    assert tracker.total_usage.output_tokens == 50
+
+
+def test_calls_accumulate(tracker):
+    """The property that matters: a summary reflects the whole run, not the last call."""
+    tracker.add_usage(PRICED, 100, 50)
+    tracker.add_usage(PRICED, 200, 75)
+
+    assert tracker.calls == 2
+    assert tracker.total_usage.input_tokens == 300
+    assert tracker.total_usage.output_tokens == 125
+
+
+def test_the_total_is_the_sum_of_both(tracker):
+    tracker.add_usage(PRICED, 100, 50)
+
+    assert tracker.total_usage.total_tokens == 150
+
+
+def test_a_zero_token_call_still_counts(tracker):
+    """A call that returned nothing was still a call, and still cost latency."""
+    tracker.add_usage(PRICED, 0, 0)
+
+    assert tracker.calls == 1
+
+
+# ── cost ──────────────────────────────────────────────────────────────────
+
+
+def test_a_priced_model_produces_a_cost(tracker):
+    tracker.add_usage(PRICED, 1000, 1000)
+
+    assert tracker.cost_usd > 0
+
+
+def test_cost_accumulates_across_calls(tracker):
+    tracker.add_usage(PRICED, 1000, 1000)
+    first = tracker.cost_usd
+    tracker.add_usage(PRICED, 1000, 1000)
+
+    assert tracker.cost_usd == pytest.approx(first * 2)
+
+
+def test_more_tokens_cost_more(tracker):
+    small = TokenTracker()
+    small.add_usage(PRICED, 100, 100)
+    tracker.add_usage(PRICED, 10_000, 10_000)
+
+    assert tracker.cost_usd > small.cost_usd
+
+
+def test_an_unknown_model_does_not_raise(tracker):
+    """
+    A self-hosted or newly released model is not in the table. Reporting no
+    cost is right; raising would fail a run over a reporting detail.
+    """
+    tracker.add_usage("some-local-model", 100, 50)
+
+    assert tracker.calls == 1
+    assert tracker.cost_usd == 0
+
+
+def test_the_default_model_is_priced():
+    """
+    The one model that must be in the table. If the default falls out of it,
+    every run reports Unknown and the cost figure silently becomes useless.
+    """
+    assert MODEL in PRICING_TABLE
+
+
+# ── the summary ───────────────────────────────────────────────────────────
+
+
+def test_the_summary_reports_the_totals(tracker):
+    tracker.add_usage(PRICED, 300, 125)
+    summary = tracker.get_summary()
+
+    assert "300" in summary
+    assert "125" in summary
+    assert "425" in summary
+
+
+def test_the_summary_reports_the_call_count(tracker):
+    tracker.add_usage(PRICED, 10, 10)
+    tracker.add_usage(PRICED, 10, 10)
+
+    assert "2" in tracker.get_summary()
+
+
+def test_an_unknown_model_says_so(tracker):
+    """Rather than printing $0.0000, which reads as free."""
+    tracker.add_usage("some-local-model", 100, 50)
+
+    assert "Unknown" in tracker.get_summary()
+
+
+def test_an_empty_tracker_summarises_without_error(tracker):
+    assert isinstance(tracker.get_summary(), str)
+
+
+# ── the pricing table ─────────────────────────────────────────────────────
+
+
+def test_every_entry_has_both_rates():
+    """(input, output) per 1K tokens. A one-element tuple would raise at use."""
+    for model, pricing in PRICING_TABLE.items():
+        assert len(pricing) == 2, f"{model} has {len(pricing)} rate(s)"
+        assert all(isinstance(rate, (int, float)) and rate >= 0 for rate in pricing)
+
+
+def test_usage_defaults_to_zero():
+    usage = TokenUsage()
+
+    assert (usage.input_tokens, usage.output_tokens, usage.total_tokens) == (0, 0, 0)


### PR DESCRIPTION
Closes #271

36 tests across the two modules that had none.

## `secret_scanner` — 20 cases

This is the module whose failure is silent. A pattern that stops matching does not raise; it returns nothing, and the secret goes through. There was no test asserting that a known key shape is redacted.

What it finds: five shapes — AWS key ID, GitHub token, generic API key, password assignment, private key block — parametrised. The finding names the line, not just the file. It carries a severity. Several secrets in one file are all reported.

What it leaves alone: five kinds of ordinary content, parametrised. **False positives are not harmless here** — a scanner that cries wolf gets switched off, and then it catches nothing at all.

Scanning a tree: a directory is scanned and the clean file is not reported; a clean directory reports nothing; a missing directory does not raise, because a scanner that crashes on a bad path fails the run it was protecting.

The table itself: every pattern compiles and has a valid severity — a malformed regex would raise at scan time, on the run it exists to protect. And the table is not empty, since an empty one scans clean and protects nothing.

**Every key in these tests is fabricated, shape-correct only.** None is real.

## `token_tracker` — 16 cases

An error here is a wrong number rather than a crash, which is the kind that goes unnoticed.

Accumulation: a fresh tracker is empty; one call is recorded; calls accumulate — the property that matters, since a summary must reflect the whole run rather than the last call; the total is the sum of both; a zero-token call still counts.

Cost: a priced model produces a cost; cost accumulates; more tokens cost more; **an unknown model does not raise** — a self-hosted or newly released model is not in the table, and reporting no cost is right where failing a run over a reporting detail is not.

One assertion worth calling out: **the default model must be in the pricing table.** If it ever falls out, every run reports "Unknown" and the cost figure silently becomes useless while nothing fails.

The summary: it reports the totals and the call count; an unknown model says so rather than printing `$0.0000`, which reads as free; an empty tracker summarises without error.

## Verified

- 36 tests pass
- both modules behave correctly — every test passed on the first run, so this is coverage for working code rather than a fix
- all six import-guard checks green

Tests only — no code changes.