### PR TITLE
fix(config): correct --config precedence, type checking and unknown keys — Closes #279, #281, #287

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import sys
 
@@ -28,7 +29,7 @@ from modules.task_source import (
 )
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args() -> tuple[argparse.Namespace, argparse.ArgumentParser]:
     parser = argparse.ArgumentParser(
         description="Autonomous AI Developer Agent",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -225,7 +226,10 @@ Examples:
                              "committing. Ignored when --yes is set or CI=true.")
 
 
-    return parser.parse_args()
+    # The parser comes back too. Merging a config file needs to know what each
+    # flag's default actually is and what type it declares, and neither is
+    # recoverable from the Namespace alone.
+    return parser.parse_args(), parser
 
 
 def write_github_output(outputs: dict[str, str]):
@@ -319,8 +323,98 @@ def _report_expected_error(error) -> None:
     sys.exit(1)
 
 
+def apply_config_file(
+    path: str,
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> None:
+    """
+    Merge a config file into the parsed arguments.
+
+    Precedence is defaults, then the config file, then the command line. That
+    is the order every other tool uses, and the previous implementation got it
+    wrong in both directions.
+
+    It guarded each key with
+
+        getattr(args, k) in (None, "anthropic", "claude-sonnet-4-20250514", False)
+
+    trying to express "apply this only where the user did not pass a flag".
+    argparse does not record whether a value came from the command line or from
+    `default=`, so that guard approximated the question by comparing against
+    four literals -- and the approximation failed both ways.
+
+    Fourteen settings could never be configured, because their defaults are not
+    in that tuple: timeout, max_iter, workers, runner, base_branch, log_dir and
+    others. A config file setting them did nothing, silently.
+
+    And a config value could beat an explicit flag: "anthropic" is in the tuple,
+    so `--provider anthropic --config c.json` with `{"provider": "openai"}` ran
+    against OpenAI. The file won over the command line.
+
+    Comparing against the parser's own defaults answers the question the old
+    guard was approximating, for every flag, without a list of literals to keep
+    in step.
+    """
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            config_data = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"Warning: failed to load config file {path}: {exc}", file=sys.stderr)
+        return
+
+    if not isinstance(config_data, dict):
+        print(
+            f"Warning: config file {path} must contain a JSON object, "
+            f"found {type(config_data).__name__}; ignoring it",
+            file=sys.stderr,
+        )
+        return
+
+    actions = {action.dest: action for action in parser._actions if action.dest != "help"}
+    defaults = {dest: action.default for dest, action in actions.items()}
+
+    for key, value in config_data.items():
+        action = actions.get(key)
+
+        # An unknown key was previously dropped in silence, so a typo was
+        # indistinguishable from a setting the build does not support -- both
+        # produced no output at all. A warning rather than an error, since a
+        # config shared across versions may carry a key an older build predates.
+        if action is None:
+            print(
+                f"Warning: config file key '{key}' matches no option, ignoring",
+                file=sys.stderr,
+            )
+            continue
+
+        # The command line wins. A value differing from the parser's default is
+        # one the user supplied, which is the question the old literal tuple was
+        # trying and failing to answer.
+        if getattr(args, key, None) != defaults[key]:
+            continue
+
+        # Coerce through the flag's own type. Without this a string reaches a
+        # field the loop uses as an integer, and the failure surfaces as a
+        # TypeError several hundred lines away with no mention of the file or
+        # the key that caused it.
+        if action.type is not None and value is not None:
+            try:
+                value = action.type(value)
+            except (TypeError, ValueError):
+                print(
+                    f"Warning: config file key '{key}' should be "
+                    f"{getattr(action.type, '__name__', action.type)}, "
+                    f"found {value!r}; ignoring it",
+                    file=sys.stderr,
+                )
+                continue
+
+        setattr(args, key, value)
+
+
 def main():
-    args = parse_args()
+    args, parser = parse_args()
 
     if args.tasks:
         sys.exit(_run_task_batch(args))
@@ -337,15 +431,7 @@ def main():
     # Configuration file support (#22)
     config_file = args.config or os.path.join(args.repo or ".", ".repopilot.json")
     if os.path.exists(config_file):
-        try:
-            import json
-            with open(config_file, "r", encoding="utf-8") as f:
-                config_data = json.load(f)
-                for k, v in config_data.items():
-                    if hasattr(args, k) and getattr(args, k) in (None, "anthropic", "claude-sonnet-4-20250514", False):
-                        setattr(args, k, v)
-        except Exception as e:
-            print(f"Warning: Failed to load config file {config_file}: {e}", file=sys.stderr)
+        apply_config_file(config_file, args, parser)
 
 
     repo_root = os.path.abspath(args.repo)

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -1,0 +1,238 @@
+"""
+Tests for --config merging (main.py).
+
+The previous implementation guarded each key with
+
+    getattr(args, k) in (None, "anthropic", "claude-sonnet-4-20250514", False)
+
+trying to express "apply this only where the user did not pass a flag".
+argparse does not record where a value came from, so that guard approximated
+the question by comparing against four literals — and failed both ways.
+
+Fourteen settings could never be configured, because their defaults are not in
+that tuple. And a config value could beat an explicit flag, because "anthropic"
+is in it, so `--provider anthropic` was indistinguishable from the default.
+"""
+
+import argparse
+import contextlib
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import main as cli  # noqa: E402
+
+
+@pytest.fixture
+def parser():
+    """The real parser, captured by intercepting parse_args."""
+    real = argparse.ArgumentParser.parse_args
+    captured = {}
+
+    def spy(self, *args, **kwargs):
+        captured["parser"] = self
+        raise SystemExit(0)
+
+    argparse.ArgumentParser.parse_args = spy
+    try:
+        with contextlib.suppress(SystemExit), contextlib.redirect_stdout(io.StringIO()):
+            cli.main()
+    finally:
+        argparse.ArgumentParser.parse_args = real
+
+    return captured["parser"]
+
+
+@pytest.fixture
+def apply(parser, tmp_path, capsys):
+    """Write a config, apply it to a fresh namespace, return (args, stderr)."""
+    def run(config, argv=("--repo", ".", "--task", "t")):
+        path = tmp_path / "config.json"
+        path.write_text(json.dumps(config) if not isinstance(config, str) else config)
+        args = parser.parse_args(list(argv))
+        cli.apply_config_file(str(path), args, parser)
+        return args, capsys.readouterr().err
+
+    return run
+
+
+# ── settings that could never be configured ───────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "key,value,default",
+    [
+        ("max_iter", 7, 5),
+        ("workers", 3, 10),
+        ("timeout", 600, 120),
+        ("runner", "make", "pytest"),
+        ("base_branch", "develop", "main"),
+        ("branch_prefix", "bot", "agent"),
+        ("log_dir", "mylogs", "logs"),
+        ("max_parallel_tasks", 8, 4),
+    ],
+)
+def test_a_non_falsy_default_can_now_be_configured(apply, key, value, default):
+    """
+    Each of these has a default outside the old literal tuple, so a config file
+    setting it did nothing at all — silently.
+    """
+    args, _ = apply({key: value})
+
+    assert getattr(args, key) == value, f"{key} stayed at {default}"
+
+
+def test_a_falsy_default_still_works(apply):
+    """The cases the old guard did handle must keep working."""
+    args, _ = apply({"verbose_payloads": True})
+
+    assert args.verbose_payloads is True
+
+
+# ── precedence ────────────────────────────────────────────────────────────
+
+
+def test_the_command_line_beats_the_config(apply):
+    """
+    An explicit flag differing from the default must win. Under the old guard
+    a config value could beat one, because the guard compared against literals
+    rather than against what the parser would have produced.
+    """
+    args, _ = apply(
+        {"provider": "gemini"},
+        argv=("--repo", ".", "--task", "t", "--provider", "openai"),
+    )
+
+    assert args.provider == "openai"
+
+
+def test_the_config_beats_the_default(apply):
+    """The other half of the precedence: defaults lose to the file."""
+    args, _ = apply({"provider": "openai"})
+
+    assert args.provider == "openai"
+
+
+def test_an_explicit_flag_matching_a_default_is_still_respected(apply):
+    """
+    Passing --runner pytest explicitly is the same value as the default, so
+    this is the one case the parser genuinely cannot distinguish. Documented
+    rather than claimed as fixed: the config wins here.
+    """
+    args, _ = apply(
+        {"runner": "make"},
+        argv=("--repo", ".", "--task", "t", "--runner", "pytest"),
+    )
+
+    assert args.runner == "make"
+
+
+# ── wrong types ───────────────────────────────────────────────────────────
+
+
+def test_a_wrong_type_is_reported_and_ignored(apply):
+    """
+    Previously the string reached AgentConfig and the failure surfaced as a
+    TypeError inside the iteration loop, mentioning neither the file nor the key.
+    """
+    args, err = apply({"max_iter": "not a number"})
+
+    assert args.max_iter == 5
+    assert "max_iter" in err and "int" in err
+
+
+def test_a_coercible_value_is_coerced(apply):
+    """JSON has no int/float distinction the way argparse does."""
+    args, _ = apply({"max_iter": "7"})
+
+    assert args.max_iter == 7
+
+
+def test_one_bad_key_does_not_stop_the_others(apply):
+    args, _ = apply({"max_iter": "nonsense", "workers": 3})
+
+    assert args.max_iter == 5
+    assert args.workers == 3
+
+
+# ── unknown keys ──────────────────────────────────────────────────────────
+
+
+def test_an_unknown_key_is_reported(apply):
+    """
+    Silence made a typo indistinguishable from a setting the build does not
+    support, and both needed completely different fixes.
+    """
+    _, err = apply({"max_iteration": 7})
+
+    assert "max_iteration" in err
+    assert "matches no option" in err
+
+
+def test_an_unknown_key_is_a_warning_not_an_error(apply):
+    """A config shared across versions may carry a key an older build predates."""
+    args, _ = apply({"future_setting": 1, "workers": 3})
+
+    assert args.workers == 3
+
+
+# ── malformed files ───────────────────────────────────────────────────────
+
+
+def test_invalid_json_is_reported(apply):
+    _, err = apply("{not json")
+
+    assert "failed to load" in err.lower()
+
+
+def test_a_non_object_config_is_refused(apply):
+    """A list would iterate as keys and produce nonsense warnings."""
+    args, err = apply([1, 2, 3])
+
+    assert "JSON object" in err
+    assert args.workers == 10
+
+
+def test_a_malformed_file_does_not_stop_the_run(apply):
+    """A bad config should not be fatal; defaults are a usable fallback."""
+    args, _ = apply("{not json")
+
+    assert args.max_iter == 5
+
+
+# ── the mechanism ─────────────────────────────────────────────────────────
+
+
+def test_the_literal_tuple_is_gone():
+    """
+    The specific construct that caused both failures. Its absence is what this
+    change is; a future refactor reintroducing it would reintroduce both bugs.
+    """
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+
+    # Checked against the code rather than the whole file: the replacement
+    # quotes the old guard in its docstring to explain what went wrong, and
+    # matching prose would make this pass or fail on wording.
+    code = "\n".join(
+        line for line in source.splitlines()
+        if not line.strip().startswith(("#", "*"))
+    )
+    guard = 'if hasattr(args, k) and getattr(args, k) in ('
+
+    assert guard not in code
+
+
+def test_parse_args_returns_the_parser():
+    """
+    Merging needs each flag's default and declared type, and neither is
+    recoverable from the Namespace alone.
+    """
+    source = (ROOT / "main.py").read_text(encoding="utf-8")
+
+    assert "return parser.parse_args(), parser" in source


### PR DESCRIPTION
Closes #279 (precedence), #281 (type confusion), #287 (unknown keys)

All three live in the same twelve lines of `main.py`, so they are fixed together.

## The guard could not answer the question it was asking

```python
for k, v in config_data.items():
    if hasattr(args, k) and getattr(args, k) in (None, "anthropic", "claude-sonnet-4-20250514", False):
        setattr(args, k, v)
```

It was trying to express "apply this only where the user did not pass a flag". argparse does not record whether a value came from the command line or from `default=`, so the guard approximated that by comparing against four literals — and the approximation failed in both directions.

**Fourteen settings could never be configured**, because their defaults are not in the tuple:

```
max_parallel_tasks  runner            run_file_runner   coverage_source
run_pre_commit      lint_args         timeout           max_iter
workers             base_branch       branch_prefix     project_rules_file
log_dir             backup_dir
```

`timeout` and `max_iter` are two of the most likely reasons to reach for a config file at all. Setting them did nothing, silently.

**And a config value could beat an explicit flag.** `"anthropic"` is in the tuple, so `--provider anthropic --config c.json` with `{"provider": "openai"}` ran against OpenAI. The file won over the command line, which is the reverse of the precedence every other tool uses.

## The fix

Compare against the parser's own defaults, which is the question the literals were approximating:

```
setting        before       after
max_iter       5            7
workers        10           3
timeout        120          600
runner         pytest       make
base_branch    main         develop
log_dir        logs         mylogs
```

Precedence is now defaults → config file → command line, stated explicitly rather than inferred from a list of values that has to be kept in step with the defaults.

`parse_args()` returns the parser alongside the namespace, because merging needs each flag's default and its declared type and neither is recoverable from the `Namespace`.

## Wrong types are reported, not crashed on

```bash
echo '{"max_iter": "not a number"}' > c.json
```

Before, the string reached `AgentConfig` — dataclass annotations are not enforced at runtime — and surfaced as `TypeError: can only concatenate str (not "int") to str` inside the iteration loop, mentioning neither the file nor the key. That is #281.

Now:

```
Warning: config file key 'max_iter' should be int, found 'not a number'; ignoring it
```

Values are coerced through the flag's declared `type`, so `{"max_iter": "7"}` works — JSON does not distinguish int from float the way argparse does.

## Unknown keys are reported

```
Warning: config file key 'max_iteration' matches no option, ignoring
```

A warning rather than an error, since a config shared across versions may carry a key an older build predates. But it has to be visible: silence made a typo indistinguishable from a setting the build cannot apply, and those needed completely different fixes. That is #287.

A config file that is valid JSON but not an object is also refused rather than iterated as keys.

## One limitation, stated rather than hidden

Passing a flag whose value equals its default — `--runner pytest` — is still indistinguishable from not passing it, so the config wins there. That is inherent to argparse without `SUPPRESS` defaults, and there is a test documenting it rather than a claim that it is fixed.

## Tests

`tests/test_config_file.py` — 22 cases.

Previously-unreachable settings: eight of the fourteen, parametrised; a falsy default still works.

Precedence: the command line beats the config; the config beats the default; the flag-equals-default case is documented.

Types: a wrong type is reported and ignored; a coercible value is coerced; one bad key does not stop the others.

Unknown keys: reported; a warning rather than an error.

Malformed files: invalid JSON is reported; a non-object is refused; neither stops the run.

The mechanism: the literal tuple is gone; `parse_args` returns the parser.

## Verified

- the before/after table above, against a real parser and namespace
- all four warning paths through the CLI
- full suite: 1344 passing, no failures
- all six import-guard checks green