### PR TITLE
docs: add .env.example and document every environment variable — Closes #354

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# RepoPilot configuration.
+#
+# Copy to .env and fill in the keys you need, or export these in your shell.
+# .env itself is gitignored; this template is not.
+
+# --- Model providers ---------------------------------------------------------
+# You need the key for whichever --provider you use. Anthropic is the default.
+
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+GEMINI_API_KEY=
+
+# Ollama needs no key. Point --api-base-url at your instance instead.
+
+# --- Git integration ---------------------------------------------------------
+# Only needed for --push and --pr. A fine-grained token needs `pull_request:
+# write`; without it PR creation fails with a 403 that the log now explains.
+# GH_TOKEN is accepted as a fallback, which is why `gh auth login` alone is
+# sometimes enough.
+
+GITHUB_TOKEN=
+# GH_TOKEN=
+
+# --- Output ------------------------------------------------------------------
+# Set to any value to disable coloured output.
+
+# NO_COLOR=

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 # Environment and secrets
 .env
 .env.*
+# ...but the committed template is the point: `.env.*` matched `.env.example`,
+# so the file every project uses to document required variables could not be
+# added without this negation.
+!.env.example
 *.key
 *.pem
 *.p12

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ pip install -r requirements.txt
 export ANTHROPIC_API_KEY=sk-ant-...
 ```
 
+### Environment variables
+
+Copy `.env.example` and fill in what you need, or export these directly.
+
+| Variable            | When it is needed                                |
+| ------------------- | ------------------------------------------------ |
+| `ANTHROPIC_API_KEY` | the default provider                             |
+| `OPENAI_API_KEY`    | `--provider openai`                              |
+| `GEMINI_API_KEY`    | `--provider gemini`                              |
+| `GITHUB_TOKEN`      | `--push` and `--pr`; needs `pull_request: write` |
+| `GH_TOKEN`          | accepted as a fallback for `GITHUB_TOKEN`        |
+| `NO_COLOR`          | set to any value to disable coloured output      |
+
+Ollama needs no key — point `--api-base-url` at your instance.
+
 ---
 
 ## Contributing

--- a/tests/test_env_documentation.py
+++ b/tests/test_env_documentation.py
@@ -1,0 +1,110 @@
+"""
+Tests for environment variable documentation (.env.example, README, .gitignore).
+
+The code reads six user-facing environment variables. Three were absent from the
+README — `OPENAI_API_KEY`, `GEMINI_API_KEY` and `GH_TOKEN` — even though
+`--provider openai` and `--provider gemini` are both offered in `--help` and
+neither works without one.
+
+The usual fix, a committed `.env.example`, could not be added: `.gitignore` had
+`.env.*`, which matched the template as well as the real file.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+USER_FACING = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+    "NO_COLOR",
+]
+
+
+# ── the template is committable ───────────────────────────────────────────
+
+
+def test_env_example_exists():
+    assert (ROOT / ".env.example").exists()
+
+
+def test_env_example_is_not_ignored():
+    """`.env.*` matched it, so it could not be committed without the negation."""
+    result = subprocess.run(
+        ["git", "check-ignore", ".env.example"],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+
+    assert result.returncode != 0, ".env.example is still gitignored"
+
+
+def test_the_real_env_file_is_still_ignored():
+    """The negation must not open a hole for the file it was protecting."""
+    result = subprocess.run(
+        ["git", "check-ignore", ".env"],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+
+    assert result.returncode == 0, ".env is no longer ignored"
+
+
+@pytest.mark.parametrize("variant", [".env.local", ".env.production"])
+def test_other_env_variants_are_still_ignored(variant):
+    result = subprocess.run(
+        ["git", "check-ignore", variant],
+        capture_output=True, text=True, cwd=ROOT,
+    )
+
+    assert result.returncode == 0
+
+
+# ── the template has no real values ───────────────────────────────────────
+
+
+def test_the_template_carries_no_credentials():
+    """A template with a real key in it is worse than no template."""
+    text = (ROOT / ".env.example").read_text(encoding="utf-8")
+
+    assert not re.search(r"sk-ant-api03-[A-Za-z0-9_-]{20,}", text)
+    assert not re.search(r"ghp_[A-Za-z0-9]{20,}", text)
+
+
+@pytest.mark.parametrize("name", ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"])
+def test_the_provider_keys_are_listed_empty(name):
+    text = (ROOT / ".env.example").read_text(encoding="utf-8")
+
+    assert f"{name}=" in text
+    assert not re.search(rf"^{name}=\S", text, re.M), f"{name} has a value"
+
+
+# ── the README covers them ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("name", USER_FACING)
+def test_the_readme_documents_the_variable(name):
+    """
+    OPENAI_API_KEY, GEMINI_API_KEY and GH_TOKEN were the three missing ones,
+    and two of them gate provider flags that --help already advertises.
+    """
+    assert name in (ROOT / "README.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", USER_FACING)
+def test_the_template_documents_the_variable(name):
+    assert name in (ROOT / ".env.example").read_text(encoding="utf-8")
+
+
+def test_the_readme_code_fences_are_balanced():
+    """A stray fence swallows the rest of the document when rendered."""
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert text.count("```") % 2 == 0


### PR DESCRIPTION
Closes #354

The code reads six user-facing environment variables. Three were absent from the README:

```
ANTHROPIC_API_KEY    documented
GITHUB_TOKEN         documented
NO_COLOR             documented
OPENAI_API_KEY       NOT in README
GEMINI_API_KEY       NOT in README
GH_TOKEN             NOT in README
```

`--provider openai` and `--provider gemini` are both offered in `--help`, and neither works without a variable the documentation never named.

`GH_TOKEN` is accepted as a fallback for `GITHUB_TOKEN` in `git_integration.py:380`. Anyone with `gh` installed already has it set, so `--pr` silently works for some people and not others, with nothing explaining why.

## The usual fix was blocked

```
$ git check-ignore -v .env.example
.gitignore:10:.env.*    .env.example
```

`.env.*` matched the template as well as the real file, so the file most projects use to document required variables could not be committed. That is very likely why one was never added — someone would have created it, seen it not appear in `git status`, and moved on.

## The change

A negation in `.gitignore`:

```
.env
.env.*
!.env.example
```

`.env`, `.env.local` and `.env.production` all stay ignored — there are tests for each, because a negation that opened a hole for the file it was protecting would be worse than the original problem.

Then `.env.example` with all six variables, empty, one comment each. `GITHUB_OUTPUT`, `AGENT_TASK` and `PATH` are set by CI or the OS and are deliberately not in it.

The README gains a table under Installation, and notes that Ollama needs no key at all — `--api-base-url` points at your instance instead.

## Tests

`tests/test_env_documentation.py` — 22 cases.

The template is committable and the real `.env` is still ignored, along with `.env.local` and `.env.production`; the template carries no real credentials, which would make it worse than none; the provider keys are present and empty; every one of the six appears in both the README and the template.

Also a check that the README's code fences are balanced — my first attempt at the edit left a stray fence, and an unbalanced one swallows the rest of the document when rendered.

## Verified

- `git check-ignore` on the template and on three real env filenames
- `npx prettier --check README.md` clean
- full suite: 1456 passing