### PR TITLE
fix(llm): report missing credentials as ConfigurationError — Closes #353

### DIFF
--- a/modules/llm_client.py
+++ b/modules/llm_client.py
@@ -749,10 +749,19 @@ class AnthropicClient(BaseLLMClient):
     def __init__(self, api_key: Optional[str] = None, model: str = MODEL):
         super().__init__(model)
         if not _ANTHROPIC_AVAILABLE:
-            raise RuntimeError("anthropic package not installed. Run: pip install anthropic")
+            raise ConfigurationError(
+                "The anthropic package is not installed. Run "
+                "`pip install -r requirements.txt`, or use --provider with a "
+                "provider that needs no SDK (openai, gemini and ollama all go "
+                "through urllib)."
+            )
         key = api_key or os.environ.get("ANTHROPIC_API_KEY")
         if not key:
-            raise ValueError("ANTHROPIC_API_KEY not set")
+            raise ConfigurationError(
+                "ANTHROPIC_API_KEY is not set. Export it before running, or pass "
+                "--provider with a provider whose key you have set. "
+                "See the README's configuration section for the full list."
+            )
         self.client = anthropic.Anthropic(api_key=key)
 
     def _call(self, prompt: str) -> str:
@@ -824,7 +833,11 @@ class OpenAIClient(BaseLLMClient):
         super().__init__(model)
         self.api_key = api_key or os.environ.get("OPENAI_API_KEY")
         if not self.api_key:
-            raise ValueError("OPENAI_API_KEY not set")
+            raise ConfigurationError(
+                "OPENAI_API_KEY is not set. Export it before running, or pass "
+                "--provider with a provider whose key you have set. "
+                "See the README's configuration section for the full list."
+            )
 
     def _call(self, prompt: str) -> str:
         print("  [Streaming LLM Response (OpenAI)]: ", end="", flush=True)
@@ -862,7 +875,11 @@ class GeminiClient(BaseLLMClient):
         super().__init__(model)
         self.api_key = api_key or os.environ.get("GEMINI_API_KEY")
         if not self.api_key:
-            raise ValueError("GEMINI_API_KEY not set")
+            raise ConfigurationError(
+                "GEMINI_API_KEY is not set. Export it before running, or pass "
+                "--provider with a provider whose key you have set. "
+                "See the README's configuration section for the full list."
+            )
 
     def _call(self, prompt: str) -> str:
         print("  [Streaming LLM Response (Gemini)]: ", end="", flush=True)

--- a/tests/test_api_key_errors.py
+++ b/tests/test_api_key_errors.py
@@ -1,0 +1,159 @@
+"""
+Tests for missing-credential reporting (modules/llm_client.py).
+
+Every provider raised a bare exception, so the two most common first-run
+mistakes produced a Python traceback into code the user did not write:
+
+    ValueError: ANTHROPIC_API_KEY not set
+    RuntimeError: anthropic package not installed. Run: pip install anthropic
+
+`ConfigurationError` was already imported at the top of that file and is an
+`AgentError`, so it reaches the handler added in #260 and prints a message with
+a remedy. These sites were simply not converted when that landed.
+
+Exercised against the client classes directly rather than through the CLI. An
+earlier version of this file ran `main.py --repo .` without `--no-git`, which
+made the agent create and check out a branch in the repository under test —
+the tests mutated the working tree they were running in.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules import llm_client  # noqa: E402
+from modules.errors import AgentError, ConfigurationError  # noqa: E402
+
+KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"]
+
+
+@pytest.fixture
+def no_keys(monkeypatch):
+    for key in KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── a missing key ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cls_name,variable",
+    [
+        ("AnthropicClient", "ANTHROPIC_API_KEY"),
+        ("OpenAIClient", "OPENAI_API_KEY"),
+        ("GeminiClient", "GEMINI_API_KEY"),
+    ],
+)
+def test_a_missing_key_raises_configuration_error(no_keys, monkeypatch, cls_name, variable):
+    """
+    A bare ValueError escaped the top-level handler and became a traceback.
+    ConfigurationError is an AgentError, so it is reported with a remedy.
+    """
+    cls = getattr(llm_client, cls_name, None)
+    if cls is None:
+        pytest.skip(f"{cls_name} not present in this build")
+
+    # The anthropic client checks for its SDK before it checks for the key, so
+    # the availability flag is forced open here to reach the key check. On a
+    # machine without the SDK installed, the SDK error is what the user sees
+    # first -- which is why it is now a ConfigurationError too.
+    monkeypatch.setattr(llm_client, "_ANTHROPIC_AVAILABLE", True, raising=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        cls()
+
+    assert variable in str(caught.value)
+
+
+@pytest.mark.parametrize("cls_name", ["AnthropicClient", "OpenAIClient", "GeminiClient"])
+def test_the_message_offers_a_remedy(no_keys, monkeypatch, cls_name):
+    """
+    The remedy matters more than the class change — someone hitting this has
+    usually just cloned the repository.
+    """
+    cls = getattr(llm_client, cls_name, None)
+    if cls is None:
+        pytest.skip(f"{cls_name} not present in this build")
+    monkeypatch.setattr(llm_client, "_ANTHROPIC_AVAILABLE", True, raising=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        cls()
+
+    assert "Export it" in str(caught.value)
+
+
+def test_the_message_points_at_the_documentation(no_keys, monkeypatch):
+    monkeypatch.setattr(llm_client, "_ANTHROPIC_AVAILABLE", True, raising=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        llm_client.AnthropicClient()
+
+    assert "README" in str(caught.value)
+
+
+# ── a missing SDK ─────────────────────────────────────────────────────────
+
+
+def test_a_missing_sdk_raises_configuration_error(monkeypatch):
+    """
+    This fires before the key check, so on a machine without the SDK it was the
+    error the user actually saw — and it was a bare RuntimeError.
+    """
+    monkeypatch.setattr(llm_client, "_ANTHROPIC_AVAILABLE", False, raising=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        llm_client.AnthropicClient(api_key="x")
+
+    assert "not installed" in str(caught.value)
+
+
+def test_the_missing_sdk_message_names_the_install_command(monkeypatch):
+    monkeypatch.setattr(llm_client, "_ANTHROPIC_AVAILABLE", False, raising=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        llm_client.AnthropicClient(api_key="x")
+
+    assert "requirements.txt" in str(caught.value)
+
+
+def test_the_missing_sdk_message_names_the_alternative(monkeypatch):
+    """The other three providers use urllib and need no SDK at all."""
+    monkeypatch.setattr(llm_client, "_ANTHROPIC_AVAILABLE", False, raising=False)
+
+    with pytest.raises(ConfigurationError) as caught:
+        llm_client.AnthropicClient(api_key="x")
+
+    assert "--provider" in str(caught.value)
+
+
+# ── the class and the source ──────────────────────────────────────────────
+
+
+def test_configuration_error_is_an_agent_error():
+    """This is what routes it to the clean handler rather than a traceback."""
+    assert issubclass(ConfigurationError, AgentError)
+
+
+def test_no_bare_credential_error_remains():
+    """
+    The constructs being replaced. A future provider copying either pattern
+    would reintroduce the traceback.
+    """
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith("#")
+    )
+
+    for key in KEYS:
+        assert f'ValueError("{key} not set")' not in code
+    assert 'RuntimeError("anthropic package not installed' not in code
+
+
+def test_every_credential_check_uses_the_same_class():
+    source = (ROOT / "modules" / "llm_client.py").read_text(encoding="utf-8")
+
+    assert source.count("raise ConfigurationError(") >= 4


### PR DESCRIPTION
Closes #353

Two bare exceptions, for the two most common first-run mistakes there are:

```python
# llm_client.py:752
raise RuntimeError("anthropic package not installed. Run: pip install anthropic")
# :755, :827, :865
raise ValueError("ANTHROPIC_API_KEY not set")
```

Both produce a Python traceback into code the user did not write:

```
  File "/repopilot/modules/llm_client.py", line 755, in __init__
    raise ValueError("ANTHROPIC_API_KEY not set")
ValueError: ANTHROPIC_API_KEY not set
```

## The right class was already imported

Line 18:

```python
from modules.errors import ConfigurationError, ProviderError, AgentError
```

`ConfigurationError` is an `AgentError`, has `user_message()`, and is caught by the top-level handler added in #260 — which prints a clean message and a remedy instead of a stack trace. `SystemPromptError` at line 370 already subclasses it.

These four sites were simply not converted when that landed.

## The SDK check matters more than the issue said

#353 covers the three API key checks. Testing on a machine without the `anthropic` package showed the SDK check at line 752 fires **first**, so on a fresh clone where `pip install -r requirements.txt` has not run, that `RuntimeError` is the error the user actually sees.

It is now a `ConfigurationError` too, and its message names both the fix and the alternative:

> The anthropic package is not installed. Run `pip install -r requirements.txt`, or use --provider with a provider that needs no SDK (openai, gemini and ollama all go through urllib).

That last clause is worth stating — the other three providers use `urllib` directly and need no SDK at all, which is not obvious from the error.

## Tests

`tests/test_api_key_errors.py` — 13 cases.

A missing key raises `ConfigurationError` for each of the three providers and names the variable; the message offers a remedy and points at the README; a missing SDK raises `ConfigurationError` naming both `requirements.txt` and the SDK-free alternative; `ConfigurationError` is an `AgentError`; neither bare construct remains in the source.

### One note on how these are written

They exercise the client classes directly rather than through the CLI. An earlier version ran `main.py --repo .` as a subprocess, which — without `--no-git` — made the agent create and check out a branch **in the repository under test**. The tests mutated the working tree they were running in, and I only caught it because a commit landed on the wrong branch.

The current version has no subprocess call, and I confirmed the tree stays clean after a full suite run.

## Verified

- 13 tests pass with the SDK present and with it absent
- full suite: 1447 passing
- no branches created by the test run