### PR TITLE
cleanup: remove seven unused imports — Closes #268

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -40,7 +40,6 @@ from modules.sandbox import (
     parse_coverage_percent,
 )
 from modules.git_integration import GitIntegration
-from modules.doc_lookup import perform_lookups, render_lookups
 from modules.run_state import (
     RunState,
     check_resumable,

--- a/modules/doc_lookup.py
+++ b/modules/doc_lookup.py
@@ -31,7 +31,6 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from typing import Optional
 from modules.errors import ConfigurationError
 
 _LOG = logging.getLogger("agent.doc_lookup")

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -12,10 +12,9 @@ import ssl
 import sys
 import urllib.error
 import urllib.request
-import time
 from pathlib import Path
 from dataclasses import dataclass, field
-from typing import Optional, Any
+from typing import Optional
 from modules.errors import ConfigurationError, ProviderError, AgentError
 
 _LOG = logging.getLogger("agent.llm_client")

--- a/modules/token_tracker.py
+++ b/modules/token_tracker.py
@@ -4,7 +4,6 @@ Tracks token usage and estimates costs for LLM API calls.
 """
 
 from dataclasses import dataclass
-from typing import Dict, Optional
 
 # Cost per 1k tokens (input, output) in USD
 PRICING_TABLE = {


### PR DESCRIPTION
Closes #268

```
modules/agent_loop.py     modules.doc_lookup.perform_lookups
modules/agent_loop.py     modules.doc_lookup.render_lookups
modules/doc_lookup.py     typing.Optional
modules/llm_client.py     time
modules/llm_client.py     typing.Any
modules/token_tracker.py  typing.Dict
modules/token_tracker.py  typing.Optional
```

Removed with `ruff --select F401 --fix`, which is what flagged them.

## The `doc_lookup` suspicion was right

The issue said those two imports might be the last trace of a half-merged feature and were worth checking before removal. They are.

`modules/doc_lookup.py` has a full implementation and a 40-test suite that passes. It has **no CLI flag** and **no caller anywhere** — `perform_lookups` and `render_lookups` appear nowhere outside their own module and that one import line.

So the feature is built, tested, and unreachable.

Removing the imports is still correct: they do nothing, and leaving them as a breadcrumb is a poor substitute for either wiring the feature up or recording that it is not wired. But it does delete the last hint that the module is meant to be called, so this is worth its own issue rather than being buried in a cleanup PR. Happy to file it.

## Verified

- all four modules import cleanly
- full suite passes
- all six import-guard checks green
- a real `--context-only` run completes

## The one failing test is not from this change

`test_no_field_was_lost` asserts 46 `AgentConfig` fields against the current 49. **It fails on `main` too**, and has since #223 merged — #172 added `step` and #176 added `fallback_provider` and `fallback_api_key` after the assertion was written, and each was green against its own base.

Fixed in the PR closing #262–#265. Merging that one first turns `main` green and this branch with it.