### PR TITLE
fix(parallel): pair outcomes with strict=True — Closes #267

### DIFF
--- a/modules/parallel_tasks.py
+++ b/modules/parallel_tasks.py
@@ -175,9 +175,15 @@ def run_tasks(
 
     worktrees = create_worktrees(repo_root, tasks, branch_prefix, base_branch)
     branches = [f"{branch_prefix}/{slugify(t, i)}" for i, t in enumerate(tasks, 1)]
+    # strict=True rather than the default. Without it, a worktree that failed
+    # to create makes paths shorter than tasks, zip stops at the shortest, and
+    # the extra tasks disappear from the outcomes -- the run then reports
+    # success for what it did produce and says nothing about what it dropped.
+    # An exception here is loud at the point the lists disagree, which is the
+    # only point at which the disagreement can still be understood.
     outcomes = [
         TaskOutcome(task=t, branch=b, worktree=p)
-        for t, b, p in zip(tasks, branches, worktrees.paths)
+        for t, b, p in zip(tasks, branches, worktrees.paths, strict=True)
     ]
 
     try:

--- a/tests/test_parallel_tasks.py
+++ b/tests/test_parallel_tasks.py
@@ -263,3 +263,30 @@ def test_a_subdirectory_is_not_treated_as_the_repo(repo):
     nested.mkdir(parents=True)
 
     assert is_git_repo(str(nested)) is False
+
+
+# ── outcome pairing (#267) ────────────────────────────────────────────────
+
+
+def test_the_outcome_zip_is_strict():
+    """
+    Without strict=True, a worktree that failed to create makes paths shorter
+    than tasks, zip stops at the shortest, and the extra tasks disappear from
+    the outcomes — the run reports success for what it produced and says
+    nothing about what it dropped.
+    """
+    source = (
+        Path(__file__).resolve().parents[1] / "modules" / "parallel_tasks.py"
+    ).read_text(encoding="utf-8")
+
+    assert "zip(tasks, branches, worktrees.paths, strict=True)" in source
+
+
+def test_mismatched_lengths_raise_rather_than_truncate():
+    """The behaviour the flag buys, stated directly."""
+    tasks, branches, paths = ["a", "b", "c"], ["x", "y", "z"], ["p", "q"]
+
+    assert len(list(zip(tasks, branches, paths))) == 2
+
+    with pytest.raises(ValueError):
+        list(zip(tasks, branches, paths, strict=True))


### PR DESCRIPTION
Closes #267

```python
for t, b, p in zip(tasks, branches, worktrees.paths, strict=True)
```

## What it changes

```
3 tasks, 2 worktrees

without strict:  2 outcomes -- one task silently dropped
with strict:     ValueError: zip() argument 3 is shorter than arguments 1-2
```

A worktree that failed to create makes `paths` shorter than `tasks`. `zip` stops at the shortest, the extra tasks vanish from the outcomes, and the run reports success for what it produced while saying nothing about what it dropped.

That is the worst available failure mode: the user sees a green run and two branches, and has to notice for themselves that they asked for three.

An exception is loud at the point the lists disagree, which is the only point at which the disagreement can still be understood — by the time the outcomes are rendered, the missing task is indistinguishable from one that was never requested.

## Tests

Two cases added to `tests/test_parallel_tasks.py`.

The zip is strict — asserted against the source, since the flag is the whole fix and a later edit could drop it silently.

Mismatched lengths raise rather than truncate — the behaviour the flag buys, stated directly rather than left implied.

## Verified

- `ruff --select B905` clean on `modules/parallel_tasks.py`
- 25 tests pass in `test_parallel_tasks.py`, up from 23
- all six import-guard checks green