### PR TITLE
fix(cli): reject negative and zero values for numeric flags — Closes #280

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ Examples:
                         help="Run several tasks concurrently, each in its own git "
                              "worktree on its own branch. Implies isolation, so "
                              "tasks may touch the same files.")
-    parser.add_argument("--max-parallel-tasks", type=int, default=4, metavar="N",
+    parser.add_argument("--max-parallel-tasks", type=positive_int, default=4, metavar="N",
                         help="How many tasks to run at once (default: 4)")
 
     # Execution
@@ -91,20 +91,20 @@ Examples:
                              "to the model.")
     parser.add_argument("--lint-args", nargs="*", default=[],
                         help="Extra arguments for --lint")
-    parser.add_argument("--timeout", type=int, default=120,
+    parser.add_argument("--timeout", type=positive_int, default=120,
                         help="Execution timeout in seconds (default: 120)")
 
     # Loop control
     parser.add_argument("--plan-first", action="store_true",
                         help="Ask the model for an approach before it writes code. "
                              "Costs one extra API call on the first iteration.")
-    parser.add_argument("--max-iter", type=int, default=5,
+    parser.add_argument("--max-iter", type=positive_int, default=5,
                         help="Maximum number of agent iterations (default: 5)")
 
     # Parallel Processing
     parser.add_argument("--parallel", action="store_true",
                         help="Enable parallel file processing (ingestion and modification)")
-    parser.add_argument("--workers", type=int, default=10,
+    parser.add_argument("--workers", type=positive_int, default=10,
                         help="Number of worker threads for parallel processing (default: 10)")
 
     # Git
@@ -128,7 +128,7 @@ Examples:
                         help="Prefix for the auto-created branch name (default: agent)")
 
     # Context
-    parser.add_argument("--context-budget", type=int, default=None, metavar="CHARS",
+    parser.add_argument("--context-budget", type=positive_int, default=None, metavar="CHARS",
                         help="Characters of repository context to send. Derived "
                              "from the model's context window when not set.")
     parser.add_argument("--project-rules", dest="project_rules_file",
@@ -173,7 +173,7 @@ Examples:
     parser.add_argument("--clean", action="store_true",
                         help="Remove this tool's old logs and backups, then exit. "
                              "Only files it created are touched.")
-    parser.add_argument("--clean-older-than", type=float, default=None,
+    parser.add_argument("--clean-older-than", type=non_negative_float, default=None,
                         metavar="DAYS",
                         help="With --clean, keep anything newer than this.")
     parser.add_argument("--rollback",action="store_true",help="Undo the last agent run by popping the git stash.")
@@ -212,7 +212,7 @@ Examples:
                              "prompt and full prompt are identical. Off by "
                              "default: requests are not deterministic, so this "
                              "changes behaviour as well as saving money.")
-    parser.add_argument("--max-cost", type=float, default=None, metavar="USD",
+    parser.add_argument("--max-cost", type=positive_float, default=None, metavar="USD",
                         help="Stop before the next LLM call once this much has been "
                              "spent (e.g. --max-cost 1.00). Off by default.")
     parser.add_argument("--yes", "-y", action="store_true",
@@ -323,6 +323,58 @@ def _report_expected_error(error) -> None:
     sys.exit(1)
 
 
+def positive_int(text: str) -> int:
+    """
+    An integer of 1 or more.
+
+    Used on flags where zero or negative is not a weaker setting but a broken
+    one. `--workers 0` previously reached ThreadPoolExecutor and surfaced as an
+    unhandled `ValueError: max_workers must be greater than 0` from inside
+    concurrent.futures, naming a parameter the user never typed.
+
+    Raising from `type=` rather than checking after parsing is deliberate:
+    argparse prints the flag name alongside the message, which is exactly the
+    information those failures were missing.
+
+    These also apply to values coming from a config file, since #291 coerces
+    each one through its flag's declared type -- so a negative in a config is
+    now reported the same way as a negative on the command line.
+    """
+    value = int(text)
+    if value < 1:
+        raise argparse.ArgumentTypeError(f"must be 1 or greater, got {value}")
+    return value
+
+
+def positive_float(text: str) -> float:
+    """
+    A float greater than zero.
+
+    `--max-cost -1` previously stopped the run before its first request, with
+    "Spent $0.0000, which reaches the --max-cost limit of $-1.00" -- a message
+    about budgets, for what is an invalid argument. Zero is refused for the
+    same reason: a limit of nothing is not a limit, it is a run that cannot
+    start.
+    """
+    value = float(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"must be greater than 0, got {value}")
+    return value
+
+
+def non_negative_float(text: str) -> float:
+    """
+    A float of zero or more.
+
+    Zero is meaningful here -- `--clean-older-than 0` is a reasonable way to
+    say "everything" -- so only negatives are refused.
+    """
+    value = float(text)
+    if value < 0:
+        raise argparse.ArgumentTypeError(f"must be 0 or greater, got {value}")
+    return value
+
+
 def apply_config_file(
     path: str,
     args: argparse.Namespace,
@@ -401,7 +453,12 @@ def apply_config_file(
         if action.type is not None and value is not None:
             try:
                 value = action.type(value)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, argparse.ArgumentTypeError):
+                # ArgumentTypeError is included deliberately: the validators
+                # added for #280 raise it rather than ValueError, and it
+                # inherits from Exception rather than from either of the other
+                # two. Without it a negative in a config file escaped as a
+                # traceback instead of the warning every other bad value gets.
                 print(
                     f"Warning: config file key '{key}' should be "
                     f"{getattr(action.type, '__name__', action.type)}, "

--- a/tests/test_flag_validation.py
+++ b/tests/test_flag_validation.py
@@ -1,0 +1,232 @@
+"""
+Tests for numeric flag bounds (main.py).
+
+Seven numeric flags accepted anything argparse could convert. Two failed in
+ways that pointed away from the cause:
+
+`--max-cost -1` stopped the run before its first request with "Spent $0.0000,
+which reaches the --max-cost limit of $-1.00" — a message about budgets, for
+what is an invalid argument.
+
+`--workers 0` escaped as an unhandled `ValueError: max_workers must be greater
+than 0` from inside concurrent.futures, naming a parameter the user never typed.
+
+Validating in `type=` rather than after parsing is what puts the flag name in
+the message, which is the information both failures were missing.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import non_negative_float, positive_float, positive_int  # noqa: E402
+
+
+def cli(*flags):
+    """Run the CLI and return combined output."""
+    result = subprocess.run(
+        [sys.executable, "main.py", "--repo", ".", "--task", "t", "--context-only", *flags],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+    return result.stdout + result.stderr
+
+
+# ── the validators ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("text,expected", [("1", 1), ("10", 10), ("9999", 9999)])
+def test_positive_int_accepts_one_and_above(text, expected):
+    assert positive_int(text) == expected
+
+
+@pytest.mark.parametrize("text", ["0", "-1", "-100"])
+def test_positive_int_refuses_zero_and_below(text):
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_int(text)
+
+
+@pytest.mark.parametrize("text,expected", [("0.01", 0.01), ("1.5", 1.5), ("100", 100.0)])
+def test_positive_float_accepts_above_zero(text, expected):
+    assert positive_float(text) == pytest.approx(expected)
+
+
+@pytest.mark.parametrize("text", ["0", "0.0", "-0.01", "-5"])
+def test_positive_float_refuses_zero_and_below(text):
+    """A limit of nothing is not a limit; it is a run that cannot start."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        positive_float(text)
+
+
+def test_non_negative_float_accepts_zero():
+    """`--clean-older-than 0` is a reasonable way to say "everything"."""
+    assert non_negative_float("0") == 0.0
+
+
+def test_non_negative_float_refuses_negatives():
+    with pytest.raises(argparse.ArgumentTypeError):
+        non_negative_float("-1")
+
+
+def test_the_message_states_the_bound():
+    """Otherwise the user knows the value is wrong but not what would be right."""
+    with pytest.raises(argparse.ArgumentTypeError, match="1 or greater"):
+        positive_int("0")
+
+
+def test_the_message_includes_the_offending_value():
+    with pytest.raises(argparse.ArgumentTypeError, match="-5"):
+        positive_int("-5")
+
+
+def test_a_non_numeric_value_still_raises():
+    """Delegated to int()/float(); argparse catches ValueError the same way."""
+    with pytest.raises(ValueError):
+        positive_int("abc")
+
+
+# ── through the CLI ───────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "flag,value",
+    [
+        ("--max-cost", "-1"),
+        ("--max-cost", "0"),
+        ("--workers", "0"),
+        ("--timeout", "-10"),
+        ("--context-budget", "-100"),
+        ("--max-iter", "0"),
+        ("--clean-older-than", "-1"),
+    ],
+)
+def test_the_cli_refuses_an_invalid_value(flag, value):
+    output = cli(flag, value)
+
+    assert f"argument {flag}" in output, "the error should name the flag the user typed"
+    assert "must be" in output
+
+
+def test_the_budget_message_no_longer_masquerades_as_a_budget_problem():
+    """
+    The specific regression: `--max-cost -1` used to report reaching a limit,
+    which sends the reader to look at their spending rather than their command.
+    """
+    output = cli("--max-cost", "-1")
+
+    assert "Spent $0.0000" not in output
+    assert "argument --max-cost: must be greater than 0" in output
+
+
+def test_workers_zero_no_longer_leaks_a_thread_pool_error():
+    output = cli("--workers", "0")
+
+    assert "Traceback" not in output
+    assert "argument --workers: must be 1 or greater" in output
+
+
+@pytest.mark.parametrize(
+    "flags",
+    [
+        ("--max-cost", "1.5"),
+        ("--workers", "4"),
+        ("--timeout", "600"),
+        ("--max-iter", "1"),
+        ("--clean-older-than", "0"),
+        ("--context-budget", "50000"),
+    ],
+)
+def test_valid_values_are_still_accepted(flags):
+    """The bounds must not narrow what legitimately worked before."""
+    output = cli(*flags)
+
+    # Matched against argparse's own error shape rather than the words "must
+    # be": --context-only prints the compiled context, which now contains
+    # main.py including the validator docstrings that quote those words.
+    assert "error: argument" not in output
+    assert "Compiled context printed" in output
+
+
+# ── with the config file (#291) ───────────────────────────────────────────
+
+
+def _parser():
+    """The real parser, captured by intercepting parse_args."""
+    import argparse as ap
+    import contextlib
+    import io as _io
+
+    import main as cli
+
+    real = ap.ArgumentParser.parse_args
+    captured = {}
+
+    def spy(self, *args, **kwargs):
+        captured["parser"] = self
+        raise SystemExit(0)
+
+    ap.ArgumentParser.parse_args = spy
+    try:
+        with contextlib.suppress(SystemExit), contextlib.redirect_stdout(_io.StringIO()):
+            cli.main()
+    finally:
+        ap.ArgumentParser.parse_args = real
+    return captured["parser"]
+
+
+def _apply(tmp_path, config):
+    """Apply a config and return (args, stderr)."""
+    import contextlib
+    import io as _io
+    import json
+
+    import main as cli
+
+    path = tmp_path / "config.json"
+    path.write_text(json.dumps(config))
+    parser = _parser()
+    args = parser.parse_args(["--repo", ".", "--task", "t"])
+    err = _io.StringIO()
+    with contextlib.redirect_stderr(err):
+        cli.apply_config_file(str(path), args, parser)
+    return args, err.getvalue()
+
+
+def test_a_negative_in_a_config_is_reported_not_raised(tmp_path):
+    """
+    #291 coerces config values through each flag's declared type. These
+    validators raise ArgumentTypeError, which inherits from Exception rather
+    than from TypeError or ValueError — so without widening that handler, a
+    negative in a config file escaped as a traceback instead of a warning.
+    """
+    args, err = _apply(tmp_path, {"workers": -5})
+
+    assert "workers" in err
+    assert args.workers == 10
+
+
+def test_a_negative_float_in_a_config_is_reported(tmp_path):
+    args, err = _apply(tmp_path, {"max_cost": -1})
+
+    assert "max_cost" in err
+    assert args.max_cost is None
+
+
+def test_a_valid_config_value_still_applies(tmp_path):
+    """The bounds must not stop legitimate config values working."""
+    args, err = _apply(tmp_path, {"timeout": 600})
+
+    assert args.timeout == 600
+    assert err == ""
+
+
+def test_one_bad_config_value_does_not_stop_the_others(tmp_path):
+    args, _ = _apply(tmp_path, {"workers": -5, "timeout": 600})
+
+    assert args.workers == 10
+    assert args.timeout == 600


### PR DESCRIPTION
Closes #280

Seven numeric flags accepted anything argparse could convert. Two failed in ways that pointed away from the cause.

## `--max-cost -1` killed the run before it started

```
Spent $0.0000, which reaches the --max-cost limit of $-1.00.
```

`_check_budget` runs before the first request and finds `0.0 >= -1.0`, so the run stopped having done nothing. The message describes a budget being reached — someone seeing it checks their spending, not their command line.

## `--workers 0` escaped as a raw ValueError

```
ValueError: max_workers must be greater than 0
```

Unhandled, from inside `concurrent.futures`, naming a parameter the user never typed. Nothing connected it to `--workers`.

## After

```
argument --max-cost: must be greater than 0, got -1.0
argument --workers: must be 1 or greater, got 0
argument --timeout: must be 1 or greater, got -10
argument --context-budget: must be 1 or greater, got -100
argument --max-iter: must be 1 or greater, got 0
argument --clean-older-than: must be 0 or greater, got -1.0
```

## Why the validators live in `type=`

Checking after parsing would produce the same rejection with a worse message. argparse prints the flag name alongside anything raised from `type=`, and the flag name is exactly the information both original failures were missing.

Three validators rather than one, because the bounds genuinely differ:

- `positive_int` — 1 or more, for counts and durations where zero is not a weaker setting but a broken one
- `positive_float` — above zero, for `--max-cost`; a limit of nothing is a run that cannot start
- `non_negative_float` — zero or more, for `--clean-older-than`, where zero meaning "everything" is a reasonable request

Non-numeric input still raises through `int()`/`float()`, which argparse already handles.

## Tests

`tests/test_flag_validation.py` — 33 cases.

The validators: each accepts its valid range and refuses the rest, parametrised; the message states the bound and includes the offending value; a non-numeric value still raises.

Through the CLI: seven invalid combinations are refused and each names its flag; the budget message no longer masquerades as a budget problem; `--workers 0` no longer leaks a thread-pool error; six valid values are still accepted, so the bounds do not narrow what worked before.

## Verified

- every rejection and acceptance above, through the real CLI
- full suite: 1355 passing
- all six import-guard checks green

## Note

Touches `main.py`, as does #279's PR. Built on `main` rather than on that branch, so whichever merges second may want a rebase — happy to do it.