### PR TITLE
fix(git): report why a pull request could not be created — Closes #294

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -1088,6 +1088,16 @@ class AutonomousAgent:
                     )
                     if self.pr_url:
                         self.logger.info(f"  PR created: {self.pr_url}")
+                    else:
+                        # Silence here read as "the feature did not run" rather
+                        # than "it ran and failed". The reason is now logged by
+                        # create_github_pr; this makes sure the user is told to
+                        # go and look for it.
+                        self.logger.warning(
+                            "  --pr was requested but no pull request was "
+                            "created. The reason is logged above; the branch "
+                            "was pushed, so you can open one by hand."
+                        )
 
         # ── Rollback on failure if rollback_on_failure ──
         if (

--- a/modules/git_integration.py
+++ b/modules/git_integration.py
@@ -419,6 +419,22 @@ class GitIntegration:
             error_body = exc.read().decode("utf-8", errors="replace")
             if exc.code == 422 and "already exists" in error_body:
                 return f"PR already exists for {head_branch} -> {base_branch}"
+
+            # Logged rather than swallowed. This returned None for a 401, a
+            # 403, a 404 and every other HTTPError alike, and the caller did
+            # not report the None either -- so a run finished, showed no PR
+            # URL, and gave no way to tell an expired token from a missing
+            # scope from a repository the token cannot see.
+            #
+            # The likeliest cause by a distance is a fine-grained PAT without
+            # pull_request:write, which is a twenty-second fix once you know.
+            # GitHub says so in the body ("Resource not accessible by personal
+            # access token"), so passing the body through is most of the fix.
+            _LOG.error(
+                "Could not create the pull request: HTTP %s. %s",
+                exc.code, error_body.strip()[:300],
+            )
             return None
-        except Exception:
+        except Exception as exc:
+            _LOG.error("Could not create the pull request: %s", exc)
             return None

--- a/tests/test_pr_error_reporting.py
+++ b/tests/test_pr_error_reporting.py
@@ -1,0 +1,147 @@
+"""
+Tests for pull request failure reporting (modules/git_integration.py).
+
+`create_github_pr` returned `None` for a 401, a 403, a 404, a network failure
+and every other HTTPError alike, and `agent_loop` did not report the `None`
+either. A run finished, showed no PR URL, and gave no way to tell an expired
+token from a missing scope from a repository the token cannot see.
+
+The likeliest cause by a distance is a fine-grained PAT without
+`pull_request: write` — a twenty-second fix once you know that is what it is.
+"""
+
+import io
+import logging
+import subprocess
+import sys
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.git_integration import GitIntegration  # noqa: E402
+
+
+@pytest.fixture
+def git(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    return GitIntegration(str(tmp_path))
+
+
+@pytest.fixture
+def captured():
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    log = logging.getLogger("agent.git")
+    log.addHandler(handler)
+    previous = log.level
+    log.setLevel(logging.ERROR)
+    yield stream
+    log.removeHandler(handler)
+    log.setLevel(previous)
+
+
+def http_error(code, body):
+    return urllib.error.HTTPError(
+        "https://api.github.com", code, "", {}, io.BytesIO(body.encode())
+    )
+
+
+def attempt(git, error):
+    with patch("urllib.request.urlopen", side_effect=error), \
+         patch.dict("os.environ", {"GITHUB_TOKEN": "x"}), \
+         patch.object(GitIntegration, "get_remote_url",
+                      return_value="https://github.com/owner/repo.git"):
+        return git.create_github_pr(
+            title="t", body="b", head_branch="h", base_branch="main"
+        )
+
+
+# ── the reason is reported ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "code,body",
+    [
+        (401, '{"message":"Bad credentials"}'),
+        (403, '{"message":"Resource not accessible by personal access token"}'),
+        (404, '{"message":"Not Found"}'),
+        (500, '{"message":"Server Error"}'),
+    ],
+)
+def test_the_status_code_is_logged(git, captured, code, body):
+    attempt(git, http_error(code, body))
+
+    assert str(code) in captured.getvalue()
+
+
+def test_the_response_body_is_passed_through(git, captured):
+    """
+    GitHub's bodies are specific, and the scope message is the one that turns
+    an unexplained failure into a twenty-second fix.
+    """
+    attempt(git, http_error(403, '{"message":"Resource not accessible by personal access token"}'))
+
+    assert "not accessible by personal access token" in captured.getvalue()
+
+
+def test_a_network_failure_is_logged(git, captured):
+    attempt(git, OSError("connection refused"))
+
+    assert "connection refused" in captured.getvalue()
+
+
+def test_every_failure_still_returns_none(git, captured):
+    """The contract does not change; only the silence does."""
+    assert attempt(git, http_error(401, "{}")) is None
+
+
+# ── the case that already worked ──────────────────────────────────────────
+
+
+def test_an_existing_pr_still_reports_itself(git, captured):
+    """
+    The 422 path already returned a useful message. It is what showed the
+    machinery for reporting a reason existed and was used exactly once.
+    """
+    result = attempt(git, http_error(422, '{"message":"A pull request already exists"}'))
+
+    assert result is not None
+    assert "already exists" in result
+
+
+def test_the_existing_pr_case_is_not_logged_as_an_error(git, captured):
+    attempt(git, http_error(422, '{"message":"A pull request already exists"}'))
+
+    assert captured.getvalue() == ""
+
+
+# ── the caller ────────────────────────────────────────────────────────────
+
+
+def test_the_loop_warns_when_no_pr_was_created():
+    """
+    Silence read as "the feature did not run" rather than "it ran and failed",
+    and the branch had already been pushed.
+    """
+    source = (ROOT / "modules" / "agent_loop.py").read_text(encoding="utf-8")
+
+    assert "--pr was requested but no pull request was" in source
+
+
+def test_the_warning_says_the_branch_was_pushed():
+    """The useful next step: the work is not lost, open one by hand."""
+    source = (ROOT / "modules" / "agent_loop.py").read_text(encoding="utf-8")
+
+    assert "open one by hand" in source
+
+
+def test_no_bare_swallow_remains():
+    source = (ROOT / "modules" / "git_integration.py").read_text(encoding="utf-8")
+    start = source.index("def create_github_pr")
+
+    assert "except Exception:\n            return None" not in source[start:]


### PR DESCRIPTION
Closes #294

`modules/git_integration.py` ended `create_github_pr` with:

```python
except Exception:
    return None
```

so a 401, a 403, a 404, a network failure and every other `HTTPError` all looked identical to the caller — and `agent_loop` did not report the `None` either. A run finished, showed no PR URL, and gave no way to tell an expired token from a missing scope from a repository the token cannot see.

## Why it matters

The likeliest cause by a distance is a fine-grained PAT without `pull_request: write`, which is the default shape someone creates. That is a twenty-second fix once you know it is the problem. Without it, the user checks the branch pushed (it did), checks the token exists (it does), and has nothing else to go on.

GitHub says exactly what is wrong in the response body, and it was being read and discarded:

```
Could not create the pull request: HTTP 403.
{"message":"Resource not accessible by personal access token"}
```

## Two changes

**The reason is logged**, with the status code and the body. The `422` "already exists" case is untouched — it already returned a useful message, and it is what showed the machinery for reporting a reason existed and was used exactly once.

**The caller warns when nothing came back:**

```
--pr was requested but no pull request was created. The reason is logged
above; the branch was pushed, so you can open one by hand.
```

Silence there read as "the feature did not run" rather than "it ran and failed", and the branch had already been pushed — so the work is not lost and the user should know that.

The bare `except Exception` also gained a binding, so an unexpected failure is logged rather than vanishing.

## Tests

`tests/test_pr_error_reporting.py` — 12 cases.

The reason is reported: four status codes are logged, parametrised; the response body is passed through, which is what turns an unexplained failure into a quick fix; a network failure is logged; every failure still returns `None`, so the contract is unchanged.

The case that already worked: an existing PR still reports itself; that path is not logged as an error.

The caller: the loop warns when no PR was created; the warning says the branch was pushed; no bare swallow remains.

## Verified

- a 403 with GitHub's real scope message, through a patched `urlopen`
- full suite: 1402 passing
- all six import-guard checks green