### PR TITLE
chore: point package.json metadata at this repository — Closes #300

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
   "name": "repopilot",
   "version": "1.0.0",
-  "description": "A production-grade autonomous code modification system that reads a repository,\r understands a task, modifies code using an LLM, executes tests in a sandbox,\r and iteratively self-corrects until tests pass — then commits the result to Git.",
-  "main": "index.js",
+  "description": "Autonomous code modification agent: reads a repository, modifies code with an LLM, runs the tests in a sandbox, and iterates until they pass.",
   "scripts": {
     "test": "python -m pytest",
     "format": "prettier --write .",
@@ -10,17 +9,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rohitkumarnaidu/repopilot.git"
+    "url": "git+https://github.com/sreerevanth/repopilot.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/rohitkumarnaidu/repopilot/issues"
+    "url": "https://github.com/sreerevanth/repopilot/issues"
   },
-  "homepage": "https://github.com/rohitkumarnaidu/repopilot#readme",
+  "homepage": "https://github.com/sreerevanth/repopilot#readme",
   "devDependencies": {
     "prettier": "^3.9.6"
-  }
+  },
+  "private": true
 }

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,74 @@
+"""
+Tests for package.json metadata.
+
+`repository`, `bugs` and `homepage` all pointed at `rohitkumarnaidu/repopilot`
+rather than this repository — leftovers from `npm init` in a fork. Nothing
+breaks, but `npm repo`, `npm bugs` and `npm docs` all send you to the wrong
+place, and Dependabot reads `repository` when it links its own pull requests.
+
+`main` claimed `index.js`, which does not exist. This is a Python project whose
+package.json exists only to pin prettier for CI.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+MANIFEST = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
+REPO = "sreerevanth/repopilot"
+
+
+@pytest.mark.parametrize("field", ["repository", "bugs", "homepage"])
+def test_the_urls_point_at_this_repository(field):
+    value = MANIFEST[field]
+    url = value["url"] if isinstance(value, dict) else value
+
+    assert REPO in url, f"{field} points elsewhere: {url}"
+
+
+def test_no_stale_fork_owner_remains():
+    """The specific value that was wrong, in every field at once."""
+    assert "rohitkumarnaidu" not in json.dumps(MANIFEST)
+
+
+def test_no_entry_point_is_claimed():
+    """`main: index.js` named a file that does not exist in a Python project."""
+    assert "main" not in MANIFEST
+    assert not (ROOT / "index.js").exists()
+
+
+def test_it_is_marked_private():
+    """
+    This manifest exists to pin prettier for CI, not to publish anything.
+    `private` makes an accidental `npm publish` fail rather than succeed.
+    """
+    assert MANIFEST["private"] is True
+
+
+# ── the part CI depends on ────────────────────────────────────────────────
+
+
+def test_prettier_is_pinned():
+    """
+    `.github/workflows/prettier.yml` runs `npm ci` then `npm run format:check`,
+    so a missing or unpinned prettier would fail the format job on a day the
+    upstream default changed rather than on anything in this repository.
+    """
+    assert "prettier" in MANIFEST["devDependencies"]
+
+
+def test_the_format_scripts_exist():
+    scripts = MANIFEST["scripts"]
+
+    assert scripts["format:check"].startswith("prettier --check")
+    assert scripts["format"].startswith("prettier --write")
+
+
+def test_the_lockfile_is_present():
+    """`npm ci` requires it and fails outright without one."""
+    assert (ROOT / "package-lock.json").exists()


### PR DESCRIPTION
Closes #300

## Correcting the issue first

#300 says there is no `package.json` and that Dependabot's `npm` block has no manifest to track. **That is wrong.** Both `package.json` and `package-lock.json` are tracked, prettier is pinned at `^3.9.6`, and the prettier workflow runs `npm ci` then `npm run format:check` — so Dependabot has a real manifest and the `npm` block belongs there.

I filed that without opening the file. I have left a correction on the issue rather than quietly changing what it says.

## What opening it did find

```json
"repository": { "url": "git+https://github.com/rohitkumarnaidu/repopilot.git" },
"bugs":       { "url": "https://github.com/rohitkumarnaidu/repopilot/issues" },
"homepage":   "https://github.com/rohitkumarnaidu/repopilot#readme",
"main":       "index.js"
```

Every URL points at a different fork — leftovers from `npm init` in someone else's copy. `npm repo`, `npm bugs` and `npm docs` all send you there, and Dependabot reads `repository` when it links its own pull requests.

`main: index.js` names a file that does not exist. This is a Python project; the manifest exists only to pin prettier for CI.

The `description` also carried literal `\r` escapes from a paste.

## The change

All three URLs corrected to `sreerevanth/repopilot`. `main` removed rather than pointed somewhere — there is no JavaScript entry point to name. `private: true` added, so an accidental `npm publish` fails rather than succeeding. Description rewritten without the escapes.

`devDependencies`, `scripts` and the lockfile are untouched — CI depends on those and they were already correct.

## Tests

`tests/test_package_metadata.py` — 9 cases.

The URLs: all three point at this repository, parametrised; no stale fork owner remains anywhere in the file.

The shape: no entry point is claimed, and `index.js` genuinely does not exist; it is marked private.

The part CI depends on: prettier is pinned, since the format job would otherwise fail on a day the upstream default changed rather than on anything in this repository; both format scripts exist; the lockfile is present, because `npm ci` fails outright without one.

## Verified

- `npx prettier --check package.json` clean
- full suite: 1399 passing