### PR TITLE
fix(llm): select the first text block rather than assuming index 0 — Closes #266

### DIFF
--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -718,6 +718,34 @@ class BaseLLMClient:
         return self._parse_response(raw, input_tok)
 
 
+def _first_text_block(content) -> str:
+    """
+    The first block in a reply that actually carries text.
+
+    `content[0].text` assumed index 0 is a TextBlock. It is a union -- thinking,
+    tool-use and tool-result blocks are all possible, and none of them has a
+    `text` attribute. A reply opening with one raised AttributeError and killed
+    the run, which #176's provider fallback would not have caught either, since
+    an AttributeError is not a transient API error.
+
+    Nothing enables those block types today. This is one config change away
+    rather than a live failure, and the cost of being right about it is a loop.
+    """
+    for block in content or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            return text
+
+    # An empty or all-non-text reply is a parse failure, not a crash: the
+    # caller already handles an unparseable response and will retry.
+    _LOG.warning(
+        "Reply contained no text block (%d block(s) of type %s).",
+        len(content or []),
+        ", ".join(sorted({getattr(b, "type", "?") for b in content or []})) or "none",
+    )
+    return ""
+
+
 class AnthropicClient(BaseLLMClient):
     def __init__(self, api_key: Optional[str] = None, model: str = MODEL):
         super().__init__(model)
@@ -752,9 +780,7 @@ class AnthropicClient(BaseLLMClient):
                 system=self.system_prompt,
                 messages=[{"role": "user", "content": prompt}],
             )
-            print(response.content[0].text)
-            print("\n")
-            return response.content[0].text
+            return _first_text_block(response.content)
 
 
 class OpenAIClient(BaseLLMClient):
@@ -791,8 +817,6 @@ class OpenAIClient(BaseLLMClient):
             with urllib.request.urlopen(req, context=ctx) as response:
                 res = json.loads(response.read().decode("utf-8"))
                 text = res["choices"][0]["message"]["content"]
-                print(text)
-                print("\n")
                 return text
         except Exception as e:
             print(f"Error calling OpenAI API: {e}")
@@ -835,8 +859,6 @@ class GeminiClient(BaseLLMClient):
             with urllib.request.urlopen(req, context=ctx) as response:
                 res = json.loads(response.read().decode("utf-8"))
                 text = res["candidates"][0]["content"]["parts"][0]["text"]
-                print(text)
-                print("\n")
                 return text
         except Exception as e:
             print(f"Error calling Gemini API: {e}")
@@ -878,8 +900,6 @@ class OllamaClient(BaseLLMClient):
             with urllib.request.urlopen(req, context=ctx) as response:
                 res = json.loads(response.read().decode("utf-8"))
                 text = res["message"]["content"]
-                print(text)
-                print("\n")
                 return text
         except Exception as e:
             print(f"Error calling Ollama API (is the Ollama server running at {self.api_base_url}?): {e}")

--- a/tests/test_response_blocks.py
+++ b/tests/test_response_blocks.py
@@ -1,0 +1,120 @@
+"""
+Tests for reply block selection (modules/llm_client.py).
+
+`response.content[0].text` assumed index 0 is a TextBlock. It is a union —
+thinking, tool-use and tool-result blocks are all possible, and none of them
+has a `text` attribute. A reply opening with one raised AttributeError and
+killed the run.
+
+#176's provider fallback would not have caught it either: an AttributeError is
+not a transient API error, so it would have been re-raised rather than retried.
+
+There was also a bare `print(response.content[0].text)` on the line above,
+writing the full reply to stdout outside the logger.
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.llm_client import _first_text_block  # noqa: E402
+
+
+def text(value):
+    return SimpleNamespace(type="text", text=value)
+
+
+def thinking():
+    """No `text` attribute — this is what used to raise."""
+    return SimpleNamespace(type="thinking", thinking="reasoning")
+
+
+def tool_use():
+    return SimpleNamespace(type="tool_use", name="search", input={})
+
+
+# ── selection ─────────────────────────────────────────────────────────────
+
+
+def test_a_text_block_is_returned():
+    assert _first_text_block([text("hello")]) == "hello"
+
+
+def test_a_leading_thinking_block_is_skipped():
+    """The case that used to raise AttributeError."""
+    assert _first_text_block([thinking(), text("hello")]) == "hello"
+
+
+def test_several_non_text_blocks_are_skipped():
+    assert _first_text_block([tool_use(), thinking(), text("hi")]) == "hi"
+
+
+def test_the_first_text_block_wins():
+    assert _first_text_block([text("first"), text("second")]) == "first"
+
+
+def test_an_empty_string_block_is_still_text():
+    """`getattr(..., None)` rather than truthiness: "" is a real reply."""
+    assert _first_text_block([text(""), text("later")]) == ""
+
+
+# ── nothing usable ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "content,label",
+    [([thinking()], "only thinking"), ([], "empty"), (None, "none")],
+)
+def test_no_text_returns_empty_rather_than_raising(content, label):
+    """
+    A parse failure, not a crash. The caller already handles an unparseable
+    response and retries; raising here would end the run instead.
+    """
+    assert _first_text_block(content) == ""
+
+
+def test_no_text_is_logged(caplog):
+    """Silence would make an empty reply look like an empty model answer."""
+    with caplog.at_level("WARNING"):
+        _first_text_block([thinking()])
+
+    assert "no text block" in caplog.text
+
+
+# ── the print is gone ─────────────────────────────────────────────────────
+
+
+def test_the_reply_is_not_printed_to_stdout():
+    """
+    It bypassed the logger entirely: unaffected by --quiet and unmasked by the
+    secret redaction that --verbose applies, so anyone piping output got the
+    raw reply interleaved with their own.
+    """
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+
+    assert "print(response.content[0].text)" not in source
+
+
+def test_no_provider_prints_the_reply_before_returning():
+    """
+    The same three lines appeared in the OpenAI, Gemini and Ollama paths --
+    print the reply, print a blank line, return it. All four are removed.
+
+    The streaming prints are deliberate and stay: those are the streamed
+    output itself, which is the point of streaming.
+    """
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+
+    assert "print(text)\n                print" not in source
+    assert source.count("print(text)") == 0
+
+
+def test_index_zero_is_no_longer_assumed():
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+
+    assert "response.content[0].text" not in source


### PR DESCRIPTION
Closes #266

## The bug was in four places, not one

The issue reported this at `llm_client.py:755`, in the Anthropic path. The same three lines appear in the OpenAI, Gemini and Ollama paths:

```python
print(text)
print("\n")
return text
```

All four are fixed here. Finding the other three is the reason this PR is larger than the issue implies.

## The `print`

It wrote the full model reply to stdout on every call, outside the logger — unaffected by `--quiet`, unmasked by the secret redaction `--verbose` applies, and interleaved with anything the user was piping.

Removed from all four. The *streaming* prints stay: those are the streamed output itself, which is the point of streaming, and they already go through the intended path.

## `content[0].text`

`response.content[0]` is a union of block types. Only some carry `text`:

```
error: Item "ThinkingBlock" of "TextBlock | ThinkingBlock | ... | <7 more items>" has no attribute "text"
```

22 such errors, and confirmed to raise:

```
AttributeError: 'ThinkingBlock' object has no attribute 'text'
```

A reply opening with a thinking or tool-use block killed the run. #176's provider fallback would not have helped — an `AttributeError` is not a transient API error, so it is re-raised rather than retried.

`_first_text_block` walks the blocks and returns the first that actually has text:

```
text first           -> 'hello'
thinking then text   -> 'hello'
two non-text first   -> 'hi'
no text at all       -> ''
empty                -> ''
None                 -> ''
```

## Returning `""` rather than raising

An all-non-text reply is a parse failure, not a crash. The caller already handles an unparseable response and retries; raising here would end the run instead of giving the model another attempt.

It is logged with the block types received, because silence would make an empty reply indistinguishable from a model that genuinely answered with nothing.

`getattr(block, "text", None)` rather than a truthiness check — an empty string is a real reply and should be returned, not skipped.

## Nothing enables these blocks today

Worth being plain: this is one config change away rather than a live failure. The cost of being right about it is a loop.

## Tests

`tests/test_response_blocks.py` — 12 cases.

Selection: a text block is returned; a leading thinking block is skipped; several non-text blocks are skipped; the first text block wins; an empty-string block is still text.

Nothing usable: three shapes return `""` rather than raising, parametrised; the case is logged.

The print: the reply is not printed to stdout; no provider prints the reply before returning; index 0 is no longer assumed.

## Verified

- the selection table above
- **`modules/llm_client.py` is now clean under mypy** — all 22 `union-attr` errors gone
- 12 new tests pass, plus `test_streaming` and `test_cost_budget`
- all six import-guard checks green