### PR TITLE
chore(ci): declare read-only permissions on the guard and format jobs — Closes #352

### DIFF
--- a/.github/workflows/import-guard.yml
+++ b/.github/workflows/import-guard.yml
@@ -17,6 +17,18 @@ on:
 
 jobs:
   imports:
+    # Declared rather than inherited.
+    #
+    # agent-fix.yml scopes its own token; these two did not, so they took the
+    # repository default -- which for repositories created before 2023 is
+    # read/write on everything. Neither needs write: the guard job imports
+    # modules and runs --help, and the format job runs npm ci and a check.
+    #
+    # npm ci in particular executes lifecycle scripts from the lockfile, and on
+    # the push trigger that runs with a real token for this repository.
+    permissions:
+      contents: read
+
     # Windows is in the matrix because three Windows-only bugs reached main
     # this cycle and none was caught here: --update walking into an ancestor
     # repository, _discover_test_files emitting backslash paths that then broke

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -8,6 +8,18 @@ on:
 
 jobs:
   prettier:
+    # Declared rather than inherited.
+    #
+    # agent-fix.yml scopes its own token; these two did not, so they took the
+    # repository default -- which for repositories created before 2023 is
+    # read/write on everything. Neither needs write: the guard job imports
+    # modules and runs --help, and the format job runs npm ci and a check.
+    #
+    # npm ci in particular executes lifecycle scripts from the lockfile, and on
+    # the push trigger that runs with a real token for this repository.
+    permissions:
+      contents: read
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/tests/test_workflow_permissions.py
+++ b/tests/test_workflow_permissions.py
@@ -1,0 +1,63 @@
+"""
+Tests for GitHub Actions token scope (.github/workflows/).
+
+`agent-fix.yml` declared its own permissions; `import-guard.yml` and
+`prettier.yml` did not, so they inherited the repository default — which for
+repositories created before 2023 is read/write on everything.
+
+Neither needs write. The guard imports modules and runs `--help`; the format job
+runs `npm ci` and a check. `npm ci` executes lifecycle scripts from the
+lockfile, and on the `push` trigger that runs with a real token for this
+repository rather than the read-only one a fork PR receives.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def load(name):
+    return yaml.safe_load((WORKFLOWS / f"{name}.yml").read_text(encoding="utf-8"))
+
+
+def only_job(name):
+    return list(load(name)["jobs"].values())[0]
+
+
+@pytest.mark.parametrize("name", ["import-guard", "prettier", "agent-fix"])
+def test_every_workflow_declares_permissions(name):
+    """Inheriting means the scope depends on a repository setting nobody can
+    see from the code."""
+    assert "permissions" in only_job(name)
+
+
+@pytest.mark.parametrize("name", ["import-guard", "prettier"])
+def test_the_read_only_jobs_have_no_write(name):
+    permissions = only_job(name)["permissions"]
+
+    assert permissions == {"contents": "read"}
+
+
+def test_agent_fix_keeps_the_write_it_needs():
+    """It opens pull requests and comments on issues — narrowing it would
+    break the workflow."""
+    permissions = only_job("agent-fix")["permissions"]
+
+    assert permissions["contents"] == "write"
+    assert permissions["pull-requests"] == "write"
+
+
+@pytest.mark.parametrize("name", ["import-guard", "prettier", "agent-fix"])
+def test_the_workflow_still_parses_and_has_steps(name):
+    """A misplaced permissions block would silently detach the steps."""
+    job = only_job(name)
+
+    assert isinstance(job.get("steps"), list)
+    assert len(job["steps"]) >= 1


### PR DESCRIPTION
Closes #352

```
agent-fix      permissions={'contents': 'write', 'pull-requests': 'write', 'issues': 'write'}
import-guard   INHERITED (repository default)
prettier       INHERITED (repository default)
```

`agent-fix.yml` scopes its own token, so the practice is understood here. The other two took whatever the repository default is — which for repositories created before 2023, or where the org has not opted in, is read/write on everything.

Neither needs write. `import-guard` imports modules and runs `--help`. `prettier` runs `npm ci` and a format check.

## Why it is worth closing rather than leaving

`npm ci` executes lifecycle scripts from `package-lock.json`. A compromised transitive dependency gets whatever the token grants — and on the `push` trigger that is a real token for this repository, not the read-only one a fork PR receives.

`prettier.yml` already sets `persist-credentials: false` on its checkout, which is the same class of hardening. Declaring permissions is the other half of it.

## The change

```yaml
permissions:
  contents: read
```

on both jobs. After:

```
import-guard   {'contents': 'read'}
prettier       {'contents': 'read'}
agent-fix      {'contents': 'write', 'pull-requests': 'write', 'issues': 'write'}
```

`agent-fix` is untouched — it opens pull requests and comments on issues, so narrowing it would break the workflow.

## Tests

`tests/test_workflow_permissions.py` — 9 cases.

Every workflow declares permissions rather than inheriting; the two read-only jobs have exactly `{contents: read}`; `agent-fix` keeps the write it needs; and each workflow still parses with its steps attached — a misplaced `permissions` block would silently detach them, which is the failure mode worth pinning.

## Verified

- all three workflows parse under `yaml.safe_load` with steps intact
- full suite: 1443 passing

Setting the repository default to read-only would be worth doing too, but that is a settings change rather than a code one. These declarations make the workflows correct regardless of it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted repository workflow tokens to read-only contents access where write permissions are not required.
  * Preserved necessary write access for the automated fix workflow.

* **Tests**
  * Added validation to ensure workflows declare permissions, retain required access, and remain valid with executable steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->