### PR TITLE
chore: inline the isinstance check so mypy can narrow it — Closes #295

### DIFF
--- a/modules/context_builder.py
+++ b/modules/context_builder.py
@@ -195,10 +195,17 @@ def extract_outline(source: str, path: str) -> Optional[str]:
             for child in node.body:
                 # Annotated fields are the whole point of a dataclass or a
                 # Protocol, so they belong in the outline alongside methods.
-                is_field = isinstance(child, ast.AnnAssign) and isinstance(
+                # Inlined rather than bound to `is_field` first. mypy narrows
+                # a type on an isinstance check written in the condition, not
+                # through a boolean variable -- so the bound form lost the
+                # narrowing and reported `"stmt" has no attribute "annotation"`
+                # and `... "target"` on the two lines below.
+                #
+                # The code was correct either way; this is the same check in
+                # the form a checker can follow.
+                if isinstance(child, ast.AnnAssign) and isinstance(
                     child.target, ast.Name
-                )
-                if is_field:
+                ):
                     annotation = ast.unparse(child.annotation)
                     body.append(f"    {child.target.id}: {annotation}")
                 elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):


### PR DESCRIPTION
Closes #295

`modules/context_builder.py` bound an `isinstance` check to a variable before testing it:

```python
is_field = isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name)
if is_field:
    annotation = ast.unparse(child.annotation)
    body.append(f"    {child.target.id}: {annotation}")
```

mypy narrows a type on an `isinstance` written in the condition, not through a boolean binding, so it lost the narrowing:

```
error: "stmt" has no attribute "annotation"  [attr-defined]
error: "stmt" has no attribute "target"      [attr-defined]
```

The code was correct either way. This is the same check in the form a checker can follow, with the reasoning recorded so it does not get refactored back.

## Result

```
before: Found 3 errors in 2 files
after:  Found 1 error in 1 file
```

The remaining one is `main.py:455`, `"str" not callable` — argparse's stubs type `action.type` as `str | Callable`, and mypy picks `str`. That is a stub limitation with no bug behind it, and the guard above the call already ensures it is callable. I have left it alone rather than restructure working code to satisfy a checker that is not in CI.

## Verified

- 61 tests across `test_ast_outlines`, `test_context_budget` and `test_context_only`
- full suite: 1390 passing
- all six import-guard checks green

No behaviour change.