### PR TITLE
chore: ignore the response cache, document .agentcontext, add SECURITY.md — Closes #284, #285, #286

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ __pycache__/
 .DS_Store
 Thumbs.db
 node_modules/
+
+# Response cache written by --cache (#222). Committing it would put model
+# replies into the repository, and the agent itself runs `git add -A`.
+.repopilot-cache/

--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ python main.py --repo . --task "Add a retry helper"
 
 `.agentcontext` is read on every iteration and applies to every task in the repository.
 
+**Commit it.** The file describes the project rather than the person working on it, so
+everyone on the repository — and every fresh clone — gets the same conventions. It is
+deliberately not in `.gitignore` for that reason, the same way `.editorconfig` is not.
+
 ### Run several tasks at once
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately rather than in a public issue.
+
+Use GitHub's [private vulnerability reporting](https://github.com/sreerevanth/repopilot/security/advisories/new)
+on this repository. If that is unavailable, open an issue titled "Security
+contact request" containing no details, and a maintainer will arrange a private
+channel.
+
+Please include what you can: the version or commit, the flags in use, and a
+minimal reproduction. A reproduction matters more than a full write-up — most of
+what follows is easier to confirm than to describe.
+
+You can expect an acknowledgement within a few days and an assessment of whether
+the report is in scope. This is a volunteer-maintained project, so please do not
+expect a same-day response.
+
+## What this tool does with your machine
+
+RepoPilot executes model-authored code and writes to your repository, so the
+trust boundaries are worth stating plainly. A report that shows one of these
+being crossed is in scope.
+
+**Model output is untrusted.** Anything the model produces — file contents,
+paths, shell arguments — is treated as hostile input, not as instructions.
+
+**Writes stay inside the repository.** File changes are confined to the
+`--repo` root. A path that escapes it, including through a symlink, a rename
+destination or a `..` sequence, is a vulnerability.
+
+**Tests run in a sandbox when Docker is available.** Networking is disabled,
+memory is capped, and the container is removed afterwards. When Docker is not
+available the run falls back to a subprocess, which is **not** isolated. The log
+says so, but there is currently no flag to refuse the fallback — `DockerSandbox`
+accepts `strict=True` internally and it is not wired to the CLI.
+
+An escape from the Docker sandbox is in scope. The subprocess fallback is a
+documented limitation rather than a defect: if you need isolation guaranteed,
+check the log, or run in a container yourself.
+
+**API keys are not written to logs.** `--verbose` prints prompts and replies
+with known secret patterns masked by `modules/secret_scanner.py`. A key shape
+that reaches a log unmasked is in scope, and the pattern list is the thing most
+likely to fall behind.
+
+**Destructive operations ask first.** `--clean` removes only files matching the
+shapes this tool writes, and refuses to recurse. `--undo` deletes only branches
+carrying the agent's prefix, and asks before doing it. A path that removes
+something outside those rules is in scope.
+
+## Out of scope
+
+- the subprocess fallback not being isolated — documented above, and the lack
+  of a flag to refuse it is tracked separately as a feature gap
+- the model producing incorrect or low-quality code, which is a correctness
+  matter rather than a security one
+- vulnerabilities in the provider SDKs themselves; report those upstream
+- anything requiring an attacker to already have write access to your
+  repository or shell
+
+## Supported versions
+
+The `main` branch. This project has no released versions yet, so fixes land
+there and are available immediately.


### PR DESCRIPTION
Closes #284 (cache not ignored), #285 (.agentcontext undecided), #286 (no security policy)

Three small repository-metadata items, grouped because each is a few lines and none touches code.

## `.repopilot-cache/` is now ignored

#222 added `--cache`, which writes response entries to `.repopilot-cache/` in the repository root. It was not in `.gitignore`, so anyone using the flag saw it as untracked — and `git add -A`, which the agent itself runs when staging, would commit cached model responses into their repository.

`logs/` and `backups/` were already ignored, so this was the one agent-written directory that was not.

## `.agentcontext` is deliberately not ignored, and the README now says so

The file was in neither `.gitignore` nor the documentation, so the first person to notice it would have guessed.

It should be committed. It describes the project rather than the person working on it — target Python version, where tests live, house conventions — so the whole team and every fresh clone get the same rules. That is how `.editorconfig` works. One sentence in the README now states it rather than leaving it to inference.

## SECURITY.md

The repository has `CONTRIBUTING.md` and issue templates but no security policy, and this project does more than most of its size: it executes model-authored code, handles API keys, writes to and commits in the user's repository, and can push and open PRs.

Someone finding a sandbox escape, a masking gap, or a path that writes outside the repository root had no stated way to report it privately.

The file states the trust boundaries so a reporter has something concrete to say is broken:

- model output is untrusted input, not instructions
- writes stay inside the `--repo` root; an escape through a symlink, rename destination or `..` is in scope
- Docker isolation is in scope; the subprocess fallback is a documented limitation
- keys masked in `--verbose` output; an unmasked key shape is in scope, and the pattern list is what is most likely to fall behind
- `--clean` and `--undo` remove only what matches the tool's own shapes

### One correction I made to my own draft

The first version said `--strict-docker` refuses the unsandboxed fallback. **That flag does not exist** — `DockerSandbox` accepts `strict=True` internally and it is not wired to the CLI. I checked every claim in the file against `--help` before shipping it, which is how I caught it.

The policy now says plainly that there is no way to refuse the fallback, and lists that as a gap. A SECURITY.md making a false safety claim is worse than not having one.

## Verified

- every flag and module named in `SECURITY.md` confirmed to exist
- `npx prettier --check` clean on both markdown files
- all six import-guard checks green

Documentation and metadata only — no code changes.