### PR TITLE
fix: four type errors mypy found — Closes #262, #263, #264, #265

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -25,6 +25,7 @@ from typing import Optional
 from modules.repo_ingestion import ingest_repository, ingest_repository_parallel, Repository
 from modules.context_builder import build_context, budget_for_model
 from modules.llm_client import (
+    MODEL,
     load_system_prompt,
     BudgetExceededError,
     FileChange,
@@ -114,7 +115,12 @@ class AgentConfig:
     quiet: bool = False                    # suppress debug-level output
     verbose_payloads: bool = False
     system_prompt_file: Optional[str] = None   # replace the default persona         # dump raw LLM request/response
-    model: Optional[str] = None
+    # Non-optional: LLMClient expects a str, and every construction path
+    # already had a default to hand. Leaving it Optional meant anything
+    # building AgentConfig directly -- the parallel path, tests, an embedding
+    # caller -- could pass None straight through to the provider SDK, where
+    # the failure surfaces far from its cause.
+    model: str = MODEL
     context_budget: Optional[int] = None   # chars; derived from the model if unset
     provider: str = "anthropic"
     fallback_provider: Optional[str] = None   # try this one if the primary is down
@@ -598,7 +604,7 @@ class AutonomousAgent:
                 if cfg.parallel:
                     repo: Repository = ingest_repository_parallel(cfg.repo_root, max_workers=cfg.workers)
                 else:
-                    repo: Repository = ingest_repository(cfg.repo_root)
+                    repo = ingest_repository(cfg.repo_root)
             except Exception as e:
                 self.logger.error(f"Repo ingestion failed: {e}")
                 outcome = "error"

--- a/modules/repo_ingestion.py
+++ b/modules/repo_ingestion.py
@@ -8,10 +8,17 @@ import os
 import re
 import hashlib
 import logging
+from types import ModuleType
 from dataclasses import dataclass, field
 from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
+
+# Declared before the try so the fallback assignment is well-typed. Without
+# it, `pathspec = None` conflicts with the inferred Module type, and every
+# later `if pathspec:` guard becomes unverifiable -- which are exactly the
+# guards that keep an un-reinstalled checkout working.
+pathspec: Optional[ModuleType]
 
 try:  # optional at runtime so an un-reinstalled checkout still works
     import pathspec

--- a/modules/sandbox.py
+++ b/modules/sandbox.py
@@ -1097,9 +1097,12 @@ class DockerSandbox(Sandbox):
     def __enter__(self) -> "DockerSandbox":
         return self
 
-    def __exit__(self, exc_type, exc, tb) -> bool:
+    def __exit__(self, exc_type, exc, tb) -> None:
         self.cleanup()
-        return False  # never swallow the exception
+        # No return: -> None says the exception always propagates. Returning
+        # False did the same thing, but the bool annotation advertised that
+        # this context manager *may* suppress errors -- the opposite of the
+        # comment that sat beside it.
 
     @classmethod
     def sweep_orphaned_containers(cls) -> list[str]:

--- a/tests/test_no_duplicate_fields.py
+++ b/tests/test_no_duplicate_fields.py
@@ -172,5 +172,6 @@ def test_no_field_was_lost():
 
     from modules.agent_loop import AgentConfig
 
-    # 46 on current main. Pinned so a field cannot be dropped unnoticed.
-    assert len(fields(AgentConfig)) == 46
+    # 49 on current main; rises as flags are added. Pinned so a field
+    # cannot be dropped unnoticed by a merge, not to freeze the count.
+    assert len(fields(AgentConfig)) == 49


### PR DESCRIPTION
Closes #262
Closes #263
Closes #264
Closes #265

Four unrelated type errors in four different files, grouped because none of them shares a file with any other and splitting them would mean four PRs against a queue that has already needed several rebases today.

mypy goes from 38 errors to 24. The remainder are #266's `union-attr` cluster, fixed separately.

## #262 — `repo` annotated twice

```python
if cfg.parallel:
    repo: Repository = ingest_repository_parallel(...)
else:
    repo: Repository = ingest_repository(...)     # <- second annotation
```

The second becomes a plain assignment. Harmless today since both branches assign the same type, but it is the same shape as the four `AgentConfig` fields fixed in #229 — a duplicate declaration that is valid Python and therefore invisible to tests, ruff and the import guard.

## #263 — `__exit__` typed `-> bool`

```
error: "bool" is invalid as return type for "__exit__" that always returns False
```

Now `-> None`, with the explicit `return False` removed. The behaviour is identical — exceptions propagate either way — but the annotation no longer advertises that this context manager *may* suppress errors, which was the opposite of the comment sitting beside it.

## #264 — a `None` model could reach `LLMClient`

`AgentConfig.model` was `Optional[str] = None`, passed straight to a client expecting `str`. `main.py` supplies a default so the CLI path never hit it; anything constructing `AgentConfig` directly — the parallel path, tests, an embedding caller — could, and the failure surfaced inside the provider SDK rather than at the call site.

Now `model: str = MODEL`, the same constant the client falls back to. Non-optional rather than a runtime guard: every construction path already had a default to hand, so the type can simply say so.

## #265 — `pathspec` typed as a module, assigned `None`

```python
pathspec: Optional[ModuleType]

try:
    import pathspec
except ImportError:
    pathspec = None
```

The fallback was always deliberate and always worked. Declaring the type before the `try` means every later `if pathspec:` guard is checkable — and those guards are precisely what keeps an un-reinstalled checkout working.

## One test updated, and it was already failing

`test_no_field_was_lost` asserts the `AgentConfig` field count. It was written against 46 fields in #229; #172 added `step` and #176 added `fallback_provider` and `fallback_api_key`, taking it to 49.

**`main` has been red since #223 merged.** Each of those PRs was green against its own base, and the assertion only fires once they are all on `main` together — so nothing caught it.

Updated to 49, with the comment rewritten to say it is pinned to catch a *dropped* field rather than to freeze the count. The assertion did its job; it just needed reading.

## Verified

- mypy: 38 → 24 errors, and all four target diagnostics (`no-redef`, `exit-return`, `arg-type`, `assignment`) gone
- full suite green — 1257 passing where `main` had one failure
- all six import-guard checks green
- a real `--context-only` run completes

## Follow-up worth having

The import guard runs a smoke run, not the suite. That is why `main` could go red across three merges without anyone noticing. Running the full suite there would close the gap — happy to file it.