### PR TITLE
fix(dashboard): stop serving the working directory, escape output, bind loopback — Closes #347, #348, #349, #350

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ python main.py --repo . --task "Fix the failing parser test"
 
 ---
 
-### `dashboard.py` — run viewer
+### `modules/dashboard` — run viewer (terminal)
 
 Renders a run log as a readable timeline — the model's analysis, its file
 changes, and the test output for each iteration:
@@ -624,6 +624,19 @@ python -m modules.dashboard logs/agent_20260807_abc.jsonl --follow
 
 `--follow` tails the log while a run is in progress, so a long run is visible as
 it happens rather than scrolling past in CLI output.
+
+### `dashboard_server.py` — run viewer (web)
+
+A separate, zero-dependency web UI over the same logs:
+
+```bash
+python dashboard_server.py                    # http://127.0.0.1:8080
+python dashboard_server.py --host 0.0.0.0     # reachable from other machines
+```
+
+It binds loopback by default. `--host 0.0.0.0` exposes run summaries — task
+text, repository paths, and the model's analysis — to anyone who can reach the
+machine, and the server warns when you use it.
 
 It reads the JSONL `logger.py` already writes rather than being instrumented
 into the loop. That keeps it decoupled: it works on a finished run, on a run in

--- a/dashboard_server.py
+++ b/dashboard_server.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """
-dashboard.py
+dashboard_server.py
 A zero-dependency web dashboard to visualize RepoPilot agent run history.
 Serves an elegant modern UI on http://localhost:8080.
 """
 
+import argparse
 import http.server
 import socketserver
 import os
@@ -13,6 +14,13 @@ import glob
 import sys
 
 PORT = 8080
+
+# Loopback, not every interface.
+#
+# The bind was ("", PORT) -- 0.0.0.0 -- while both the module docstring and the
+# startup banner said localhost. --host restores the old reach for anyone who
+# wants it, with the difference that they chose it.
+DEFAULT_HOST = "127.0.0.1"
 LOGS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "logs")
 
 class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
@@ -289,6 +297,22 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
     </div>
 
     <script>
+        // Escape before interpolating into innerHTML.
+        //
+        // Every value below comes from a run log: the task string (which under
+        // agent-fix.yml is the body of a GitHub issue anyone can open), the
+        // model's own prose, and the sandbox's captured stdout and stderr.
+        // innerHTML parses its input as HTML, so an unescaped tag in any of
+        // them executes here.
+        function esc(value) {
+            return String(value === undefined || value === null ? "" : value)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#39;");
+        }
+
         async function fetchRuns() {
             try {
                 const response = await fetch('/api/runs');
@@ -311,10 +335,10 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
                     
                     card.innerHTML = `
                         <div class="flex-row">
-                            <span style="font-weight: 600; font-size: 0.95rem; word-break: break-all;">${run.run_id}</span>
-                            <span class="badge ${badgeClass}">${run.outcome.toUpperCase()}</span>
+                            <span style="font-weight: 600; font-size: 0.95rem; word-break: break-all;">${esc(run.run_id)}</span>
+                            <span class="badge ${badgeClass}">${esc(String(run.outcome || '').toUpperCase())}</span>
                         </div>
-                        <p style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.25rem;">Task: ${run.task ? run.task.substring(0, 60) + '...' : 'N/A'}</p>
+                        <p style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.25rem;">Task: ${run.task ? esc(run.task.substring(0, 60)) + '...' : 'N/A'}</p>
                     `;
                     
                     card.addEventListener('click', () => {
@@ -357,23 +381,23 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
                     iterationsHtml += `
                         <div class="iteration-view">
                             <div class="iteration-header">
-                                <h3>Iteration ${iter.iteration}</h3>
-                                <span class="badge badge-neutral">${iter.timestamp}</span>
+                                <h3>Iteration ${esc(iter.iteration)}</h3>
+                                <span class="badge badge-neutral">${esc(iter.timestamp)}</span>
                             </div>
-                            <p><strong>Analysis:</strong> ${iter.llm_analysis}</p>
+                            <p><strong>Analysis:</strong> ${esc(iter.llm_analysis)}</p>
                             <p style="margin-top: 0.5rem;"><strong>LLM Confidence:</strong> ${(iter.llm_confidence * 100).toFixed(1)}%</p>
                             
                             ${changesHtml}
                             
                             <div style="margin-top: 1rem;">
-                                <strong>Execution Command:</strong> <code>${iter.execution_command || 'None'}</code>
+                                <strong>Execution Command:</strong> <code>${esc(iter.execution_command || 'None')}</code>
                                 <p style="margin-top: 0.5rem;"><strong>Test Result:</strong> 
                                     <span class="badge ${iter.execution_success ? 'badge-success' : 'badge-failed'}">
                                         ${iter.execution_success ? 'PASSED' : 'FAILED'}
                                     </span>
                                 </p>
-                                ${iter.execution_stdout ? `<pre style="margin-top: 0.5rem;">${iter.execution_stdout}</pre>` : ''}
-                                ${iter.execution_stderr ? `<pre style="margin-top: 0.5rem; border-color: var(--error)">${iter.execution_stderr}</pre>` : ''}
+                                ${iter.execution_stdout ? `<pre style="margin-top: 0.5rem;">${esc(iter.execution_stdout)}</pre>` : ''}
+                                ${iter.execution_stderr ? `<pre style="margin-top: 0.5rem; border-color: var(--error)">${esc(iter.execution_stderr)}</pre>` : ''}
                             </div>
                         </div>
                     `;
@@ -382,8 +406,8 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
                 panel.innerHTML = `
                     <div class="flex-row" style="align-items: center; border-bottom: 1px solid var(--border); padding-bottom: 1.5rem;">
                         <div>
-                            <h2>Run Summary: ${summary.run_id || runId}</h2>
-                            <p style="color: var(--text-secondary)">Outcome: <span class="badge ${summary.outcome === 'success' ? 'badge-success' : 'badge-failed'}">${(summary.outcome || 'N/A').toUpperCase()}</span></p>
+                            <h2>Run Summary: ${esc(summary.run_id || runId)}</h2>
+                            <p style="color: var(--text-secondary)">Outcome: <span class="badge ${summary.outcome === 'success' ? 'badge-success' : 'badge-failed'}">${esc(String(summary.outcome || 'N/A').toUpperCase())}</span></p>
                         </div>
                     </div>
 
@@ -404,7 +428,7 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
 
                     <div>
                         <h3 style="margin-bottom: 1rem;">Task</h3>
-                        <p style="background: #151f32; padding: 1rem; border-radius: 0.5rem; border: 1px solid var(--border);">${summary.task || 'N/A'}</p>
+                        <p style="background: #151f32; padding: 1rem; border-radius: 0.5rem; border: 1px solid var(--border);">${esc(summary.task || 'N/A')}</p>
                     </div>
 
                     <div>
@@ -414,7 +438,7 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
                 `;
             } catch (err) {
                 console.error("Error loading run details:", err);
-                panel.innerHTML = `<p style="color: var(--error)">Error loading run details: ${err}</p>`;
+                panel.innerHTML = `<p style="color: var(--error)">Error loading run details: ${esc(err)}</p>`;
             }
         }
 
@@ -427,20 +451,49 @@ class DashboardHTTPHandler(http.server.SimpleHTTPRequestHandler):
             self.wfile.write(html_content.encode("utf-8"))
             return
 
-        super().do_GET()
+        # Anything else is refused rather than served.
+        #
+        # This called super().do_GET(), which is SimpleHTTPRequestHandler -- it
+        # serves the process working directory. Started from a repository root,
+        # `GET /.env` returned the file, and I confirmed a real API key came
+        # back over HTTP. Dotfiles are not excluded, and combined with the
+        # 0.0.0.0 bind that made the whole working tree readable by anyone on
+        # the network.
+        #
+        # The dashboard needs exactly the routes handled above, so there is
+        # nothing legitimate to fall through to.
+        self.send_response(404)
+        self.send_header("Content-Type", "text/plain")
+        self.end_headers()
+        self.wfile.write(b"Not found")
 
-def run_server():
+
+def run_server(host: str = DEFAULT_HOST, port: int = PORT) -> None:
     socketserver.TCPServer.allow_reuse_address = True
-    with socketserver.TCPServer(("", PORT), DashboardHTTPHandler) as httpd:
-        print(f"\n==================================================")
-        print(f"  RepoPilot Dashboard Server started successfully!")
-        print(f"  Url: http://localhost:{PORT}")
-        print(f"==================================================\n")
+    with socketserver.TCPServer((host, port), DashboardHTTPHandler) as httpd:
+        print("\n==================================================")
+        print("  RepoPilot Dashboard Server started successfully!")
+        print(f"  Url: http://{host}:{port}")
+        if host not in ("127.0.0.1", "localhost"):
+            print("  WARNING: bound beyond loopback -- run summaries and task")
+            print("           text are readable by anyone who can reach this host.")
+        print("==================================================\n")
         try:
             httpd.serve_forever()
         except KeyboardInterrupt:
             print("\nShutting down Dashboard Server...")
             sys.exit(0)
 
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="RepoPilot run dashboard (web).")
+    parser.add_argument("--host", default=DEFAULT_HOST,
+                        help=f"Interface to bind (default: {DEFAULT_HOST}, loopback only)")
+    parser.add_argument("--port", type=int, default=PORT,
+                        help=f"Port to listen on (default: {PORT})")
+    args = parser.parse_args(argv)
+    run_server(args.host, args.port)
+
+
 if __name__ == "__main__":
-    run_server()
+    main()

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -1,0 +1,202 @@
+"""
+Tests for the web dashboard (dashboard_server.py).
+
+446 lines with no tests, and three defects in them.
+
+The handler fell through to `SimpleHTTPRequestHandler`, which serves the process
+working directory — started from a repository root, `GET /.env` returned the
+file. I confirmed a real API key came back over HTTP before fixing it.
+
+Every run value was interpolated into `innerHTML` unescaped: the task string
+(under agent-fix.yml that is a GitHub issue body anyone can open), the model's
+own prose, and the sandbox's captured stdout and stderr.
+
+And the bind was `("", 8080)` — every interface — while the docstring and the
+startup banner both said localhost.
+"""
+
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from http.server import HTTPServer
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import dashboard_server  # noqa: E402
+
+
+@pytest.fixture
+def server(tmp_path, monkeypatch):
+    """
+    A live server on an ephemeral port.
+
+    `LOGS_DIR` is resolved from the module's own location rather than the
+    working directory, so it is patched explicitly — chdir alone does not move
+    it. The working directory is still changed, because that is what the
+    removed `SimpleHTTPRequestHandler` fallthrough used to serve from.
+    """
+    (tmp_path / "logs").mkdir()
+    monkeypatch.setattr(dashboard_server, "LOGS_DIR", str(tmp_path / "logs"))
+    (tmp_path / ".env").write_text("ANTHROPIC_API_KEY=sk-ant-secret\n")
+    (tmp_path / "secret.txt").write_text("do not serve me\n")
+    monkeypatch.chdir(tmp_path)
+
+    httpd = HTTPServer(("127.0.0.1", 0), dashboard_server.DashboardHTTPHandler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{httpd.server_port}"
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def get(base, path):
+    try:
+        with urllib.request.urlopen(base + path, timeout=5) as response:
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+
+
+# ── the working directory is not served ───────────────────────────────────
+
+
+def test_dotenv_is_not_served(server):
+    """
+    The exact exploit: this returned the file, API key and all, before the
+    fallthrough to SimpleHTTPRequestHandler was removed.
+    """
+    status, body = get(server, "/.env")
+
+    assert status == 404
+    assert "sk-ant-secret" not in body
+
+
+@pytest.mark.parametrize("path", ["/secret.txt", "/dashboard_server.py", "/logs/"])
+def test_no_working_directory_file_is_served(server, path):
+    status, _ = get(server, path)
+
+    assert status == 404
+
+
+def test_the_handler_does_not_fall_through():
+    """
+    `super().do_GET()` is what served the directory. Its absence is the fix;
+    a future refactor restoring it would restore the file read.
+    """
+    source = (ROOT / "dashboard_server.py").read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith("#")
+    )
+
+    assert "super().do_GET()" not in code
+
+
+# ── the routes that should work ───────────────────────────────────────────
+
+
+def test_the_index_is_served(server):
+    status, body = get(server, "/")
+
+    assert status == 200
+    assert "RepoPilot" in body
+
+
+def test_api_runs_returns_json(server):
+    status, body = get(server, "/api/runs")
+
+    assert status == 200
+    assert json.loads(body) == []
+
+
+def test_api_runs_reads_a_summary(server, tmp_path):
+    (tmp_path / "logs" / "r1_summary.json").write_text(
+        json.dumps({"run_id": "r1", "outcome": "success", "task": "do a thing"})
+    )
+    _, body = get(server, "/api/runs")
+
+    assert any(run["run_id"] == "r1" for run in json.loads(body))
+
+
+def test_an_unknown_run_id_returns_empty_rather_than_raising(server):
+    status, body = get(server, "/api/runs/does-not-exist")
+
+    assert status == 200
+    assert json.loads(body) is not None
+
+
+@pytest.mark.parametrize("run_id", ["../../etc/passwd", "..%2f..%2fetc%2fpasswd"])
+def test_a_traversing_run_id_stays_inside_logs(server, run_id):
+    """
+    `split("/")[-1]` discards the traversal before the join. This held before
+    the change too — pinned so it keeps holding.
+    """
+    status, body = get(server, f"/api/runs/{run_id}")
+
+    assert status == 200
+    assert "root:" not in body
+
+
+# ── output escaping ───────────────────────────────────────────────────────
+
+
+def test_the_escape_helper_is_defined(server):
+    _, body = get(server, "/")
+
+    assert "function esc(value)" in body
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["run.run_id", "iter.llm_analysis", "iter.execution_stdout",
+     "iter.execution_stderr", "summary.task"],
+)
+def test_untrusted_values_are_escaped(server, value):
+    """
+    Each of these carries text from outside: an issue body, the model's prose,
+    or captured test output. `innerHTML` parses its input as HTML.
+    """
+    _, body = get(server, "/")
+
+    assert f"${{{value}}}" not in body, f"{value} is interpolated raw"
+
+
+def test_the_escape_helper_covers_the_dangerous_characters(server):
+    _, body = get(server, "/")
+    helper = body[body.index("function esc(value)"):][:600]
+
+    for char in ("&", "<", ">", '"', "'"):
+        assert f'"{char}"' in helper or f"/{char}/g" in helper
+
+
+# ── the bind address ──────────────────────────────────────────────────────
+
+
+def test_the_default_host_is_loopback():
+    assert dashboard_server.DEFAULT_HOST == "127.0.0.1"
+
+
+def test_no_wildcard_bind_remains():
+    """`("", PORT)` is 0.0.0.0 — every interface."""
+    source = (ROOT / "dashboard_server.py").read_text(encoding="utf-8")
+    code = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith("#")
+    )
+
+    assert 'TCPServer(("", ' not in code
+
+
+def test_host_and_port_are_configurable():
+    import contextlib
+    import io
+
+    with contextlib.suppress(SystemExit), contextlib.redirect_stdout(io.StringIO()) as out:
+        dashboard_server.main(["--help"])
+
+    assert "--host" in out.getvalue()
+    assert "--port" in out.getvalue()


### PR DESCRIPTION
Closes #347 (XSS), #348 (duplicate filename), #349 (bind address), #350 (no tests)

Four issues in one 446-line file with no tests. They are fixed together because three of them are in the same request handler, and the fourth is the reason nothing caught them.

## The working directory was served over HTTP

The handler ended with:

```python
super().do_GET()
```

That is `SimpleHTTPRequestHandler`, which serves the process working directory. Dotfiles are not excluded. I confirmed this rather than inferring it:

```
$ echo "ANTHROPIC_API_KEY=sk-ant-secret123" > .env
$ python dashboard.py &
$ curl http://127.0.0.1:8080/.env
ANTHROPIC_API_KEY=sk-ant-secret123
```

The key came back over HTTP.

The dashboard needs exactly the routes handled above that line, so there was nothing legitimate to fall through to. Unmatched paths now return 404:

```
GET /.env       -> Not found
GET /api/runs   -> []
```

## It was bound to every interface

```python
with socketserver.TCPServer(("", PORT), DashboardHTTPHandler) as httpd:
```

`("", 8080)` is `0.0.0.0`, while both the module docstring and the startup banner said `localhost`. Anyone reading either would believe it was loopback-only — and combined with the file read above, the whole working tree was readable by anyone who could reach the machine.

Now `DEFAULT_HOST = "127.0.0.1"`, which is what the banner already promised, with `--host` and `--port` flags. Using `--host 0.0.0.0` prints a warning naming what becomes reachable.

## Output was interpolated raw

The UI is built with `innerHTML` and template literals. Ten values carrying untrusted text went in unescaped:

```js
${run.task}              // under agent-fix.yml, a GitHub issue body
${iter.llm_analysis}     // the model's own prose
${iter.execution_stdout} // captured sandbox output
${iter.execution_stderr}
${summary.task}
```

`innerHTML` parses its input as HTML, so a tag in any of them executes when the dashboard is opened. 13 interpolations now pass through an `esc()` helper.

## Two files were called dashboard.py

```
dashboard.py           446 lines — this web server
modules/dashboard.py   261 lines — a CLI run viewer
```

Different tools, same name. The README documented the module under a heading naming the file — so anyone following it and running `python dashboard.py` got a web server on a port they did not expect, and anyone reviewing "the dashboard" read the tested module and never looked at this one. `tests/test_dashboard.py` covers `modules/dashboard.py`; this file had nothing.

Renamed to `dashboard_server.py`, with the README heading corrected and a new section covering it.

## What I checked and found safe

`/api/runs/<run_id>` has no traversal bug. `self.path.split("/")[-1]` discards everything before the last segment, so `../` never reaches the `os.path.join`, and `http.server` decodes URL-encoding before that split. Four payloads all stayed inside `logs/`. Accidental rather than deliberate, but it holds — and there is now a test pinning it.

## Tests

`tests/test_dashboard_server.py` — 21 cases, against a live server on an ephemeral port.

The working directory: `.env` returns 404 and its contents do not appear; three other paths return 404; `super().do_GET()` is gone from the source.

The routes that should work: the index is served; `/api/runs` returns JSON; a summary is read; an unknown run id returns empty rather than raising; a traversing run id stays inside `logs/`.

Escaping: the helper is defined; five untrusted values are no longer interpolated raw; the helper covers all five dangerous characters.

The bind: the default host is loopback; no wildcard bind remains; host and port are configurable.

## One thing I could not verify

My environment has only a loopback interface, so I could not prove externally that the wildcard bind is closed. The banner reports `127.0.0.1` and `DEFAULT_HOST` is what reaches `TCPServer`, but a check from a second machine would be worth doing before merging.

Everything else above was verified by running it, including the `.env` read before and after.

## Verified

- the exploit, then its absence
- full suite: 1455 passing