### PR TITLE
fix(docker): run the agent as a non-root user — Closes #299

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,23 @@ COPY . .
 # Ensure the entrypoint is executable
 RUN chmod +x main.py
 
+# Run as a non-root user.
+#
+# This image exists to run model-authored code and a project's test suite, both
+# of which are untrusted input executed inside the container. As root, anything
+# escaping the Python process has root in the container, and a bind-mounted
+# repository -- the normal way this is used -- is writable as root.
+#
+# Placed after pip install so dependencies still install system-wide, and after
+# chmod so that still runs as root.
+#
+# The image is given ownership of /app so a run can write logs and backups. A
+# mounted repository still belongs to the host user, so pass
+# `--user $(id -u):$(id -g)` when your uid is not 1000 -- that also stops the
+# agent leaving root-owned files behind on your machine.
+RUN useradd --create-home --uid 1000 agent \
+    && chown -R agent:agent /app
+USER agent
+
 # Entry command
 ENTRYPOINT ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -301,6 +301,22 @@ Pops the git stash taken before the changes were applied.
 
 ---
 
+## Running in Docker
+
+```bash
+docker build -t repopilot .
+docker run --rm \
+  -v "$PWD:/repo" \
+  --user "$(id -u):$(id -g)" \
+  -e ANTHROPIC_API_KEY \
+  repopilot --repo /repo --task "Fix the parser"
+```
+
+The image runs as a non-root user (uid 1000), because it executes
+model-authored code and your project's test suite. Pass `--user` when your host
+uid differs from 1000 — that lets the agent write to the mounted repository and
+stops it leaving root-owned files behind.
+
 ## Flag reference
 
 Every flag `python main.py --help` accepts, grouped by what it affects.


### PR DESCRIPTION
Closes #299

The `Dockerfile` had no `USER` directive, so the entrypoint ran as root.

This image exists to run model-authored code and a project's test suite — both untrusted input, executed inside the container by design. As root, anything escaping the Python process has root in the container, and a bind-mounted repository (the normal way this is used) is writable as root.

There is also a mundane cost: files the agent creates end up owned by root on the host, which anyone who has hit it will recognise.

## The change

```dockerfile
RUN useradd --create-home --uid 1000 agent \
    && chown -R agent:agent /app
USER agent
```

Placed after `pip install` so dependencies still install system-wide, and after `chmod +x main.py` so that still runs as root. Verified:

```
 8  RUN pip install
 9  COPY . .
10  RUN chmod
13  USER agent
14  ENTRYPOINT
```

`/app` is chowned so a run can still write logs and backups inside the container.

## The mounted-repository case

A mounted repository still belongs to the host user, so the README now documents the standard answer:

```bash
docker run --rm \
  -v "$PWD:/repo" \
  --user "$(id -u):$(id -g)" \
  -e ANTHROPIC_API_KEY \
  repopilot --repo /repo --task "Fix the parser"
```

`--user` makes the container write as you, which both fixes the permission problem when your uid is not 1000 and stops the agent leaving root-owned files behind. There was no Docker section in the README at all before this.

## Verified

- directive ordering, checked programmatically rather than by eye
- `npx prettier --check README.md` clean
- no Python changes, so the suite is unaffected

## Note

I have not run a build here — no Docker daemon in my environment. The Dockerfile is otherwise unchanged, and the two added directives are standard, but a `docker build` before merging would be worth it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Docker containers now run as a non-root user for improved security.

* **Documentation**
  * Added instructions for building and running the project in Docker.
  * Documented API key configuration, repository mounting, user ID matching, and parser-fix tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->