### PR TITLE
fix(security): verify TLS certificates by default — Closes #293

### DIFF
--- a/main.py
+++ b/main.py
@@ -198,6 +198,12 @@ Examples:
     parser.add_argument("--provider", default="anthropic",
                         choices=["anthropic", "openai", "gemini", "ollama"],
                         help="LLM provider to use (default: anthropic)")
+    parser.add_argument("--insecure-tls", action="store_true",
+                        help="Skip TLS certificate verification for the OpenAI, "
+                             "Gemini and Ollama endpoints. For a self-signed "
+                             "local server only -- it allows anyone on the network "
+                             "path to read your API key and rewrite the model's "
+                             "response. Prefer SSL_CERT_FILE for a corporate CA.")
     parser.add_argument("--api-base-url", default=None,
                         help="Custom API base URL (for Ollama or self-hosted endpoints)")
 
@@ -489,6 +495,19 @@ def main():
     config_file = args.config or os.path.join(args.repo or ".", ".repopilot.json")
     if os.path.exists(config_file):
         apply_config_file(config_file, args, parser)
+
+    if args.insecure_tls:
+        # Printed every run rather than logged once. Someone who set this for a
+        # local Ollama server and forgot is otherwise running two public APIs
+        # unverified with nothing to remind them.
+        print(
+            "WARNING: --insecure-tls is set. Certificates are not verified for "
+            "OpenAI, Gemini or Ollama, so anyone on the network path can read "
+            "your API key and alter the model's response.",
+            file=sys.stderr,
+        )
+        set_insecure_tls(True)
+
 
 
     repo_root = os.path.abspath(args.repo)

--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -782,6 +782,43 @@ class AnthropicClient(BaseLLMClient):
             return _first_text_block(response.content)
 
 
+# Set by --insecure-tls. Off by default: the three urllib providers below
+# previously hard-coded `check_hostname = False` and `CERT_NONE`, which accepts
+# any certificate including a self-signed one and never matches the hostname.
+#
+# On the OpenAI and Gemini paths that is a public API over the internet, so an
+# attacker on the network path could read the API key from the Authorization
+# header, read the prompt -- which carries the user's source -- and rewrite the
+# response, which is code this tool then writes to disk and runs.
+#
+# The likely reason it was there is a local Ollama instance with a self-signed
+# certificate, or a corporate proxy with its own CA. Both are real, so the
+# capability stays; it is opt-in now, so the person disabling verification is
+# the person who decided to.
+_INSECURE_TLS = False
+
+
+def set_insecure_tls(enabled: bool) -> None:
+    """Enable or disable certificate verification for the urllib providers."""
+    global _INSECURE_TLS
+    _INSECURE_TLS = bool(enabled)
+
+
+def _tls_context() -> ssl.SSLContext:
+    """
+    A verifying TLS context, unless --insecure-tls was passed.
+
+    For a corporate CA the correct answer is `SSL_CERT_FILE` or
+    `create_default_context(cafile=...)`, both of which keep verification on --
+    this switch exists for the self-signed case where neither applies.
+    """
+    context = ssl.create_default_context()
+    if _INSECURE_TLS:
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+    return context
+
+
 class OpenAIClient(BaseLLMClient):
     def __init__(self, api_key: Optional[str] = None, model: str = "gpt-4o"):
         super().__init__(model)
@@ -808,9 +845,7 @@ class OpenAIClient(BaseLLMClient):
         }
         
         req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), headers=headers)
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        ctx = _tls_context()
 
         try:
             with urllib.request.urlopen(req, context=ctx) as response:
@@ -850,9 +885,7 @@ class GeminiClient(BaseLLMClient):
         }
 
         req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), headers=headers)
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        ctx = _tls_context()
 
         try:
             with urllib.request.urlopen(req, context=ctx) as response:
@@ -891,9 +924,7 @@ class OllamaClient(BaseLLMClient):
         }
 
         req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), headers=headers)
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        ctx = _tls_context()
 
         try:
             with urllib.request.urlopen(req, context=ctx) as response:

--- a/tests/test_tls_verification.py
+++ b/tests/test_tls_verification.py
@@ -1,0 +1,155 @@
+"""
+Tests for TLS verification (modules/llm_client.py).
+
+The OpenAI, Gemini and Ollama request paths each hard-coded:
+
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+which accepts any certificate, including a self-signed one, and never matches
+the hostname. Two of those three are public APIs reached over the internet.
+
+The consequence is worse here than a credential leak. An attacker on the
+network path could read the API key from the Authorization header, read the
+prompt — which carries the user's source — and rewrite the response, which is
+code this tool writes to disk and runs.
+"""
+
+import ssl
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.llm_client import _tls_context, set_insecure_tls  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset():
+    """Module-level state; leaking it would make other tests unverified."""
+    set_insecure_tls(False)
+    yield
+    set_insecure_tls(False)
+
+
+# ── the default ───────────────────────────────────────────────────────────
+
+
+def test_certificates_are_verified_by_default():
+    context = _tls_context()
+
+    assert context.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_the_hostname_is_checked_by_default():
+    """
+    Verification without hostname checking accepts any valid certificate for
+    any domain, which is most of the way to no verification at all.
+    """
+    assert _tls_context().check_hostname is True
+
+
+def test_no_provider_disables_verification_inline():
+    """
+    The three hard-coded sites are what this replaces. Their absence is the
+    change; a future provider copying the old pattern would reintroduce it.
+    """
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith("#")
+    )
+
+    assert "ctx.verify_mode = ssl.CERT_NONE" not in code
+    assert "ctx.check_hostname = False" not in code
+
+
+def test_every_provider_uses_the_shared_context():
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+
+    assert source.count("ctx = _tls_context()") == 3
+
+
+# ── the opt-out ───────────────────────────────────────────────────────────
+
+
+def test_insecure_tls_disables_verification():
+    """
+    The capability stays: a local Ollama with a self-signed certificate is a
+    real case. It is opt-in now, so the person disabling it decided to.
+    """
+    set_insecure_tls(True)
+    context = _tls_context()
+
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False
+
+
+def test_it_can_be_turned_back_off():
+    set_insecure_tls(True)
+    set_insecure_tls(False)
+
+    assert _tls_context().verify_mode == ssl.CERT_REQUIRED
+
+
+def test_each_call_returns_a_fresh_context():
+    """A shared context mutated by one provider would affect the others."""
+    assert _tls_context() is not _tls_context()
+
+
+# ── the CLI ───────────────────────────────────────────────────────────────
+
+
+def cli(*flags):
+    """Combined output."""
+    result = subprocess.run(
+        [sys.executable, "main.py", "--repo", ".", "--task", "t", "--context-only", *flags],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+    return result.stdout + result.stderr
+
+
+def cli_stderr(*flags):
+    """
+    stderr only. The warning is checked here rather than in combined output
+    because --context-only prints the compiled context, which now contains
+    main.py including the literal warning string.
+    """
+    return subprocess.run(
+        [sys.executable, "main.py", "--repo", ".", "--task", "t", "--context-only", *flags],
+        capture_output=True, text=True, cwd=ROOT,
+    ).stderr
+
+
+def test_the_flag_exists():
+    assert "--insecure-tls" in cli("--help")
+
+
+def test_using_it_warns():
+    """
+    Every run, not once. Someone who set it for a local server and forgot is
+    otherwise running two public APIs unverified with nothing to remind them.
+    """
+    output = cli_stderr("--insecure-tls")
+
+    assert "WARNING: --insecure-tls is set" in output
+
+
+def test_the_warning_says_what_is_at_risk():
+    """"Verification disabled" alone does not convey that the key is exposed."""
+    output = cli_stderr("--insecure-tls")
+
+    assert "API key" in output
+
+
+def test_a_normal_run_is_silent_about_tls():
+    assert "WARNING: --insecure-tls is set" not in cli_stderr()
+
+
+def test_the_help_text_names_the_safer_alternative():
+    """A corporate CA is the common reason to reach for this, and it has a
+    correct answer that keeps verification on."""
+    assert "SSL_CERT_FILE" in cli("--help")


### PR DESCRIPTION
Closes #293

## What was there

`modules/llm_client.py`, at three sites — the OpenAI, Gemini and Ollama request paths:

```python
ctx = ssl.create_default_context()
ctx.check_hostname = False
ctx.verify_mode = ssl.CERT_NONE
```

`create_default_context()` returns a correctly configured context, and the next two lines undo it. Any certificate is accepted, including a self-signed one, and the hostname is never matched against it.

Two of those three are public APIs reached over the internet.

## What it allowed

An attacker on the network path — untrusted Wi-Fi, a hostile proxy, a compromised router — could present their own certificate and be accepted silently. From there:

- **read the API key**, sent in the `Authorization` header on every request
- **read the prompt**, which carries the user's source code
- **rewrite the response**, which is code this tool writes to disk and runs

The third is what makes this more than a credential leak. The agent's entire purpose is to apply the response and commit it.

## The change

```python
ctx = _tls_context()
```

at all three sites. `_tls_context()` returns a verifying context:

```
default        : check_hostname=True   verify_mode=CERT_REQUIRED
--insecure-tls : check_hostname=False  verify_mode=CERT_NONE
```

## The capability is kept, but opt-in

The likely reason those lines existed is a local Ollama instance with a self-signed certificate, or a corporate proxy with its own CA. Both are real needs, so `--insecure-tls` keeps them working — the difference is that the person disabling verification is now the person who decided to.

It warns on **every** run that uses it:

```
WARNING: --insecure-tls is set. Certificates are not verified for OpenAI,
Gemini or Ollama, so anyone on the network path can read your API key and
alter the model's response.
```

Every run rather than once, because someone who set it for a local server and forgot is otherwise running two public APIs unverified with nothing to remind them. The warning names the API key specifically — "verification disabled" does not convey what is actually exposed.

The help text points at `SSL_CERT_FILE`, which is the correct answer for a corporate CA and keeps verification on.

## Scope

Anthropic is unaffected — it goes through the official SDK, which verifies normally. `create_github_pr` in `git_integration.py` also uses `urllib` and never disabled verification, so this was inconsistent within the codebase rather than a project-wide decision.

## Tests

`tests/test_tls_verification.py` — 12 cases.

The default: certificates are verified; the hostname is checked, since verification without it accepts any valid certificate for any domain; no provider disables verification inline; all three use the shared context.

The opt-out: it disables verification; it can be turned back off; each call returns a fresh context, so one provider cannot mutate another's.

The CLI: the flag exists; using it warns; the warning says what is at risk; a normal run is silent; the help text names the safer alternative.

## Verified

- the context table above, from the real function
- the warning present with the flag and absent without it
- full suite: 1402 passing
- all six import-guard checks green