### PR TITLE
fix(resume): validate state file fields, not just the version — Closes #351

### DIFF
--- a/modules/agent_loop.py
+++ b/modules/agent_loop.py
@@ -45,6 +45,7 @@ from modules.run_state import (
     RunState,
     check_resumable,
     clear_state,
+    ResumeError,
     load_state,
     save_state,
 )
@@ -192,6 +193,24 @@ def _checkpoint(agent, cfg, iteration, last_changes, exec_result) -> None:
 # Coverage is reported to one decimal place and rounding moves it slightly
 # between runs. Failing a run for 0.05% would be noise, not a signal.
 COVERAGE_TOLERANCE = 0.5
+
+
+def _restore_changes(raw: list, run_id: str) -> list[FileChange]:
+    """
+    Rebuild FileChange objects from a state file.
+
+    Split out rather than inlined: `FileChange(**c)` raised a raw TypeError for
+    a malformed entry, and the caller only knows how to report ResumeError --
+    anything else reaches the user as a traceback. Kept a module function so
+    _run does not grow past the length guard added with #171.
+    """
+    try:
+        return [FileChange(**entry) for entry in raw]
+    except (TypeError, AttributeError) as exc:
+        raise ResumeError(
+            f"State file for run '{run_id}' has a malformed last_changes entry "
+            f"({exc}). Start a fresh run rather than resuming."
+        ) from exc
 
 
 class AutonomousAgent:
@@ -565,7 +584,7 @@ class AutonomousAgent:
             check_resumable(state, cfg.repo_root, cfg.task)
             start_iteration = state.iteration + 1
             self.branch_name = state.branch_name or self.branch_name
-            last_changes = [FileChange(**c) for c in state.last_changes]
+            last_changes = _restore_changes(state.last_changes, cfg.resume_from)
             if state.last_exit_code is not None:
                 # Rebuilt rather than stored whole: the retry prompt only reads
                 # these four fields, and persisting a full ExecutionResult would

--- a/modules/run_state.py
+++ b/modules/run_state.py
@@ -106,7 +106,52 @@ def load_state(log_dir: str, run_id: str) -> RunState:
         )
 
     known = set(RunState.__dataclass_fields__)
-    return RunState(**{k: v for k, v in data.items() if k in known})
+
+    # Unknown keys were already filtered, but the values that remain were not
+    # checked. Dataclass annotations are not enforced at runtime, so a file with
+    # the right keys and wrong values loaded cleanly and failed later, somewhere
+    # else, as a type the caller was not expecting.
+    try:
+        state = RunState(**{k: v for k, v in data.items() if k in known})
+    except TypeError as exc:
+        # A missing required field raised TypeError straight out of __init__.
+        # ResumeError is an AgentError, so it reaches the handler that prints a
+        # remedy; a bare TypeError escaped as an unhandled traceback instead.
+        raise ResumeError(
+            f"State file {path} is missing a required field ({exc}). "
+            f"Start a fresh run rather than resuming."
+        ) from exc
+
+    # iteration is the one that failed silently. A negative value made the loop
+    # start below zero and run more iterations than --max-iter allows, each one
+    # a paid API call, with nothing reported. A string raised deep inside the
+    # loop instead, far from the file that caused it.
+    if not isinstance(state.iteration, int) or isinstance(state.iteration, bool):
+        raise ResumeError(
+            f"State file {path} has iteration={state.iteration!r}, which is not "
+            f"an integer. The file is corrupt; start a fresh run."
+        )
+    if state.iteration < 0:
+        raise ResumeError(
+            f"State file {path} has iteration={state.iteration}, which is "
+            f"negative. Resuming would run past --max-iter. Start a fresh run."
+        )
+
+    for field, value in (("run_id", state.run_id), ("task", state.task),
+                         ("repo_root", state.repo_root)):
+        if not isinstance(value, str):
+            raise ResumeError(
+                f"State file {path} has {field}={value!r}, expected a string. "
+                f"The file is corrupt; start a fresh run."
+            )
+
+    if not isinstance(state.last_changes, list):
+        raise ResumeError(
+            f"State file {path} has last_changes={state.last_changes!r}, "
+            f"expected a list. The file is corrupt; start a fresh run."
+        )
+
+    return state
 
 
 def list_resumable(log_dir: str) -> list[str]:

--- a/tests/test_resume_state_validation.py
+++ b/tests/test_resume_state_validation.py
@@ -1,0 +1,182 @@
+"""
+Tests for state file validation (modules/run_state.py).
+
+`load_state` checked the version and filtered unknown keys, then splatted the
+rest into the dataclass. Annotations are not enforced at runtime, so a file with
+the right keys and wrong values loaded cleanly and failed later, elsewhere.
+
+Three distinct outcomes, all from a corrupt `iteration`:
+
+- a string reached `range()` and raised deep inside the loop
+- a negative value did not raise at all — `range(-4, 4)` ran eight iterations
+  where `--max-iter 3` was asked for, each one a paid API call
+- a missing field raised `TypeError` from `__init__` rather than `ResumeError`,
+  so it escaped the handler that prints a remedy and became a traceback
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from modules.errors import AgentError  # noqa: E402
+from modules.run_state import STATE_VERSION, ResumeError, load_state  # noqa: E402
+
+VALID = {
+    "version": STATE_VERSION,
+    "run_id": "r1",
+    "iteration": 2,
+    "branch_name": "agent/x",
+    "task": "do a thing",
+    "repo_root": ".",
+    "outcome": "failed",
+}
+
+
+@pytest.fixture
+def write(tmp_path):
+    def inner(payload):
+        (tmp_path / "r1_state.json").write_text(json.dumps(payload))
+        return str(tmp_path)
+    return inner
+
+
+# ── files that should load ────────────────────────────────────────────────
+
+
+def test_a_valid_state_loads(write):
+    state = load_state(write(VALID), "r1")
+
+    assert state.iteration == 2
+    assert state.run_id == "r1"
+
+
+def test_unknown_keys_are_still_filtered(write):
+    """Existing behaviour, pinned: a newer build's extra field must not break."""
+    state = load_state(write({**VALID, "field_from_the_future": 1}), "r1")
+
+    assert state.iteration == 2
+
+
+def test_iteration_zero_is_allowed(write):
+    """A run that checkpointed before its first iteration is legitimate."""
+    assert load_state(write({**VALID, "iteration": 0}), "r1").iteration == 0
+
+
+# ── iteration ─────────────────────────────────────────────────────────────
+
+
+def test_a_string_iteration_is_refused(write):
+    with pytest.raises(ResumeError, match="not an integer"):
+        load_state(write({**VALID, "iteration": "not a number"}), "r1")
+
+
+def test_a_negative_iteration_is_refused(write):
+    """
+    The one that failed silently. `state.iteration + 1` became -4, so the loop
+    ran from -4 and exceeded --max-iter with nothing reported.
+    """
+    with pytest.raises(ResumeError, match="negative"):
+        load_state(write({**VALID, "iteration": -5}), "r1")
+
+
+def test_the_negative_message_names_the_consequence(write):
+    """"Invalid" alone does not tell the user why it matters."""
+    with pytest.raises(ResumeError, match="max-iter"):
+        load_state(write({**VALID, "iteration": -1}), "r1")
+
+
+def test_a_boolean_iteration_is_refused(write):
+    """`isinstance(True, int)` is True in Python, so bool needs excluding."""
+    with pytest.raises(ResumeError):
+        load_state(write({**VALID, "iteration": True}), "r1")
+
+
+# ── the other fields ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("field", ["run_id", "task", "repo_root"])
+def test_a_non_string_field_is_refused(write, field):
+    with pytest.raises(ResumeError, match=field):
+        load_state(write({**VALID, field: ["a", "list"]}), "r1")
+
+
+def test_a_non_list_last_changes_is_refused(write):
+    with pytest.raises(ResumeError, match="last_changes"):
+        load_state(write({**VALID, "last_changes": "not a list"}), "r1")
+
+
+def test_a_missing_field_raises_resume_error_not_type_error(write):
+    """
+    The distinction that matters: ResumeError reaches the handler added in
+    #260 and prints a remedy; TypeError escapes as a traceback.
+    """
+    payload = {k: v for k, v in VALID.items() if k != "iteration"}
+
+    with pytest.raises(ResumeError, match="missing a required field"):
+        load_state(write(payload), "r1")
+
+
+# ── malformed last_changes ────────────────────────────────────────────────
+
+
+def test_a_malformed_change_entry_raises_resume_error():
+    """
+    `FileChange(**c)` raised a bare TypeError for an entry with a missing or
+    unexpected key. Same class of escape as above, one line further on.
+    """
+    from modules.agent_loop import _restore_changes
+
+    with pytest.raises(ResumeError, match="malformed last_changes"):
+        _restore_changes([{"path": "a.py"}], "r1")
+
+
+def test_an_unexpected_key_in_a_change_entry_is_refused():
+    from modules.agent_loop import _restore_changes
+
+    with pytest.raises(ResumeError):
+        _restore_changes([{"path": "a.py", "action": "modify",
+                           "content": "x", "explanation": "e", "bogus": 1}], "r1")
+
+
+def test_a_well_formed_change_entry_still_restores():
+    from modules.agent_loop import _restore_changes
+
+    restored = _restore_changes(
+        [{"path": "a.py", "action": "modify", "content": "x", "explanation": "e"}],
+        "r1",
+    )
+
+    assert restored[0].path == "a.py"
+
+
+# ── the error class ───────────────────────────────────────────────────────
+
+
+def test_resume_error_is_an_agent_error():
+    """This is what routes it to the clean handler rather than a traceback."""
+    assert issubclass(ResumeError, AgentError)
+
+
+def test_every_corrupted_shape_raises_resume_error(write):
+    """
+    No corrupted file should leak a different exception type — that is the
+    whole defect being fixed.
+    """
+    corruptions = [
+        {**VALID, "iteration": "x"},
+        {**VALID, "iteration": -1},
+        {**VALID, "iteration": True},
+        {**VALID, "task": 5},
+        {**VALID, "last_changes": {}},
+        {k: v for k, v in VALID.items() if k != "run_id"},
+        {**VALID, "version": 999},
+    ]
+
+    for payload in corruptions:
+        with pytest.raises(ResumeError):
+            load_state(write(payload), "r1")

--- a/tests/test_run_state.py
+++ b/tests/test_run_state.py
@@ -252,4 +252,8 @@ def test_previous_output_is_restored_for_the_retry_prompt():
 
     assert "last_exec = ExecutionResult(" in block
     assert "state.last_stderr" in block
-    assert "FileChange(**c)" in block
+    # Matched on the call rather than on `FileChange(**c)`: the reconstruction
+    # moved into _restore_changes so a malformed entry raises ResumeError
+    # instead of a bare TypeError. What matters here is that the restore still
+    # happens on the resume path, not how it is spelled.
+    assert "_restore_changes(state.last_changes" in block


### PR DESCRIPTION
Closes #351

`load_state` checked the version and filtered unknown keys, then splatted the rest into the dataclass:

```python
known = set(RunState.__dataclass_fields__)
return RunState(**{k: v for k, v in data.items() if k in known})
```

Annotations are not enforced at runtime, so a file with the right keys and wrong values loaded cleanly and failed later, somewhere else:

```
valid                loaded  iteration=2
iteration a string   loaded  iteration='not a number'
iteration negative   loaded  iteration=-5
branch_name a list   loaded  iteration=2
missing iteration    TypeError (not ResumeError)
```

## Three distinct failures

**A string `iteration`** reached `range(start_iteration, cfg.max_iterations + 1)` and raised `TypeError: 'str' object cannot be interpreted as an integer` deep inside the loop, far from the file that caused it.

**A negative `iteration`** is worse, because it did not raise. `state.iteration + 1` became `-4`, so the loop ran `range(-4, 4)` — eight iterations where `--max-iter 3` was requested. The limit was silently exceeded, and every one of those iterations is a paid API call.

**A missing field** raised `TypeError` from `__init__` rather than `ResumeError`. That matters because `ResumeError` is an `AgentError`, so the handler added in #260 reports it cleanly with a remedy; a raw `TypeError` escapes as an unhandled traceback.

The same applied one line further on, in `agent_loop`:

```python
last_changes = [FileChange(**c) for c in state.last_changes]
```

All four shapes I tried — incomplete, unknown key, missing key, traversal path — raised `TypeError` rather than `ResumeError`.

## What was already right

This module does more validation than most of the codebase: the version check is present, unknown keys are filtered rather than splatted, and the messages are specific and actionable. `check_resumable` also verifies the repository and task match, so a state file cannot redirect a run at a different repository.

The traversal case is contained too — `_safe_abs_path` in `code_modifier` still refuses a write outside the repository root, so a corrupted `last_changes` carries a bad value but cannot act on it.

The gap was only the field values.

## The change

Every corruption now raises `ResumeError`:

```
valid       loaded iteration=2
string      ResumeError
negative    ResumeError
bool        ResumeError
task list   ResumeError
missing     ResumeError
```

`bool` is checked explicitly because `isinstance(True, int)` is `True` in Python.

The `FileChange` reconstruction moved into a module-level `_restore_changes` rather than being wrapped inline. `_run` is already at the ceiling enforced by the length guard from #171 — inlining the `try` pushed it to exactly 500 lines and tripped that test, which is the guard doing its job.

## Tests

`tests/test_resume_state_validation.py` — 17 cases.

Files that should load: a valid state; unknown keys still filtered, so a newer build's extra field does not break resuming; `iteration=0`, since a run that checkpointed before its first iteration is legitimate.

`iteration`: string, negative, and boolean all refused; the negative message names the consequence, because "invalid" alone does not say why it matters.

Other fields: non-string `run_id`/`task`/`repo_root`; non-list `last_changes`; a missing field raising `ResumeError` rather than `TypeError`.

`last_changes`: a malformed entry and an unexpected key both raise `ResumeError`; a well-formed entry still restores.

One existing test in `test_run_state.py` asserted the literal string `FileChange(**c)`. It now matches the call to `_restore_changes` instead — what matters is that the restore happens on the resume path, not how it is spelled.

## Verified

- every corruption above, run against the real loader
- full suite: 1451 passing