### PR TITLE
fix(rules): close the file handle when reading .agentcontext — Closes #283

### DIFF
--- a/modules/project_rules.py
+++ b/modules/project_rules.py
@@ -48,7 +48,8 @@ def load_project_rules(
         return None
 
     try:
-        text = open(path, "r", encoding="utf-8", errors="replace").read()
+        with open(path, "r", encoding="utf-8", errors="replace") as handle:
+            text = handle.read()
     except OSError as exc:
         _LOG.warning("could not read %s: %s", path, exc)
         return None


### PR DESCRIPTION
Closes #283

`modules/project_rules.py:51`:

```python
text = open(path, "r", encoding="utf-8", errors="replace").read()
```

No context manager. The handle is closed when the temporary file object is collected, which on CPython is immediately after `.read()` returns — so this works today and will keep working on CPython. It is not guaranteed by the language, and this runs once per iteration of every run.

```python
with open(path, "r", encoding="utf-8", errors="replace") as handle:
    text = handle.read()
```

## Why it is worth a PR

Small, but this was the only place in `modules/` that did it — every other read already uses `with`. The inconsistency is the argument: someone reading this file learns a pattern that is wrong everywhere else in the codebase.

`ruff` flags it under `SIM115` if that rule set is ever enabled, and a grep for `= open(` outside a `with` now returns nothing.

The surrounding `try/except OSError` is unchanged.

## Verified

- no unclosed handles remain in `modules/`
- `test_project_rules` and `test_agentcontext` pass
- all six import-guard checks green